### PR TITLE
Macro if-python2 for compile-time choice between Python 2 and Python 3 code branches

### DIFF
--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -1,5 +1,11 @@
 ;;; hy core macros
 
+(defmacro if-python2 [python2-form python3-form]
+  (import sys)
+  (if (< (get sys.version_info 0) 3)
+    python2-form
+    python3-form))
+
 (defmacro yield-from [_hy_yield_from_els]
   (quasiquote
     (for [_hy_yield_from_x (unquote _hy_yield_from_els)]

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -99,3 +99,8 @@
       (yield i))
     (yield-from [1 2 3]))
   (assert (= (list (yield-from-test)) [0 1 2 1 2 3])))
+
+(defn test-if-python2 []
+  (import sys)
+  (assert (= (get sys.version_info 0)
+             (if-python2 2 3))))


### PR DESCRIPTION
See my in-line comments in #269 for a motivation. We should never test the Python version at runtime for such things.
