### PR TITLE
Fix commandline scripts and support Windows 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *swp
 *hy*egg*
+*pyreadline*egg*
 .tox
 *pycache*
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 # command to install dependencies
 install:
   - pip install -r requirements.txt --use-mirrors
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install importlib unittest2 astor --use-mirrors; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install argparse importlib unittest2 astor --use-mirrors; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install astor --use-mirrors; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install astor --use-mirrors; fi
   - python setup.py -q install

--- a/AUTHORS
+++ b/AUTHORS
@@ -14,4 +14,5 @@
 * Thomas Ballinger <thomasballinger@gmail.com>
 * Morten Linderud <mcfoxax@gmail.com>
 * Guillermo Vayá <guivaya@gmail.com>
+* Bob Tolbert <bob@tolbert.org>
 * Ralph Möritz <ralph.moeritz@outlook.com>

--- a/bin/hy
+++ b/bin/hy
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-
-import sys
-from hy.cmdline import cmdline_handler
-
-
-if __name__ == '__main__':
-    sys.exit(cmdline_handler("hy", sys.argv))

--- a/bin/hyc
+++ b/bin/hyc
@@ -1,6 +1,0 @@
-#!/usr/bin/env hy
-
-(import sys)
-(import [hy.importer [write-hy-as-pyc]])
-
-(write-hy-as-pyc (get sys.argv 1))

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,116 @@
+@ECHO OFF
+
+REM Make batch file for Hy development
+
+if "%1" == "" goto help
+
+if "%1" == "help" (
+    :help
+    echo. No default step. Use setup.py
+    echo.
+    echo.  Other targets:
+    echo.
+    echo.    - docs
+    echo.    - full
+    echo.
+    echo.    - dev "test & flake"
+    echo.    - flake
+    echo.    - test
+    echo.    - diff
+    echo.    - tox
+    echo.    - d
+    echo.    - r
+    echo.
+    goto end
+)
+
+if "%1" == "docs" (
+:docs
+    echo.docs not yet supported under Windows
+goto :EOF
+)
+
+if "%1" == "upload" (
+:upload
+    python setup.py sdist upload
+goto :EOF
+)
+
+if "%1" == "clear" (
+:clear
+    cls
+goto :EOF
+)
+
+if "%1" == "d" (
+:d
+    call :clear
+    call :dev
+goto :EOF
+)
+
+if "%1" == "test" (
+:test
+    call :venv
+    nosetests -sv
+goto :EOF
+)
+
+if "%1" == "venv" (
+:venv
+    echo.%VIRTUAL_ENV% | findstr /C:"hy" 1>nul
+    if errorlevel 1 (
+        echo.You're not in a Hy virtualenv. FOR SHAME
+    ) ELSE (
+        echo.We're properly in a virtualenv. Going ahead.
+    )
+goto :EOF
+)
+
+if "%1" == "flake" (
+:flake
+    echo.flake8 hy
+    flake8 hy
+goto :EOF
+)
+
+if "%1" == "dev" (
+:dev
+    call :test
+    call :flake
+goto :EOF
+)
+
+if "%1" == "tox" (
+:tox
+    call :venv
+    tox -e "py26,py27,py32,py33,flake8"
+goto :EOF
+)
+
+if "%1" == "d" (
+:d
+    call :clear
+    call :dev
+goto :EOF
+)
+
+if "%i" == "diff" (
+:diff
+    git diff --color
+goto :EOF
+)
+
+if "%1" == "r" (
+:r
+    call :d
+    call :tox
+    call :diff
+goto :EOF
+)
+
+if "%1" == full (
+    call :docs
+    call :d
+    call :tox
+)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2012 Paul Tagliamonte <paultag@debian.org>
+# Copyright (c) 2012, 2013 Paul Tagliamonte <paultag@debian.org>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,12 +23,15 @@
 from hy import __appname__, __version__
 from setuptools import setup
 import os
+import sys
 
 long_description = """Hy is a Python <--> Lisp layer. It helps
 make things work nicer, and lets Python and the Hy lisp variant play
 nice together. """
 
 install_requires = []
+if sys.version_info[0] == 2:
+    install_requires.append('argparse>=1.2.1')
 if os.name == 'nt':
     install_requires.append('pyreadline==2.0')
 
@@ -36,10 +39,12 @@ setup(
     name=__appname__,
     version=__version__,
     install_requires=install_requires,
-    scripts=[
-        "bin/hy",
-        "bin/hyc",
-    ],
+    entry_points={
+        'console_scripts': [
+            'hy = hy.cmdline:hy_main',
+            'hyc = hy.cmdline:hyc_main'
+        ]
+    },
     packages=[
         'hy',
         'hy.lex',

--- a/tests/resources/argparse_ex.hy
+++ b/tests/resources/argparse_ex.hy
@@ -1,0 +1,18 @@
+#!/usr/bin/env hy
+
+(import sys)
+(import argparse)
+
+(setv parser (argparse.ArgumentParser))
+
+(.add_argument parser "-i")
+(.add_argument parser "-c")
+
+(setv args (.parse_args parser))
+
+;; using (cond) allows -i to take precedence over -c
+
+(cond (args.i
+       (print (str args.i)))
+      (args.c
+       (print (str "got c"))))


### PR DESCRIPTION
Updated: based on comments from @pautag below, I've now also changed all the CL handing from optparse to argparse since argparse handles the separation of flags between hy and a user hy script for us. Also added a test for the case of running "hy foo" where foo doesn't exist.

This PR fixes the command line argument handling in "hy". The current version eats all CL arguments, 
making it impossible to pass args to a user script. The change it to make "hy" work just like Python. Arguments before a user script are consumed by "hy". The user script is passed a modified version of sys.argv where the user script is in sys.argv[0] and any args for the script are in sys.argv[1:] just like Python. I also stash the location of the "hy" script in hy.executable just like sys.executable points to the actual Python executable.

This also does away with the scripts in "bin" and changes
setup.py to use entry_points in cmdline.py for the scripts 'hy' and
'hyc'.  This allows setup.py to install hy and hyc for *nix and hy.exe/hyc.exe for Windows.

This fixes installing and running on Windows.

The tests are updated to run the 'hy' script produced by setup.py
and not from bin/hy. This is more correct and makes the tox tests
run on both Window and *nix.

There is also now a make.bat file that mirrors the Makefile. Note that pypy is omitted from "make.bat tox" on Windows since there appears to be an outstanding bug with creating a pypy virtualenv on Windows.

For running hy or nosetests directly in the source tree, you do have
to run 'python setup.py develop' first. But since tox runs and builds
dists, all tox tests pass on all platforms.
