### PR TITLE
Allow macros to return None, fixes #357

### DIFF
--- a/hy/macros.py
+++ b/hy/macros.py
@@ -84,7 +84,8 @@ _wrappers = {
     complex: HyComplex,
     str_type: HyString,
     dict: lambda d: HyDict(_wrap_value(x) for x in sum(d.items(), ())),
-    list: lambda l: HyList(_wrap_value(x) for x in l)
+    list: lambda l: HyList(_wrap_value(x) for x in l),
+    type(None): lambda foo: HySymbol("None"),
 }
 
 

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -34,6 +34,9 @@
 (defmacro a-dict [] {1 2})
 (assert (= (a-dict) {1 2}))
 
+(defmacro a-none [])
+(assert (= (a-none) None))
+
 ; A macro calling a previously defined function
 (eval-when-compile
  (defn foo [x y]


### PR DESCRIPTION
Allows Hy macros to return None, to test this

  (defmacro foo [])
  (foo)

Should work now
Much thanks to @olasd for pointing out how this is to be done
