### PR TITLE
Allow get with multiple arguments

### DIFF
--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -253,7 +253,6 @@ def test_ast_bad_get():
     "Make sure AST can't compile invalid get"
     cant_compile("(get)")
     cant_compile("(get 1)")
-    cant_compile("(get 1 2 3)")
 
 
 def test_ast_good_slice():

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -129,7 +129,16 @@
 (defn test-index []
   "NATIVE: Test that dict access works"
   (assert (= (get {"one" "two"} "one") "two"))
-  (assert (= (get [1 2 3 4 5] 1) 2)))
+  (assert (= (get [1 2 3 4 5] 1) 2))
+  (assert (= (get {"first" {"second" {"third" "level"}}}
+                  "first" "second" "third")
+             "level"))
+  (assert (= (get ((fn [] {"first" {"second" {"third" "level"}}}))
+                  "first" "second" "third")
+             "level"))
+  (assert (= (get {"first" {"second" {"third" "level"}}}
+                  ((fn [] "first")) "second" "third")
+             "level")))
 
 
 (defn test-lambda []


### PR DESCRIPTION
When calling get with more than two arguments, treat the rest as indexes
into the expression from the former. That is, (get foo "bar" "baz")
would translate to foo["bar"]["baz"], and so on.

This fixes #362.

Requested-by: Sean B. Palmer sean@miscoranda.com
Signed-off-by: Gergely Nagy algernon@balabit.hu
