### PR TITLE
Add &optional args to function definitions

### DIFF
--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -353,6 +353,8 @@ def test_ast_non_kwapplyable():
 def test_ast_lambda_lists():
     """Ensure the compiler chokes on invalid lambda-lists"""
     cant_compile('(fn [&key {"a" b} &key {"foo" bar}] [a foo])')
+    cant_compile('(fn [&optional a &key {"foo" bar}] [a foo])')
+    cant_compile('(fn [&optional [a b c]] a)')
 
 
 def test_ast_print():

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -645,6 +645,14 @@
   (assert (= (kwapply (foo) {"b" 42}) [None 42])))
 
 
+(defn test-optional-arguments []
+  "NATIVE: test &optional function arguments"
+  (defn foo [a b &optional c [d 42]] [a b c d])
+  (assert (= (foo 1 2) [1 2 None 42]))
+  (assert (= (foo 1 2 3) [1 2 3 42]))
+  (assert (= (foo 1 2 3 4) [1 2 3 4])))
+
+
 (defn test-quoted-hoistable []
   "NATIVE: test quoted hoistable"
   (setf f (quote (if true true true)))


### PR DESCRIPTION
Python doesn't have a separate concept of &key and &optional args, so I made the decision that the compiler should reject a combination of the two.

I threw in some &key-related tests as, well, there weren't any.
