### PR TITLE
Add hy._compat module.

### DIFF
--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -19,10 +19,20 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+try:
+    import __builtin__ as builtins
+except ImportError:
+    import builtins  # NOQA
 import sys
 
+PY3 = sys.version_info[0] == 3
 
-if sys.version_info[0] >= 3:
+if PY3:
     str_type = str
 else:
     str_type = unicode  # NOQA
+
+if PY3:
+    long_type = int
+else:
+    long_type = long  # NOQA

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -41,11 +41,7 @@ from hy.models.expression import HyExpression
 from hy.models.string import HyString
 from hy.models.symbol import HySymbol
 
-
-try:
-    import __builtin__ as builtins
-except ImportError:
-    import builtins
+from hy._compat import builtins
 
 
 class HyQuitter(object):

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -37,7 +37,7 @@ from hy.models.list import HyList
 from hy.models.dict import HyDict
 
 from hy.macros import require, process
-from hy.util import str_type
+from hy._compat import str_type
 import hy.importer
 
 import traceback

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -43,15 +43,11 @@ except ImportError:
 import hy.macros
 import hy.compiler
 
-try:
-    import __builtin__
-except ImportError:
-    import builtins as __builtin__  # NOQA
-
+from hy._compat import builtins
 
 PATH = [hy.compiler._compile_table,
         hy.macros._hy_macros,
-        __builtin__.__dict__]
+        builtins.__dict__]
 
 
 class Completer(object):

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -32,11 +32,7 @@ import ast
 import os
 import __future__
 
-if sys.version_info[0] >= 3:
-    long_type = int
-else:
-    import __builtin__
-    long_type = long  # NOQA
+from hy._compat import builtins, long_type
 
 
 def ast_compile(ast, filename, mode):
@@ -129,10 +125,7 @@ def write_hy_as_pyc(fname):
     code = ast_compile(_ast, fname, "exec")
     cfile = "%s.pyc" % fname[:-len(".hy")]
 
-    if sys.version_info[0] >= 3:
-        open_ = open
-    else:
-        open_ = __builtin__.open
+    open_ = builtins.open
 
     with open_(cfile, 'wb') as fc:
         if sys.version_info[0] >= 3:

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -26,7 +26,7 @@ from hy.models.integer import HyInteger
 from hy.models.float import HyFloat
 from hy.models.complex import HyComplex
 from hy.models.dict import HyDict
-from hy.util import str_type
+from hy._compat import str_type
 
 from collections import defaultdict
 

--- a/hy/models/keyword.py
+++ b/hy/models/keyword.py
@@ -20,7 +20,7 @@
 
 from __future__ import unicode_literals
 from hy.models import HyObject
-from hy.util import str_type
+from hy._compat import str_type
 
 
 class HyKeyword(HyObject, str_type):

--- a/hy/models/string.py
+++ b/hy/models/string.py
@@ -19,7 +19,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 from hy.models import HyObject
-from hy.util import str_type
+from hy._compat import str_type
 
 
 class HyString(HyObject, str_type):


### PR DESCRIPTION
There was a couple of duplicate imports and type checkings in the
codebase. So I added a new module to unify all Python 2 and 3
compatibility codes.

Also, this is a somewhat common pattern in Python. See Jinja2 for
example:

https://github.com/mitsuhiko/jinja2/blob/master/jinja2/_compat.py
