### PR TITLE
fix to assoc docs + new multiassoc definition

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -94,17 +94,23 @@ assoc
 -----
 
 `assoc` form is used to associate a key with a value in a dictionary or to set
-an index of a list to a value. It takes three parameters: `datastructure` to be
-modified, `key` or `index`  and `value`.
+an index of a list to a value. It takes at least three parameters: `datastructure` 
+to be modified, `key` or `index`  and `value`. If more than three parameters are
+used it will associate in pairs.
 
 Examples of usage:
 
 .. code-block:: clj
 
-  =>(let [[collection ({})]]
+  =>(let [[collection {}]]
   ... (assoc collection "Dog" "Bark")
   ... (print collection))
   {u'Dog': u'Bark'}
+
+  =>(let [[collection {}]]
+  ... (assoc collection "Dog" "Bark" "Cat" "Meow")
+  ... (print collection))
+  {u'Cat': u'Meow', u'Dog': u'Bark'}
 
   =>(let [[collection [1 2 3 4]]]
   ... (assoc collection 2 None)


### PR DESCRIPTION
fixes a typo in the current docs of assoc (let s-expr had some parenthesis that were syntactically incorrect)
added also documentation on how to use assoc on multiple keys
