### PR TITLE
Documented punycode conversion more thoroughly using a compound case

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -24,8 +24,8 @@ languages.
 
   * UTF-8 entities will be encoded using
     `punycode <http://en.wikipedia.org/wiki/Punycode>`_ and prefixed with
-    `hy_`. For instance, `⚘` will become `hy_w7h`, and `♥` will become
-    `hy_g6h`.
+    `hy_`. For instance, `⚘` will become `hy_w7h`, `♥` will become `hy_g6h`,
+    and `i♥u` will become `hy_iu_t0x`.
 
   * Symbols that contain dashes will have them replaced with underscores. For
     example, `render-template` will become `render_template`.


### PR DESCRIPTION
It wasn't clear how cases like `i♥u` would be handled in the punycode conversion, so I documented this.
