### PR TITLE
Removes `setf` in favor of `setv`

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -173,7 +173,7 @@ Some example usage:
 `do` can accept any number of arguments, from 1 to n.
 
 
-def / setf / setv
+def / setv
 -----------------
 
 

--- a/eg/python3/futures/hello-world.hy
+++ b/eg/python3/futures/hello-world.hy
@@ -6,6 +6,6 @@
 
 
 (with-as (ThreadPoolExecutor 10) executor
-  (setf jobs (list-comp (.submit executor task-to-do) (x (range 0 10))))
+  (setv jobs (list-comp (.submit executor task-to-do) (x (range 0 10))))
   (for (future (as-completed jobs))
     (.result future)))

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1481,7 +1481,6 @@ class HyASTCompiler(object):
         return func + ret
 
     @builds("def")
-    @builds("setf")
     @builds("setv")
     @checkargs(2)
     def compile_def_expression(self, expression):

--- a/hy/core/bootstrap.py
+++ b/hy/core/bootstrap.py
@@ -128,10 +128,10 @@ def let_macro(variables, *body):
 
     for var in variables:
         if isinstance(var, list):
-            expr.append(HyExpression([HySymbol("setf"),
+            expr.append(HyExpression([HySymbol("setv"),
                                       var[0], var[1]]))
         else:
-            expr.append(HyExpression([HySymbol("setf"),
+            expr.append(HyExpression([HySymbol("setv"),
                                       var, HySymbol("None")]))
 
     return HyExpression([expr + list(body)])

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -408,11 +408,11 @@
 
 (defn test-for-doodle []
   "NATIVE: test for-do"
-  (do (do (do (do (do (do (do (do (do (setf (, x y) (, 0 0)))))))))))
+  (do (do (do (do (do (do (do (do (do (setv (, x y) (, 0 0)))))))))))
   (foreach [- [1 2]]
     (do
-     (setf x (+ x 1))
-     (setf y (+ y 1))))
+     (setv x (+ x 1))
+     (setv y (+ y 1))))
   (assert (= y x 2)))
 
 
@@ -597,10 +597,10 @@
 (defn test-eval []
   "NATIVE: test eval"
   (assert (= 2 (eval (quote (+ 1 1)))))
-  (setf x 2)
+  (setv x 2)
   (assert (= 4 (eval (quote (+ x 2)))))
-  (setf test-payload (quote (+ x 2)))
-  (setf x 4)
+  (setv test-payload (quote (+ x 2)))
+  (setv x 4)
   (assert (= 6 (eval test-payload)))
   (assert (= 9 ((eval (quote (fn [x] (+ 3 3 x)))) 3)))
   (assert (= 1 (eval (quote 1))))
@@ -689,9 +689,9 @@
 (defn test-try-except-return []
   "NATIVE: test we can return from in a try except"
   (assert (= ((fn [] (try xxx (except [NameError] (+ 1 1))))) 2))
-  (setf foo (try xxx (except [NameError] (+ 1 1))))
+  (setv foo (try xxx (except [NameError] (+ 1 1))))
   (assert (= foo 2))
-  (setf foo (try (+ 2 2) (except [NameError] (+ 1 1))))
+  (setv foo (try (+ 2 2) (except [NameError] (+ 1 1))))
   (assert (= foo 4)))
 
 

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -3,22 +3,22 @@
 
 (defn test-quote []
   "NATIVE: test for quoting functionality"
-  (setf q (quote (a b c)))
+  (setv q (quote (a b c)))
   (assert (= (len q) 3))
   (assert (= q [(quote a) (quote b) (quote c)])))
 
 
 (defn test-quoted-hoistable []
   "NATIVE: check whether quote works on hoisted things"
-  (setf f (quote (if true true true)))
+  (setv f (quote (if true true true)))
   (assert (= (car f) (quote if)))
   (assert (= (cdr f) (quote (true true true)))))
 
 
 (defn test-quoted-macroexpand []
   "NATIVE: check that we don't expand macros in quoted expressions"
-  (setf q1 (quote (-> a b c)))
-  (setf q2 (quasiquote (-> a b c)))
+  (setv q1 (quote (-> a b c)))
+  (setv q2 (quasiquote (-> a b c)))
   (assert (= q1 q2))
   (assert (= (car q1) (quote ->)))
   (assert (= (cdr q1) (quote (a b c)))))
@@ -26,7 +26,7 @@
 
 (defn test-quote-dicts []
   "NATIVE: test quoting dicts"
-  (setf q (quote {foo bar baz quux}))
+  (setv q (quote {foo bar baz quux}))
   (assert (= (len q) 4))
   (assert (= (get q 0) (quote foo)))
   (assert (= (get q 1) (quote bar)))
@@ -37,41 +37,41 @@
 
 (defn test-quote-expr-in-dict []
   "NATIVE: test quoting nested exprs in dict"
-  (setf q (quote {(foo bar) 0}))
+  (setv q (quote {(foo bar) 0}))
   (assert (= (len q) 2))
-  (setf qq (get q 0))
+  (setv qq (get q 0))
   (assert (= qq (quote (foo bar)))))
 
 
 (defn test-quasiquote []
   "NATIVE: test that quasiquote and quote are equivalent for simple cases"
-  (setf q (quote (a b c)))
-  (setf qq (quasiquote (a b c)))
+  (setv q (quote (a b c)))
+  (setv qq (quasiquote (a b c)))
   (assert (= q qq)))
 
 
 (defn test-unquote []
   "NATIVE: test that unquote works as expected"
-  (setf q (quote (unquote foo)))
+  (setv q (quote (unquote foo)))
   (assert (= (len q) 2))
   (assert (= (get q 1) (quote foo)))
-  (setf qq (quasiquote (a b c (unquote (+ 1 2)))))
+  (setv qq (quasiquote (a b c (unquote (+ 1 2)))))
   (assert (= (len qq) 4))
   (assert (= qq (quote (a b c 3)))))
 
 
 (defn test-unquote-splice []
   "NATIVE: test splicing unquotes"
-  (setf q (quote (c d e)))
-  (setf qq (quasiquote (a b (unquote-splice q) f (unquote-splice q))))
+  (setv q (quote (c d e)))
+  (setv qq (quasiquote (a b (unquote-splice q) f (unquote-splice q))))
   (assert (= (len qq) 9))
   (assert (= qq (quote (a b c d e f c d e)))))
 
 
 (defn test-nested-quasiquote []
   "NATIVE: test nested quasiquotes"
-  (setf qq (quasiquote (1 (quasiquote (unquote (+ 1 (unquote (+ 2 3))))) 4)))
-  (setf q (quote (1 (quasiquote (unquote (+ 1 5))) 4)))
+  (setv qq (quasiquote (1 (quasiquote (unquote (+ 1 (unquote (+ 2 3))))) 4)))
+  (setv q (quote (1 (quasiquote (unquote (+ 1 5))) 4)))
   (assert (= (len q) 3))
   (assert (= (get qq 1) (quote (quasiquote (unquote (+ 1 5))))))
   (assert (= q qq)))


### PR DESCRIPTION
cf Issue #240: `setf` and `setv` are redundant. Only one should remain.
