### PR TITLE
Get bin tests working on Windows

### DIFF
--- a/bin/hy.bat
+++ b/bin/hy.bat
@@ -1,0 +1,2 @@
+@echo off
+python %~dp0\hy %*

--- a/bin/hy2py.bat
+++ b/bin/hy2py.bat
@@ -1,0 +1,2 @@
+@echo off
+python %~dp0\hy2py %*

--- a/bin/hyc.bat
+++ b/bin/hyc.bat
@@ -1,0 +1,2 @@
+@echo off
+python %~dp0\hyc %*

--- a/bin/py2ast.bat
+++ b/bin/py2ast.bat
@@ -1,0 +1,2 @@
+@echo off
+python %~dp0\py2ast %*


### PR DESCRIPTION
On Windows the tests in tests.test_bin were failing for reasons listed in #228.
I got them working by create batch file wrappers for bin/hy et al and tweaking
the commands being tested where necessary. I also introduced a wrapper for
tests.test_bin.run_cmd to make running OS dependent commands less cumbersome.

Fixes #228.
