### PR TITLE
Added 'take' and 'drop' functions

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -673,36 +673,6 @@ class HyASTCompiler(object):
                             step=None),
             ctx=ast.Load())
 
-    @builds("take")
-    @checkargs(2)
-    def compile_take_expression(self, expr):
-        expr.pop(0)
-        n = self.compile(expr.pop(0))
-        seq = self.compile(expr.pop(0))
-        return ast.Subscript(
-            lineno=expr.start_line,
-            col_offset=expr.start_column,
-            value=seq,
-            slice=ast.Slice(lower=None,
-                            upper=n,
-                            step=None),
-            ctx=ast.Load())
-
-    @builds("drop")
-    @checkargs(2)
-    def compile_drop_expression(self, expr):
-        expr.pop(0)
-        n = self.compile(expr.pop(0))
-        seq = self.compile(expr.pop(0))
-        return ast.Subscript(
-            lineno=expr.start_line,
-            col_offset=expr.start_column,
-            value=seq,
-            slice=ast.Slice(lower=n,
-                            upper=None,
-                            step=None),
-            ctx=ast.Load())
-
     @builds("assoc")
     @checkargs(3)
     def compile_assoc_expression(self, expr):

--- a/hy/core/bootstrap.py
+++ b/hy/core/bootstrap.py
@@ -149,3 +149,24 @@ def let_macro(tree):
         expr.append(stmt)
 
     return HyExpression([expr])
+
+
+@macro("take")
+def take_macro(tree):
+    tree.pop(0)  # "take"
+    n = tree.pop(0)
+    ret = tree.pop(0)
+    return HyExpression([HySymbol('slice'),
+                         ret,
+                         HyInteger(0),
+                         HyInteger(n)])
+
+
+@macro("drop")
+def drop_macro(tree):
+    tree.pop(0)  # "drop"
+    n = tree.pop(0)
+    ret = tree.pop(0)
+    return HyExpression([HySymbol('slice'),
+                         ret,
+                         HyInteger(n)])

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -242,20 +242,9 @@ def test_ast_good_take():
     hy_compile(tokenize("(take 1 [2 3])"))
 
 
-def test_ast_bad_take():
-    "Make sure AST chokes on bad 'take'"
-    cant_compile("(take)")
-    cant_compile("(take 2)")
-
 def test_ast_good_drop():
     "Make sure AST can compile valid 'drop'"
     hy_compile(tokenize("(drop 1 [2 3])"))
-
-
-def test_ast_bad_drop():
-    "Make sure AST chokes on bad 'drop'"
-    cant_compile("(drop)")
-    cant_compile("(drop 2)")
 
 
 def test_ast_good_assoc():


### PR DESCRIPTION
I wanted Clojure's / Haskell's 'take' for a small test program.  Here it is implemented in the AST code per @paultag on IRC.  I wonder if it would be better to just have a small core library in Hy for such things, but I guess this would be a bit faster.

Where should these be documented?
