### PR TITLE
Uses square brackets for conds in docs

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -173,8 +173,8 @@ code:
 
 .. code-block:: clj
 
-    (cond (condition-1 result-1)
-          (condition-2 result-2))
+    (cond [condition-1 result-1]
+          [condition-2 result-2])
 
     (if condition-1 result-1
       (if condition-2 result-2))
@@ -184,10 +184,10 @@ As shown below only the first matching result block is executed.
 .. code-block:: clj
 
     => (defn check-value [value]
-    ...  (cond ((< value 5) (print "value is smaller than 5"))
-    ...        ((= value 5) (print "value is equal to 5"))
-    ...        ((> value 5) (print "value is greater than 5"))
-    ...	       (True (print "value is something that it should not be"))))
+    ...  (cond [(< value 5) (print "value is smaller than 5")]
+    ...        [(= value 5) (print "value is equal to 5")]
+    ...        [(> value 5) (print "value is greater than 5")]
+    ...	       [True (print "value is something that it should not be")]))
  
     => (check-value 6)
     value is greater than 5
@@ -564,8 +564,8 @@ For example:
 .. code-block:: clj
 
     => (defn rent-car [&kwargs kwargs]
-    ...  (cond ((in :brand kwargs) (print "brand:" (:brand kwargs)))
-    ...        ((in :model kwargs) (print "model:" (:model kwargs)))))
+    ...  (cond [(in :brand kwargs) (print "brand:" (:brand kwargs))]
+    ...        [(in :model kwargs) (print "model:" (:model kwargs))]))
 
     => (kwapply (rent-car) {:model "T-Model"})
     model: T-Model

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -254,12 +254,12 @@ In hy, you would do:
 .. code-block:: clj
 
    (cond
-    ((> somevar 50)
-     (print "That variable is too big!"))
-    ((< somevar 10)
-     (print "That variable is too small!"))
-    (true
-     (print "That variable is jussssst right!")))
+    [(> somevar 50)
+     (print "That variable is too big!")]
+    [(< somevar 10)
+     (print "That variable is too small!")]
+    [true
+     (print "That variable is jussssst right!")])
 
 What you'll notice is that cond switches off between a some statement
 that is executed and checked conditionally for true or falseness, and


### PR DESCRIPTION
Apparently `cond` uses square brackets `[]` now.
