### PR TITLE
Use Hy notation for the repr of builtin types, improves REPL

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -42,7 +42,7 @@ from hy.importer import (ast_compile, import_buffer_to_module,
                          import_file_to_ast, import_file_to_hst)
 from hy.completer import completion
 
-from hy.macros import macro, require
+from hy.macros import macro, require, _wrap_value
 from hy.models.expression import HyExpression
 from hy.models.string import HyString
 from hy.models.symbol import HySymbol
@@ -75,6 +75,15 @@ def print_python_code(_ast):
     _ast_for_print = ast.Module()
     _ast_for_print.body = _ast.body
     print(astor.codegen.to_source(_ast_for_print))
+
+
+def print_hyrepr(obj):
+    obj = _wrap_value(obj)
+    if obj:
+        sys.stdout.write(builtins.repr(obj))
+        sys.stdout.write("\n")
+
+sys.displayhook = print_hyrepr
 
 
 class HyREPL(code.InteractiveConsole):

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -69,20 +69,24 @@ class HyQuitter(object):
 builtins.quit = HyQuitter('quit')
 builtins.exit = HyQuitter('exit')
 
+
 def print_python_code(_ast):
     # astor cannot handle ast.Interactive, so disguise it as a module
     _ast_for_print = ast.Module()
     _ast_for_print.body = _ast.body
     print(astor.codegen.to_source(_ast_for_print))
 
+
 def hyrepr(obj):
     if hasattr(obj, "__hyrepr__"):
         return obj.__hyrepr__()
     return _wrap_value(obj).__repr__()
 
+
 def print_hyrepr(obj):
     sys.stdout.write(hyrepr(obj))
     sys.stdout.write("\n")
+
 
 sys.displayhook = print_hyrepr
 

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -69,19 +69,20 @@ class HyQuitter(object):
 builtins.quit = HyQuitter('quit')
 builtins.exit = HyQuitter('exit')
 
-
 def print_python_code(_ast):
     # astor cannot handle ast.Interactive, so disguise it as a module
     _ast_for_print = ast.Module()
     _ast_for_print.body = _ast.body
     print(astor.codegen.to_source(_ast_for_print))
 
+def hyrepr(obj):
+    if hasattr(obj, "__hyrepr__"):
+        return obj.__hyrepr__()
+    return _wrap_value(obj).__repr__()
 
 def print_hyrepr(obj):
-    obj = _wrap_value(obj)
-    if obj:
-        sys.stdout.write(builtins.repr(obj))
-        sys.stdout.write("\n")
+    sys.stdout.write(hyrepr(obj))
+    sys.stdout.write("\n")
 
 sys.displayhook = print_hyrepr
 

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -108,11 +108,10 @@ def require(source_module, target_module):
 
 
 def _keyword_or_string(s):
-    # This is horrible and introduces bugs. We need a better way to map
-    # a string back to a keyword, maybe a really unique
-    # HyKeyword.magic_marker (hash).
-    if s.startswith(HyKeyword.magic_marker):
-        return HyKeyword(s.strip(HyKeyword.magic_marker))
+    # Not guaranteed to be always correct since the magic marker
+    # is not really unique...
+    if s.startswith(HyKeyword._magic_marker):
+        return HyKeyword(s.lstrip(HyKeyword._magic_marker))
     return HyString(s)
 
 # type -> wrapping function mapping for _wrap_value

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -26,6 +26,7 @@ from hy.models.integer import HyInteger
 from hy.models.float import HyFloat
 from hy.models.complex import HyComplex
 from hy.models.dict import HyDict
+from hy.models.keyword import HyKeyword
 from hy._compat import str_type, long_type
 
 from hy.errors import HyTypeError, HyMacroExpansionError
@@ -106,16 +107,24 @@ def require(source_module, target_module):
         reader_refs[name] = reader
 
 
+def _keyword_or_string(s):
+    # This is horrible and introduces bugs. We need a better way to map
+    # a string back to a keyword, maybe a really unique
+    # HyKeyword.magic_marker (hash).
+    if s.startswith(HyKeyword.magic_marker):
+        return HyKeyword(s.strip(HyKeyword.magic_marker))
+    return HyString(s)
+
 # type -> wrapping function mapping for _wrap_value
 _wrappers = {
     int: HyInteger,
     bool: lambda x: HySymbol("True") if x else HySymbol("False"),
     float: HyFloat,
     complex: HyComplex,
-    str_type: HyString,
     dict: lambda d: HyDict(_wrap_value(x) for x in sum(d.items(), ())),
     list: lambda l: HyList(_wrap_value(x) for x in l),
     tuple: lambda t: HyList(_wrap_value(x) for x in t),
+    str_type: _keyword_or_string,
     type(None): lambda foo: HySymbol("None"),
 }
 

--- a/hy/models/keyword.py
+++ b/hy/models/keyword.py
@@ -34,3 +34,6 @@ class HyKeyword(HyObject, str_type):
 
         obj = str_type.__new__(cls, value)
         return obj
+
+    def __repr__(self):
+        return self.strip(self.magic_marker)

--- a/hy/models/keyword.py
+++ b/hy/models/keyword.py
@@ -27,13 +27,15 @@ class HyKeyword(HyObject, str_type):
     """Generic Hy Keyword object. It's either a ``str`` or a ``unicode``,
     depending on the Python version.
     """
+    __slots__ = ['_magic_marker']
+    _magic_marker = "\uFDD0"
 
     def __new__(cls, value):
-        if not value.startswith("\uFDD0"):
-            value = "\uFDD0" + value
+        if not value.startswith(cls._magic_marker):
+            value = cls._magic_marker + value
 
         obj = str_type.__new__(cls, value)
         return obj
 
     def __repr__(self):
-        return self.strip(self.magic_marker)
+        return self.strip(self._magic_marker)

--- a/hy/models/string.py
+++ b/hy/models/string.py
@@ -28,4 +28,9 @@ class HyString(HyObject, str_type):
     scripts. It's either a ``str`` or a ``unicode``, depending on the
     Python version.
     """
-    pass
+    def __escaped__(self):
+        # XXX: Not sure this covers all cases...
+        return str_type.encode(self, 'unicode_escape')
+
+    def __repr__(self):
+        return '"%s"' % self.__escaped__()

--- a/hy/models/symbol.py
+++ b/hy/models/symbol.py
@@ -28,3 +28,6 @@ class HySymbol(HyString):
 
     def __init__(self, string):
         self += string
+
+    def __repr__(self):
+        return self.__escaped__()


### PR DESCRIPTION
A cleaner implementation of #351 that passes all tests. Need to exercise the corner cases with more tests and think about other objects. Feedback!