### PR TITLE
Operators + and * work without args, fixes #372

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1343,11 +1343,9 @@ class HyASTCompiler(object):
                                  lineno=e.start_line,
                                  col_offset=e.start_column)
 
-    @builds("+")
     @builds("%")
     @builds("/")
     @builds("//")
-    @builds("*")
     @builds("**")
     @builds("<<")
     @builds(">>")
@@ -1383,6 +1381,23 @@ class HyASTCompiler(object):
                              lineno=child.start_line,
                              col_offset=child.start_column)
         return ret
+
+    @builds("+")
+    @builds("*")
+    def compile_maths_expression_mul(self, expression):
+        if len(expression) > 2:
+            return self.compile_maths_expression(expression)
+        else:
+            id_op = {"+": HyInteger(0), "*": HyInteger(1)}
+
+            op = expression.pop(0)
+            arg = expression.pop(0) if expression else id_op[op]
+            expr = HyExpression([
+                HySymbol(op),
+                id_op[op],
+                arg
+            ]).replace(expression)
+            return self.compile_maths_expression(expr)
 
     @builds("-")
     @checkargs(min=1)

--- a/tests/native_tests/math.hy
+++ b/tests/native_tests/math.hy
@@ -8,7 +8,9 @@
 
 (setv test_mult (fn []
                   "NATIVE: Test multiplication."
-                  (assert (= 4 (square 2)))))
+                  (assert (= 4 (square 2)))
+                  (assert (= 8 (* 8)))
+                  (assert (= 1 (*)))))
 
 
 (setv test_sub (fn []
@@ -19,7 +21,9 @@
 
 (setv test_add (fn []
                  "NATIVE: Test addition"
-                 (assert (= 4 (+ 1 1 1 1)))))
+                 (assert (= 4 (+ 1 1 1 1)))
+                 (assert (= 8 (+ 8)))
+                 (assert (= 0 (+)))))
 
 
 (setv test_div (fn []


### PR DESCRIPTION
Like other lisps, operators `+` and `*` return their identity values
when called with no arguments. With a single operand they return
the operand.

Without arguments, the present implementation expands `(+)` -> `(+ 0 0)` & 
`(*)` -> `(* 1 1)` 

An alternative approach for `+` would be to use `ast.UAdd` 
and use only one operand, however no such unary operation  is defined 
for multiplication, so I went ahead with something that works for both 
addition and multiplication

This fixes #372
