### PR TITLE
Permit macros to return constants

### DIFF
--- a/hy/macros.py
+++ b/hy/macros.py
@@ -20,6 +20,7 @@
 
 from hy.models.expression import HyExpression
 from hy.models.string import HyString
+from hy.models.symbol import HySymbol
 from hy.models.list import HyList
 from hy.models.integer import HyInteger
 from hy.models.float import HyFloat
@@ -57,6 +58,7 @@ def _wrap_value(x):
         return wrapper(x)
 
 _wrappers = {int: HyInteger,
+             bool: lambda x: HySymbol("True") if x else HySymbol("False"),
              float: HyFloat,
              complex: HyComplex,
              str_type: HyString,

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -15,6 +15,11 @@
 (defmacro an-int [] 42)
 (assert (= (an-int) 42))
 
+(defmacro a-true [] True)
+(assert (= (a-true) True))
+(defmacro a-false [] False)
+(assert (= (a-false) False))
+
 (defmacro a-float [] 42.)
 (assert (= (a-float) 42.))
 


### PR DESCRIPTION
This is mainly a pretty obvious bug fix. The open question is the way constants of type `list` are treated. In this fix they become constants of type list, which is consistent with how Hy handles lists elsewhere. But in Lisp, constructing and returning a list is the main way to construct s-expressions. Most Lispers would thus expect a list constant to become a `HyExpression`.

Right now there is no way in Hy to construct s-expressions programmatically from a macro (unless I overlooked something). I propose that we do provide such a way, but don't call it `list`. Something like `expr` would do fine.
