### PR TITLE
Handle raw strings

### DIFF
--- a/hy/lex/machine.py
+++ b/hy/lex/machine.py
@@ -88,7 +88,7 @@ class Machine(object):
                 self.line += 1
                 self.column = 0
 
-            if char == "r" and i<len(buf)-1 and buf[i+1] == "\"":
+            if char == "r" and i < len(buf)-1 and buf[i+1] == "\"":
                 char = "r\""
                 skip_one = True
 

--- a/hy/lex/states.py
+++ b/hy/lex/states.py
@@ -237,6 +237,7 @@ class Dict(ListeyThing):
 
     end_char = "}"
 
+
 class RawString(State):
     """
     RawString state. This will handle stuff like:
@@ -260,7 +261,7 @@ class RawString(State):
         if char == "\"":
             return Idle
 
-        if  char == "r\"":
+        if char == 'r"':
             self.nodes.append("r")
             return Idle
 
@@ -305,7 +306,7 @@ class String(State):
         if char == "\"":
             return Idle
 
-        if  char == "r\"":
+        if char == 'r"':
             self.nodes.append("r")
             return Idle
 
@@ -388,7 +389,7 @@ class Idle(State):
             return String
 
         if char == "r\"":
-             return RawString
+            return RawString
 
         if char == ";":
             return Comment

--- a/tests/lex/test_lex.py
+++ b/tests/lex/test_lex.py
@@ -97,16 +97,14 @@ def test_lex_symbols():
 def test_lex_strings():
     """ Make sure that strings are valid expressions"""
     objs = tokenize("\"foo\" ")
-    print objs
-    print HyString("foo")
     assert objs == [HyString("foo")]
+
 
 def test_lex_raw_strings():
     """ Make sure that raw strings are valid """
     objs = tokenize("r\"\ntr\"")
-    print objs
-    print HyString(r"\ntr")
-    assert objs == [HyString(r"\ntr")]
+    assert objs == [HyString("\ntr")]
+
 
 def test_lex_integers():
     """ Make sure that integers are valid expressions"""


### PR DESCRIPTION
This is a change to the lexer state machine to allow using raw string literals, like (print r"$\mu = 4")

Adds a new RawString class to the choice of states. 

Biggest change is in the state machine "process(..." method. The current system is able do a simple char-by-char loop over the input, but in order to handle r" as the beginning of a raw string, the loop needs to be able to look-ahead one character and push r" together as a single token.

I'm sure there is a more elegant want to handle the look-ahead.
