### PR TITLE
Do not quit hy if hy.core.process raises an exception

### DIFF
--- a/bin/hy
+++ b/bin/hy
@@ -48,7 +48,12 @@ class HyREPL(code.InteractiveConsole):
             _machine = Machine(Idle, 1, 0)
             return True
 
-        tokens = process(_machine.nodes)
+        try:
+            tokens = process(_machine.nodes)
+        except Exception:
+            _machine = Machine(Idle, 1, 0)
+            self.showtraceback()
+            return False
 
         _machine = Machine(Idle, 1, 0)
         try:


### PR DESCRIPTION
Typing

  (let [x 1] x)

into hy made it crash following an IndexError in hy.core.process. This should fix that.
