### PR TITLE
PyPI is now behind a CDN. The `--use-mirrors` option is deprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ python:
   - "2.6"
 # command to install dependencies
 install:
-  - pip install -r requirements.txt --use-mirrors
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install argparse importlib unittest2 astor --use-mirrors; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install astor --use-mirrors; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install astor --use-mirrors; fi
+  - pip install -r requirements.txt
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install argparse importlib unittest2 astor; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install astor; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install astor; fi
   - python setup.py -q install
 # # command to run tests
 script: make travis


### PR DESCRIPTION
See PEP 449 and https://mail.python.org/pipermail/distutils-sig/2013-May/020848.html
for more information.
