### PR TITLE
Remove `pass' from the language.

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -145,13 +145,16 @@ class HyASTCompiler(object):
             "Unknown type - `%s' - %s" % (str(type(tree)), tree))
 
     def _mangle_branch(self, tree, start_line, start_column):
+        tree = list(flatten_literal_list(tree))
+        tree = list(filter(bool, tree))  # Remove empty statements
+
         # If tree is empty, just return a pass statement
         if tree == []:
             return [ast.Pass(lineno=start_line, col_offset=start_column)]
 
-        ret = []
-        tree = list(flatten_literal_list(tree))
         tree.reverse()
+
+        ret = []
 
         if self.returnable and len(tree) > 0:
             el = tree[0]
@@ -446,11 +449,6 @@ class HyASTCompiler(object):
                 kwonlyargs=[],
                 kw_defaults=[]),
             body=self.compile(body))
-
-    @builds("pass")
-    @checkargs(0)
-    def compile_pass_expression(self, expr):
-        return ast.Pass(lineno=expr.start_line, col_offset=expr.start_column)
 
     @builds("yield")
     @checkargs(max=1)

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -192,17 +192,6 @@ def test_ast_bad_lambda():
     cant_compile("(lambda [])")
 
 
-def test_ast_good_pass():
-    "Make sure AST can compile valid pass"
-    hy_compile(tokenize("(pass)"))
-
-
-def test_ast_bad_pass():
-    "Make sure AST can't compile invalid pass"
-    cant_compile("(pass 1)")
-    cant_compile("(pass 1 2)")
-
-
 def test_ast_good_yield():
     "Make sure AST can compile valid yield"
     hy_compile(tokenize("(yield 1)"))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -172,11 +172,11 @@
 
   (try (do))
 
-  (try (pass))
+  (try (do))
 
-  (try (pass) (except))
+  (try (do) (except))
 
-  (try (pass) (except [IOError]) (except))
+  (try (do) (except [IOError]) (except))
 
   ;; Test correct (raise)
   (let [[passed false]]
@@ -208,16 +208,15 @@
     (except [[IOError]] (assert false))
     (catch [e [KeyError]] (assert e)))
 
-
   (try
     (get [1] 3)
     (catch [IndexError] (assert true))
-    (except [IndexError] (pass)))
+    (except [IndexError] (do)))
 
   (try
     (print foobar42ofthebaz)
     (catch [IndexError] (assert false))
-    (except [NameError] (pass)))
+    (except [NameError] (do)))
 
   (try
     (get [1] 3)
@@ -233,11 +232,11 @@
 
   (try
     (print foobar42)
-    (catch [[IndexError NameError]] (pass)))
+    (catch [[IndexError NameError]] (do)))
 
   (try
     (get [1] 3)
-    (catch [[IndexError NameError]] (pass)))
+    (catch [[IndexError NameError]] (do)))
 
   (try
     (print foobar42ofthebaz)
@@ -249,7 +248,7 @@
 
   (try
     (print foobar42ofthebaz)
-    (except [] (pass)))
+    (except [] (do)))
 
   (try
     (print foobar42ofthebaz)
@@ -259,7 +258,7 @@
 
   (let [[passed false]]
     (try
-      (try (pass) (except) (else (bla)))
+      (try (do) (except) (else (bla)))
       (except [NameError] (setv passed true)))
     (assert passed))
 
@@ -324,7 +323,7 @@
 
 (defn test-pass []
   "NATIVE: Test pass worksish"
-  (if true (pass) (pass))
+  (if true (do) (do))
   (assert (= 1 1)))
 
 
@@ -362,7 +361,7 @@
 (defn test-context []
   "NATIVE: test with"
   (with [fd (open "README.md" "r")] (assert fd))
-  (with [(open "README.md" "r")] (pass)))
+  (with [(open "README.md" "r")] (do)))
 
 
 (defn test-for-doodle []
@@ -506,8 +505,8 @@
                    2)
                  1)))
   (assert (= 1 (let [[x 1] [y 2]]
-                 (pass)
-                 (pass)
+                 (do)
+                 (do)
                  ((fn [] 1))))))
 
 (defn test-keyword []


### PR DESCRIPTION
This also fixes a bug in the pass optimize missing branch where the code is 
something like: [stmt, [], stmt]; in such case we want to filter out [], so if
we end up with [] we can optimize it. This fix is needed otherwise (do) inside
(do) are not properly optimized.
