### PR TITLE
built in documentation

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -355,7 +355,7 @@ Parameters may have following keywords in front of them:
         => (zig-zag-sum 3 9 4)
         8
         => (zig-zag-sum 1 2 3 4 5 6)
-       -3
+        -3
 
 defmacro
 --------


### PR DESCRIPTION
documentation for defn and let. &key still missing from defn.
