### PR TITLE
compiler: add `else' support in `try'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,16 @@ Changes from Hy 0.9.4
 
   [ Syntax Fixes ]
 
+    * `try' now accepts `else': (JD)
+      (try BODY
+        (except [] BODY)
+        (else BODY))
+
+
+Changes from Hy 0.9.4
+
+  [ Syntax Fixes ]
+
     * Statements in the `fn' path early will not return anymore. (PT)
     * Added "not" as the inline "not" operator. It's advised to still
       use "not-in" or "is-not" rather then nesting. (JD)

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -116,8 +116,16 @@ def test_ast_good_try():
     "Make sure AST can compile valid try"
     hy_compile(tokenize("(try)"))
     hy_compile(tokenize("(try 1)"))
-    hy_compile(tokenize("(try 1 bla)"))
-    hy_compile(tokenize("(try 1 bla bla)"))
+    hy_compile(tokenize("(try 1 (except) (else 1))"))
+    hy_compile(tokenize("(try 1 (else 1) (except))"))
+
+
+def test_ast_bad_try():
+    "Make sure AST can't compile invalid try"
+    cant_compile("(try 1 bla)")
+    cant_compile("(try 1 bla bla)")
+    cant_compile("(try (do) (else 1) (else 2))")
+    cant_compile("(try 1 (else 1))")
 
 
 def test_ast_good_catch():

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -235,7 +235,39 @@
     (print foobar42ofthebaz)
     (catch []
         (setv foobar42ofthebaz 42)
-        (assert (= foobar42ofthebaz 42)))))
+        (assert (= foobar42ofthebaz 42))))
+
+  (let [[passed false]]
+    (try
+      (try (pass) (except) (else (bla)))
+      (except [NameError] (setv passed true)))
+    (assert passed))
+
+  (let [[x 0]]
+    (try
+      (raise IOError)
+      (except [IOError]
+              (setv x 45))
+      (else (setv x 44)))
+    (assert (= x 45)))
+
+  (let [[x 0]]
+    (try
+      (raise KeyError)
+      (except []
+              (setv x 45))
+      (else (setv x 44)))
+    (assert (= x 45)))
+
+  (let [[x 0]]
+    (try
+      (try
+        (raise KeyError)
+        (except [IOError]
+                (setv x 45))
+        (else (setv x 44)))
+      (except))
+    (assert (= x 0))))
 
 (defn test-earmuffs []
   "NATIVE: Test earmuffs"


### PR DESCRIPTION
This is a bit tricky, since we'll also have to support `finally' in the end, 
I've introduced an Else statement on my own to be able to recognize it.

In the end, we even do a better job than Python (sort of) since we support a 
syntax that doesn't in Python:

  (try
   (pass)
   (else (pass))

is translated to:

  try:
     pass
 else:
    pass

Which seems impossible in Python syntax. How fun?

This fixes issue #74.
