### PR TITLE
Fix rply dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ long_description = """Hy is a Python <--> Lisp layer. It helps
 make things work nicer, and lets Python and the Hy lisp variant play
 nice together. """
 
-install_requires = []
+install_requires = ['rply>=0.6.2']
 if sys.version_info[:2] < (2, 7):
     install_requires.append('argparse>=1.2.1')
 if os.name == 'nt':
@@ -55,6 +55,7 @@ setup(
     name=PKG,
     version=__version__,
     install_requires=install_requires,
+    dependency_links=['https://github.com/hylang/rply/zipball/master#egg=rply-0.6.2'],
     entry_points={
         'console_scripts': [
             'hy = hy.cmdline:hy_main',


### PR DESCRIPTION
To test this, replace the https://github.com/hylang/rply/zipball/master#egg=rply-0.6.2
url with https://github.com/berkerpeksag/rply/zipball/master#egg=rply-0.6.2
in setup.py.

$ cd hy
$ virtualenv dummy
$ . dummy/bin/activate
$ pip install .
$ pip install astor nose
$ make test
...
...
Ran 252 tests in 9.723s

OK
