### PR TITLE
Implement the missing (and) and (or) functions

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -547,13 +547,16 @@ class HyASTCompiler(object):
                            col_offset=operator.start_column)
 
     @builds("and")
+    @builds("or")
     @checkargs(min=2)
-    def compile_and_operator(self, expression):
+    def compile_logical_or_and_and_operator(self, expression):
+        ops = {"and": ast.And,
+               "or": ast.Or}
         operator = expression.pop(0)
         values = []
         for child in expression:
             values.append (self.compile(child))
-        return ast.BoolOp(op=ast.And(),
+        return ast.BoolOp(op=ops[operator](),
                           lineno=operator.start_line,
                           col_offset=operator.start_column,
                           values=values)

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -413,6 +413,15 @@
    (assert (= and123 3))
    (assert (= and-false False))))
 
+(defn test-or []
+  "NATIVE: test the or function"
+  (let [[or-all-true (or 1 2 3 True "string")]
+        [or-some-true (or False "hello")]
+        [or-none-true (or False False)]]
+   (assert (= or-all-true 1))
+   (assert (= or-some-true "hello"))
+   (assert (= or-none-true False))))
+
 ; FEATURE: native hy-eval
 ;
 ;   - related to bug #64


### PR DESCRIPTION
The patches in this request implement the `(and)` and `(or)` functions, both of which take at least two arguments, and compile down to a `BoolOp` with op set appropriately to either `ast.And` or `ast.Or`, with the (compiled) arguments passed to the op as values.
