### PR TITLE
Always import __future__.print_statement in hy code

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -966,31 +966,6 @@ class HyASTCompiler(object):
                              col_offset=expression.start_column)
         return ret
 
-    @builds("print")
-    def compile_print_expression(self, expr):
-        call = expr.pop(0)  # print
-        values, ret = self._compile_collect(expr)
-
-        if sys.version_info[0] >= 3:
-            call = self.compile(call)
-            ret += call
-            ret += ast.Call(func=call.expr,
-                            args=values,
-                            keywords=[],
-                            starargs=None,
-                            kwargs=None,
-                            lineno=expr.start_line,
-                            col_offset=expr.start_column)
-        else:
-            ret += ast.Print(
-                lineno=expr.start_line,
-                col_offset=expr.start_column,
-                dest=None,
-                values=values,
-                nl=True)
-
-        return ret
-
     @builds("break")
     def compile_break_expression(self, expr):
         ret = ast.Break(lineno=expr.start_line,

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -42,7 +42,9 @@ else:
 def ast_compile(ast, filename, mode):
     """Compile AST.
     Like Python's compile, but with some special flags."""
-    return compile(ast, filename, mode, __future__.CO_FUTURE_DIVISION)
+    flags = (__future__.CO_FUTURE_DIVISION |
+             __future__.CO_FUTURE_PRINT_FUNCTION)
+    return compile(ast, filename, mode, flags)
 
 
 def import_buffer_to_hst(buf):

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -26,7 +26,6 @@ from hy.compiler import hy_compile, HyCompileError, HyTypeError
 from hy.lex import tokenize
 
 import ast
-import sys
 
 
 def _ast_spotcheck(arg, root, secondary):
@@ -369,10 +368,7 @@ def test_ast_lambda_lists():
 def test_ast_print():
     code = can_compile("(print \"foo\")").body[0]
 
-    if sys.version_info[0] >= 3:
-        assert type(code.value) == ast.Call
-        return
-    assert type(code) == ast.Print
+    assert type(code.value) == ast.Call
 
 
 def test_ast_tuple():


### PR DESCRIPTION
This allows us to drop the print special-casing in the
compiler, and makes behavior consistent in Python2/3.
