### PR TITLE
Simplify the decorator hy.compiler.builds

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -89,10 +89,7 @@ def ast_str(foobar):
 def builds(_type):
     def _dec(fn):
         _compile_table[_type] = fn
-
-        def shim(*args, **kwargs):
-            return fn(*args, **kwargs)
-        return shim
+        return fn
     return _dec
 
 


### PR DESCRIPTION
Not so much for the efficiency gain, but to save keystrokes in the
debugger when looking at methods with lots of builds decorators.
