### PR TITLE
Make kwapply behave when called multiple times

### DIFF
--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -18,5 +18,11 @@
       (next citer))
     citer))
 
+(defmacro kwapply [call kwargs] 
+  (let [[fun (first call)]
+        [args (rest call)]] 
+    (quasiquote (apply (unquote fun) 
+                       [(unquote-splice args)] 
+                       (unquote kwargs)))))
 
-(def *exports* ["take" "drop"])
+(def *exports* ["take" "drop" "kwapply"])

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -154,6 +154,14 @@
   (assert (= (kwapply (kwtest) mydict) mydict))
   (assert (= (kwapply (kwtest) ((fn [] {"one" "two"}))) {"one" "two"})))
 
+(defn test-apply []
+  "NATIVE: test working with args and functions"
+  (defn sumit [a b c] (+ a b c))
+  (assert (= (apply sumit [1] {"b" 2 "c" 3}) 6))
+  (assert (= (apply sumit [1 2 2]) 5))
+  (assert (= (apply sumit [] {"a" 1 "b" 1 "c" 2}) 4))
+  (assert (= (apply sumit ((fn [] [1 1])) {"c" 1}) 3)))
+
 
 (defn test-dotted []
   "NATIVE: test dotted invocation"


### PR DESCRIPTION
Kwapply can now be called multiple times without removing previous kwargs of the call. 

Also if a key is repeated it will replace it's value with the new one.
