### PR TITLE
Set sys.argv default to [''] like Python does.

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -228,7 +228,10 @@ def cmdline_handler(scriptname, argv):
     options = parser.parse_args(argv[1:])
 
     # reset sys.argv like Python
-    sys.argv = options.args
+    if options.args and len(options.args) > 0:
+        sys.argv = options.args
+    else: # Python default
+        sys.argv =  ['']
 
     if options.command:
         # User did "hy -c ..."


### PR DESCRIPTION
Fixes pyNN.nest import, since it expects sys.argv to be [''].
