### PR TITLE
Add the (require) form.

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1197,6 +1197,19 @@ class HyASTCompiler(object):
                                col_offset=operator.start_column)
         return operand
 
+    @builds("require")
+    def compile_require(self, expression):
+        """
+        TODO: keep track of what we've imported in this run and then
+        "unimport" it after we've completed `thing' so that we don't polute
+        other envs.
+        """
+        expression.pop(0)
+        for entry in expression:
+            __import__(entry)  # Import it fo' them macros.
+        return ast.Pass(lineno=expression.start_line,
+                        col_offset=expression.start_column)
+
     @builds("and")
     @builds("or")
     @checkargs(min=2)

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -686,3 +686,11 @@
   (assert (= foo 2))
   (setf foo (try (+ 2 2) (except [NameError] (+ 1 1))))
   (assert (= foo 4)))
+
+
+(defn test-require []
+  (try
+    (assert (= "this won't happen" (qplah 1 2 3 4)))
+  (catch [NameError]))
+  (require tests.resources.tlib)
+  (assert (= [1 2 3] (qplah 1 2 3))))

--- a/tests/resources/tlib.py
+++ b/tests/resources/tlib.py
@@ -1,0 +1,7 @@
+from hy.macros import macro
+from hy import HyList
+
+
+@macro("qplah")
+def tmac(tree):
+    return HyList(tree[1:])


### PR DESCRIPTION
Needed to do imports at compile-time rather than bytecode runtime; ultra kludge.

Needs eventual work to pop the namespace back out when we change up files. Meh. Let's wait until someone notices on that one.
