### PR TITLE
Adding support for coverage tests at coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+omit =
+    */python?.?/*
+    */lib-python/?.?/*.py
+    */lib_pypy/_*.py
+    */site-packages/nose/*
+    */pypy/*
+
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ python:
 # command to install dependencies
 install:
   - pip install -r requirements.txt
+  - pip install coveralls
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install argparse importlib unittest2 astor; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install astor; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install astor; fi
   - python setup.py -q install
 # # command to run tests
 script: make travis
+after_success: coveralls
 notifications:
   email:
     - paultag@gmail.com

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ diff:
 r: d tox diff
 
 travis:
-	nosetests -s
+	nosetests -s --with-coverage --cover-package hy
 ifeq (PyPy,$(findstring PyPy,$(shell python -V 2>&1 | tail -1)))
 	@echo "skipping flake8 on pypy"
 else

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lisp and Python should love each other. Let's make it happen.
 [![Build Status](https://travis-ci.org/hylang/hy.png?branch=master)](https://travis-ci.org/hylang/hy)
 [![Downloads](https://pypip.in/d/hy/badge.png)](https://crate.io/packages/hy)
 [![version](https://pypip.in/v/hy/badge.png)](https://crate.io/packages/hy)
-
+[![Coverage Status](https://coveralls.io/repos/hylang/hy/badge.png)](https://coveralls.io/r/hylang/hy)
 
 Hylarious Hacks
 ---------------


### PR DESCRIPTION
This commit adds support for coverage tests at [coveralls](https://coveralls.io)
uses coverage plugin from nosetests. https://coveralls.io/r/theanalyst/hy will give an idea of what this looks like.

I'm not 100% sure on what to exclude, added some defaults so that we are checking hy and not the virtualenv itself. 
