### PR TITLE
Make HyObject.replace more resilient

### DIFF
--- a/hy/models/__init__.py
+++ b/hy/models/__init__.py
@@ -29,7 +29,7 @@ class HyObject(object):
         if isinstance(other, HyObject):
             for attr in ["start_line", "end_line",
                          "start_column", "end_column"]:
-                if not hasattr(self, attr):
+                if not hasattr(self, attr) and hasattr(other, attr):
                     setattr(self, attr, getattr(other, attr))
         else:
             raise TypeError("Can't replace a non Hy object with a Hy object")


### PR DESCRIPTION
This makes it work on quoted objects, and allows us to make macroexpand this:

``` clj
(defn macroexpand [form]
  (import hy.macros)
  (hy.macros.macroexpand form --name--))
```
