### PR TITLE
compiler: Make maps and lists able to look up their params

### DIFF
--- a/hy/compiler/ast27.py
+++ b/hy/compiler/ast27.py
@@ -163,6 +163,10 @@ class AST27Converter(object):
             "for": self._ast_for,
             "kwapply": self._ast_kwapply,
         }
+        self.special_types = {
+            HYMap: self._ast_fn_index,
+            HYList: self._ast_fn_index,
+        }
         self.in_fn = False
 
     def _ast_index(self, node):
@@ -175,6 +179,13 @@ class AST27Converter(object):
             self.render(val),
             ast.Index(value=self.render(tar), ctx=ast.Load()),
             ast.Load())
+
+    def _ast_fn_index(self, node):
+        i = node.get_invocation()
+        cmd = ["index"]
+        cmd.append(i['function'])
+        cmd.extend(i['args'])
+        return self.render_expression(HYExpression(cmd))
 
     def _ast_dot(self, node):
         inv = node.get_invocation()
@@ -370,6 +381,9 @@ class AST27Converter(object):
 
         inv = node.get_invocation()
 
+        if type(inv['function']) in self.special_types:
+            return self.special_types[type(inv['function'])](node)
+        
         if inv['function'] in self.native_cases:
             return self.native_cases[inv['function']](node)
 

--- a/tests/lang/colls.hy
+++ b/tests/lang/colls.hy
@@ -1,0 +1,5 @@
+(defn test-map-index []
+  ({"foo" "bar"} "foo"))
+
+(defn test-list-index []
+  (["first" "second"] 1))

--- a/tests/lang/test_types_as_fn.py
+++ b/tests/lang/test_types_as_fn.py
@@ -1,0 +1,7 @@
+import tests.lang.colls
+
+def test_map_index():
+    assert tests.lang.colls.test_map_index() == "bar"
+
+def test_list_index():
+    assert tests.lang.colls.test_list_index() == "second"


### PR DESCRIPTION
As a neat syntactic sugar, it's very neat if maps and lists are able to work as if they were functions, and look up their arguments.

This implements just that, by translating `(map key)` to `(index map key)` internally, and `(list idx)` to `(index list idx)`.

I am not entirely convinced this is the best way to go around it, but this works as a starting point. If we could skip the translation to `(index blah blah)` and do it in one step less, that'd be better. But I haven't found a neat way to do that yet.

Review and hints are appreciated, I'll happily rework this based on your suggestions.
