### PR TITLE
Better catch syntax

### DIFF
--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -116,13 +116,20 @@ def test_ast_bad_try():
 
 def test_ast_good_catch():
     "Make sure AST can compile valid catch"
-    hy_compile(tokenize("(catch 1 2)"))
+    hy_compile(tokenize("(catch)"))
+    hy_compile(tokenize("(catch [])"))
+    hy_compile(tokenize("(catch [Foobar])"))
+    # hy_compile(tokenize("(catch [[]])"))
+    # hy_compile(tokenize("(catch [x FooBar])"))
+    # hy_compile(tokenize("(catch [x [FooBar BarFoo]])"))
+    # hy_compile(tokenize("(catch [x [FooBar BarFoo]])"))
 
 
 def test_ast_bad_catch():
     "Make sure AST can't compile invalid catch"
-    cant_compile("(catch)")
     cant_compile("(catch 1)")
+    cant_compile("(catch [1 3])")
+    cant_compile("(catch [x [FooBar] BarBar]])")
 
 
 def test_ast_good_assert():

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -164,8 +164,56 @@
   "NATIVE: test Exceptions"
   (try
     (throw (KeyError))
-  (catch IOError  e (assert (= 2 1)))
-  (catch KeyError e (+ 1 1) (assert (= 1 1)))))
+    (catch [[IOError]] (assert false))
+    (catch [e [KeyError]] (assert e)))
+
+  (try
+    (get [1] 3)
+    (catch [IndexError] (assert true))
+    (catch [IndexError] (pass)))
+
+  (try
+    (print foobar42ofthebaz)
+    (catch [IndexError] (assert false))
+    (catch [NameError] (pass)))
+
+  (try
+    (get [1] 3)
+    (catch [e IndexError] (assert (isinstance e IndexError))))
+
+  (try
+    (get [1] 3)
+    (catch [e [IndexError NameError]] (assert (isinstance e IndexError))))
+
+  (try
+    (print foobar42ofthebaz)
+    (catch [e [IndexError NameError]] (assert (isinstance e NameError))))
+
+  (try
+    (print foobar42)
+    (catch [[IndexError NameError]] (pass)))
+
+  (try
+    (get [1] 3)
+    (catch [[IndexError NameError]] (pass)))
+
+  (try
+    (print foobar42ofthebaz)
+    (catch))
+
+  (try
+    (print foobar42ofthebaz)
+    (catch []))
+
+  (try
+    (print foobar42ofthebaz)
+    (catch [] (pass)))
+
+  (try
+    (print foobar42ofthebaz)
+    (catch []
+        (setv foobar42ofthebaz 42)
+        (assert (= foobar42ofthebaz 42)))))
 
 (defn test-earmuffs []
   "NATIVE: Test earmuffs"
@@ -327,7 +375,7 @@
              6))
   (try
     (assert (= x 42))                   ; This ain't true
-    (catch NameError e (assert e)))
+    (catch [e [NameError]] (assert e)))
   (assert (= y 123)))
 
 


### PR DESCRIPTION
The syntax is now changed to:

  (catch [] BODY)
 (catch [Exception] BODY)
 (catch [e Exception] BODY)
 (catch [e [Exception1 Exception2]] BODY)

Signed-off-by: Julien Danjou julien@danjou.info
