### PR TITLE
Translate all foo? -> is_foo. Close #334

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+Changes from Hy 0.9.11
+
+    [ Misc. Fixes ]
+    [ Syntax Fixes ]
+    [ Language Changes ]
+     * Translate foo? -> is_foo, for better Python interop. (PT)
+
 Changes from Hy 0.9.10
 
     * Many thanks to Guillermo Vayá (Willyfrog) for preparing this release's

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -212,9 +212,7 @@
   (_numeric_check n)
   (= n 0))
 
-(def *exports* ["cycle" "dec" "distinct" "drop" "drop_while" "empty?"
-                "even?" "filter" "float?" "inc"
-                "instance?" "integer?" "iterable?" "iterate" "iterator?" "neg?"
-                "none?" "nth" "numeric?" "odd?" "pos?" "remove" "repeat"
-                "repeatedly" "second" "string?" "take" "take_nth" "take_while"
-                "zero?"])
+(def *exports* '[cycle dec distinct drop drop-while empty? even? filter float?
+                 inc instance? integer? iterable? iterate iterator? neg? none?
+                 nth numeric? odd? pos? remove repeat repeatedly second string?
+                 take take-nth take-while zero?])

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -238,6 +238,9 @@ def t_identifier(p):
     if "-" in obj and obj != "-":
         obj = obj.replace("-", "_")
 
+    if obj.endswith("?") and obj != "?":
+        obj = "is_%s" % (obj[:-1])
+
     return HySymbol(obj)
 
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -551,6 +551,12 @@
     (assert (= -_- "what?"))))
 
 
+(defn test-symbol-question-mark []
+  "NATIVE: test foo? -> is_foo behavior"
+  (let [[foo? "nachos"]]
+    (assert (= is_foo "nachos"))))
+
+
 (defn test-and []
   "NATIVE: test the and function"
   (let [[and123 (and 1 2 3)]


### PR DESCRIPTION
The fancypants Hy award goes to Nick for coming up with the quoted
symbol hack for exports. This broke with foo?, since the export string
needs to be is_foo, but using a quoted string will pick up the change
due to it being a Symbol.

Mad clown love for that, @olasd.
