### PR TITLE
Paultag/bugfix/anon macros

### DIFF
--- a/hy/core/__init__.py
+++ b/hy/core/__init__.py
@@ -31,9 +31,12 @@ MACROS = [
 
 def process(tree):
     load_macros()
-    tree = mprocess(tree)
-    for m in hy.mangle.MANGLES:
-        m().mangle(tree)
+    old = None
+    while old != tree:
+        old = tree
+        tree = mprocess(tree)
+        for m in hy.mangle.MANGLES:
+            m().mangle(tree)
     return tree
 
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -377,6 +377,11 @@
   (assert (= true (if true true true))))
 
 
+(defn test-nested-mangles []
+  "NATIVE: test that we can use macros in mangled code"
+  (assert (= ((fn [] (-> 2 (+ 1 1) (* 1 2)))) 8)))
+
+
 (defn test-let-scope []
   "NATIVE: test let works rightish"
   (setv y 123)


### PR DESCRIPTION
Keep mangling until it stops moving.

This may introduce bugs with `17:41 < olasd> .oO(mutually recursive macros)`, but I'm OK with it for now. 
