### PR TITLE
Remove parenthesis from kwapply caller, added lapply

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1257,6 +1257,23 @@ class HyASTCompiler(object):
                               col_offset=expr.start_column)                            
         return ret
 
+    @builds("lapply")
+    @checkargs(2)
+    def compile_kwapply_expression(self, expr):
+        expr.pop(0)  # kwapply
+        call = self.compile(expr.pop(0))
+        argish = expr.pop(0)
+        argish = self.compile(argish)
+        ret = argish + ast.Call(func=call.expr,
+                              args= [],
+                              keywords=[],
+                              starargs=argish.force_expr,
+                              kwargs=None,
+                              lineno=expr.start_line,
+                              col_offset=expr.start_column)                            
+        return ret
+
+    
     @builds("not")
     @builds("~")
     @checkargs(1)

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -149,10 +149,10 @@
 
 (defn test-kwargs []
   "NATIVE: test kwargs things."
-  (assert (= (kwapply (kwtest) {"one" "two"}) {"one" "two"}))
+  (assert (= (kwapply kwtest {"one" "two"}) {"one" "two"}))
   (setv mydict {"one" "three"})
-  (assert (= (kwapply (kwtest) mydict) mydict))
-  (assert (= (kwapply (kwtest) ((fn [] {"one" "two"}))) {"one" "two"})))
+  (assert (= (kwapply kwtest mydict) mydict))
+  (assert (= (kwapply kwtest ((fn [] {"one" "two"}))) {"one" "two"})))
 
 
 (defn test-dotted []
@@ -650,8 +650,15 @@
   "NATIVE: test &key function arguments"
   (defn foo [&key {"a" None "b" 1}] [a b])
   (assert (= (foo) [None 1]))
-  (assert (= (kwapply (foo) {"a" 2}) [2 1]))
-  (assert (= (kwapply (foo) {"b" 42}) [None 42])))
+  (assert (= (kwapply foo {"a" 2}) [2 1]))
+  (assert (= (kwapply foo {"b" 42}) [None 42])))
+
+(defn test-key-arguments []
+  "NATIVE: test &key function arguments"
+  (defn foo [&key {"a" None "b" 1}] [a b])
+  (assert (= (foo) [None 1]))
+  (assert (= (lapply foo [2]) [2 1]))
+  (assert (= (lapply foo [4 2]) [4 2])))
 
 
 (defn test-optional-arguments []


### PR DESCRIPTION
kwapply's syntax felt a bit weird having to add extra parens to a call e.g. (I put some extra space to make it clear to the ones I refer):
   `(kwapply ( (fn [a b] (+ a b)) ) {"a" 1 "b" 2})`
I believe this should be:
   `(kwapply (fn [a b] (+ a b)) {"a" 1 "b" 2})`

But this change will break existing code.

With basically the same syntax is lapply (any better name for this? It's late around here and I lack imagination :P)
    `(lapply (fn [a b] (+ a b)) [1 2])`

I also modified the tests, and made similar ones for lapply
