### PR TITLE
Adding macros `prog1' and `prog2' similar to cl

### DIFF
--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -101,6 +101,21 @@
   ret)
 
 
+(defmacro-alias [do1 prog1] [&rest body]
+  "eval statements in body sequentially, return the value of first expr"
+  (if (> (len body) 0)
+    `(let [[ret ~(car body)]]
+       ~@(cdr body)
+       ret)))
+
+
+(defmacro-alias [do2 prog2] [expr1 &rest body]
+  "eval statements in body sequentially and return the value of second expr"
+  (if (> (len body) 0)
+    `(do ~expr1 (do1 ~@body))
+    (macro-error expr1 "Atleast 2 args are needed for do2/prog2")))
+
+
 (defmacro when [test &rest body]
   "Execute `body` when `test` is true"
   `(if ~test (do ~@body)))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -107,3 +107,9 @@
   (import sys)
   (assert (= (get sys.version_info 0)
              (if-python2 2 3))))
+
+(defn test-prog1 []
+  (assert (= 4 (prog1 (+ 2 2) (+ 3 4)))))
+
+(defn test-prog2 []
+  (assert (= 4 (prog2 (+ 1 1) (+ 2 2) (+ 3 4)))))


### PR DESCRIPTION
This is an attempt at writing cl like `prog1` and `prog2` macros
Not sure whether we want them in core, this can be discussed

`prog1` executes the body sequentially (possibly for side effects),
returning the value of the first expr
eg:

```
=> (prog1 (+ 2 2) (print "some side-effects"))
"some side-effects"
 4
```

or something like

```
 => (setv a (prog1 (+ 2 2) (print "some side-effects"))
 "some side-effects"
 => a
  4
```

`prog2' is similiar to prog1 except that it returns the value of the
second expr
