### PR TITLE
Removes link to interactive demo from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,8 +32,7 @@ Meet our mascot, "Cuddles":
 ..   \|\||/
 
 
-Read more about Hy in these docs!  Or, if you'd like, try the
-`interactive hy->python demo <http://hy.pault.ag/>`_!
+Read more about Hy in these docs!
 
 We're also on IRC!  Join
 `#hy on irc.freenode.net <http://webchat.freenode.net/?channels=hy>`_!


### PR DESCRIPTION
We can revert this change when we put it back up once the macros problem is fixed (cf. #217)
