### PR TITLE
documentation for builtins

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -252,7 +252,7 @@ collection and calls side-effect to each element in the collection:
     (foreach [element collection] (side-effect element))
 
     ;; foreach can have an optional else block
-    (foreach [element collection] (side-effect-2 element)
+    (foreach [element collection] (side-effect element)
              (else (side-effect-2)))
 
 The optional `else` block is executed only if the `foreach` loop terminates


### PR DESCRIPTION
this pull request contains documentation for following builtins: def, setv, setf, defclass, foreach, kwapply, lambda, fn, with, with-decorator, yield

I would appreciate if someone could have a look on correctness of especially defclass and with-decorator sections.

relates #18
