### PR TITLE
Reader macros implementation!

### DIFF
--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -25,7 +25,6 @@
 ;;; These macros form the hy language
 ;;; They are automatically required in every module, except inside hy.core
 
-
 (defmacro for [args &rest body]
   "shorthand for nested foreach loops:
   (for [x foo y bar] baz) ->
@@ -144,3 +143,13 @@
       (setv -args (cdr (car -args))))
 
     `(apply ~-fun [~@-args] (dict (sum ~-okwargs [])))))
+
+
+(defmacro dispatch-reader-macro [char &rest body]
+  "Dispatch a reader macro based on the character"
+  (import [hy.macros])
+  (setv str_char (get char 1))
+  (if (not (in str_char hy.macros._hy_reader_chars))
+    (raise (hy.compiler.HyTypeError char (.format "There is no reader macro with the character `{0}`" str_char))))
+  `(do (import [hy.macros [_hy_reader]])
+       ((get (get _hy_reader --name--) ~char) ~(get body 0))))

--- a/hy/lex/lexer.py
+++ b/hy/lex/lexer.py
@@ -40,6 +40,7 @@ lg.add('QUASIQUOTE', r'`%s' % end_quote)
 lg.add('UNQUOTESPLICE', r'~@%s' % end_quote)
 lg.add('UNQUOTE', r'~%s' % end_quote)
 lg.add('HASHBANG', r'#!.*[^\r\n]')
+lg.add('HASHREADER', r'#.')
 
 
 lg.add('STRING', r'''(?x)

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -150,6 +150,15 @@ def term_unquote_splice(p):
     return HyExpression([HySymbol("unquote_splice"), p[1]])
 
 
+@pg.production("term : HASHREADER term")
+@set_quote_boundaries
+def hash_reader(p):
+    st = p[0].getstr()[1]
+    str_object = HyExpression([HySymbol("quote"), HyString(st)])
+    expr = HyExpression([HySymbol("quote"), p[1]])
+    return HyExpression([HySymbol("dispatch_reader_macro"), str_object, expr])
+
+
 @pg.production("dict : LCURLY list_contents RCURLY")
 @set_boundaries
 def t_dict(p):

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -40,6 +40,8 @@ EXTRA_MACROS = [
 ]
 
 _hy_macros = defaultdict(dict)
+_hy_reader = defaultdict(dict)
+_hy_reader_chars = set()
 
 
 def macro(name):
@@ -63,6 +65,30 @@ def macro(name):
     return _
 
 
+def reader(name):
+    """Decorator to define a macro called `name`.
+
+    This stores the macro `name` in the namespace for the module where it is
+    defined.
+
+    If the module where it is defined is in `hy.core`, then the macro is stored
+    in the default `None` namespace.
+
+    This function is called from the `defmacro` special form in the compiler.
+
+    """
+    def _(fn):
+        module_name = fn.__module__
+        if module_name.startswith("hy.core"):
+            module_name = None
+        _hy_reader[module_name][name] = fn
+
+        # Ugly hack to get some error handling
+        _hy_reader_chars.add(name)
+        return fn
+    return _
+
+
 def require(source_module, target_module):
     """Load the macros from `source_module` in the namespace of
     `target_module`.
@@ -74,6 +100,11 @@ def require(source_module, target_module):
     refs = _hy_macros[target_module]
     for name, macro in macros.items():
         refs[name] = macro
+
+    readers = _hy_reader[source_module]
+    reader_refs = _hy_reader[target_module]
+    for name, reader in readers.items():
+        reader_refs[name] = reader
 
 
 # type -> wrapping function mapping for _wrap_value

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,3 +11,4 @@ from .native_tests.unless import *  # noqa
 from .native_tests.when import *  # noqa
 from .native_tests.with_decorator import *  # noqa
 from .native_tests.core import *  # noqa
+from .native_tests.reader_macros import *  # noqa

--- a/tests/lex/test_lex.py
+++ b/tests/lex/test_lex.py
@@ -252,3 +252,11 @@ def test_complex():
     assert entry == HyComplex("1.0j")
     entry = tokenize("(j)")[0][0]
     assert entry == HySymbol("j")
+
+
+def test_reader_macro():
+    """Ensure reader macros are handles properly"""
+    entry = tokenize("#^()")
+    assert entry[0][0] == HySymbol("dispatch_reader_macro")
+    assert entry[0][1] == HyExpression([HySymbol("quote"), HyString("^")])
+    assert len(entry[0]) == 3

--- a/tests/macros/test_reader_macros.py
+++ b/tests/macros/test_reader_macros.py
@@ -1,0 +1,11 @@
+from hy.macros import macroexpand
+from hy.compiler import HyTypeError
+from hy.lex import tokenize
+
+
+def test_reader_macro_error():
+    """Check if we get correct error with wrong disptach character"""
+    try:
+        macroexpand(tokenize("(dispatch_reader_macro '- '())")[0], __name__)
+    except HyTypeError as e:
+        assert "with the character `-`" in str(e)

--- a/tests/native_tests/reader_macros.hy
+++ b/tests/native_tests/reader_macros.hy
@@ -1,0 +1,32 @@
+(defn test-reader-macro []
+  "Test a basic redaer macro"
+  (defreader ^ [expr]
+    expr)
+
+  (assert (= #^"works" "works")))
+
+
+(defn test-reader-macro-expr []
+  "Test basic exprs like lists and arrays"
+  (defreader n [expr]
+    (get expr 1))
+
+  (assert (= #n[1 2] 2))
+  (assert (= #n(1 2) 2)))
+
+
+(defn test-reader-macro-override []
+  "Test if we can override function symbols"
+  (defreader + [n]
+    (+ n 1))
+
+  (assert (= #+2 3)))
+
+
+(defn test-reader-macro-compile-docstring []
+  "Test if we can compile with a docstring"
+  (try
+    (defreader d []
+      "Compiles with docstrings")
+    (except [Exception] 
+            (assert False))))


### PR DESCRIPTION
This PR isnt done, but mainly for feedback and reviewing of the current code and test cases.
Basic syntax:

``` .clojure
(defreader ^ [expr]
  (print expr))

#^"woohoo!"
;; -> (dispatch_reader_macro '^ '"woohoo!")
```

Current issues:
- Error handling isnt anywhere near finished, got some hiccups there.
- Needs better test cases.
- Refactor `defmacro`and `defreader`code in `compiler.py`

Feedback & comments is more then welcome!
