### PR TITLE
Fix missing docstrings from defclass issue #248

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1646,6 +1646,17 @@ class HyASTCompiler(object):
 
         body = Result()
 
+        # grab the doc string, if there is one
+        if expression and isinstance(expression[0], HyString):
+            docstring = expression.pop(0)
+            symb = HySymbol("__doc__")
+            symb.start_line = docstring.start_line
+            symb.start_column = docstring.start_column
+            body += self._compile_assign(symb, docstring,
+                                         docstring.start_line,
+                                         docstring.start_column)
+            body += body.expr_as_stmt()
+
         if expression:
             try:
                 body_expression = iter(expression.pop(0))

--- a/tests/native_tests/defclass.hy
+++ b/tests/native_tests/defclass.hy
@@ -60,3 +60,26 @@
     (x)
     (assert false))
    (except [NameError])))
+
+(defn test-defclass-docstring []
+  "NATIVE: test defclass docstring"
+  (defclass A []
+    [[--doc-- "doc string"]
+     [x 1]])
+  (setv a (A))
+  (assert (= a.__doc__ "doc string"))
+  (defclass B []
+    "doc string"
+    [[x 1]])
+  (setv b (B))
+  (assert (= b.x 1))
+  (assert (= b.__doc__ "doc string"))
+  (defclass MultiLine []
+    "begin a very long multi-line string to make
+     sure that it comes out the way we hope
+     and can span 3 lines end."
+    [[x 1]])
+  (setv mL (MultiLine))
+  (assert (= mL.x 1))
+  (assert (in "begin" mL.__doc__))
+  (assert (in "end" mL.__doc__)))


### PR DESCRIPTION
Added ability to parse doc strings set in defclass declarations,
like:

(defclass Foo [object]
  "this is the doc string"
  [[x 1]])
