### PR TITLE
Fix sys.argv to reflect default Python behaviour

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -228,7 +228,7 @@ def cmdline_handler(scriptname, argv):
     options = parser.parse_args(argv[1:])
 
     # reset sys.argv like Python
-    sys.argv = options.args
+    sys.argv = options.args or [""]
 
     if options.command:
         # User did "hy -c ..."


### PR DESCRIPTION
By default, calling the Python REPL without arguments causes `sys.argv` to be a non-empty list with an empty string, and some modules (e.g., pyNN) rely on that.
