### PR TITLE
Allow quoting lambda list keywords.

### DIFF
--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -24,6 +24,7 @@ __version__ = "0.9.10"
 
 
 from hy.models.expression import HyExpression  # NOQA
+from hy.models.lambdalist import HyLambdaListKeyword  # NOQA
 from hy.models.integer import HyInteger  # NOQA
 from hy.models.keyword import HyKeyword  # NOQA
 from hy.models.complex import HyComplex  # NOQA

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -618,7 +618,7 @@ class HyASTCompiler(object):
             return imports, HyExpression([HySymbol(name),
                                           contents]).replace(form), False
 
-        elif isinstance(form, HySymbol):
+        elif isinstance(form, (HySymbol, HyLambdaListKeyword)):
             return imports, HyExpression([HySymbol(name),
                                           HyString(form)]).replace(form), False
 

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -75,3 +75,10 @@
   (assert (= (len q) 3))
   (assert (= (get qq 1) (quote (quasiquote (unquote (+ 1 5))))))
   (assert (= q qq)))
+
+
+(defn test-quote-lambdalistkeyword []
+  "NATIVE: test quoting lambda list keywords"
+  (setv opt (quote &optional))
+  (assert (isinstance opt hy.HyLambdaListKeyword))
+  (assert (= (str opt) "&optional")))


### PR DESCRIPTION
This fixes an obvious bug where LambdaListKeywords couldn't be quoted.
