### PR TITLE
Switched * with +

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -19,8 +19,11 @@ These rules help make sure code is idiomatic and interface-able in both
 languages.
 
 
-  * Symbols in earmufs will be translated to the uppercased version of that
-    string. For example, `*foo*` will become `FOO`.
+  * Symbols in earmufs will be considered globals.
+
+  * Symbols between + are considered constants and will be translated to 
+    the uppercased version of that string. For example, `+foo+` will 
+    become `FOO`.
 
   * UTF-8 entities will be encoded using
     `punycode <http://en.wikipedia.org/wiki/Punycode>`_ and prefixed with

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -18,20 +18,21 @@ this, it's going to come in handy.
 These rules help make sure code is idiomatic and interface-able in both
 languages.
 
+* UTF-8 entities will be encoded using
+  `punycode <http://en.wikipedia.org/wiki/Punycode>`_ and prefixed with
+  `hy_`. For instance, `⚘` will become `hy_w7h`, `♥` will become `hy_g6h`,
+  and `i♥u` will become `hy_iu_t0x`.
+     
+* Symbols that contain dashes will have them replaced with underscores. For
+  example, `render-template` will become `render_template`.
 
-  * Symbols in earmufs will be considered globals.
+.. versionchanged:: 0.9.12
 
-  * Symbols between + are considered constants and will be translated to 
-    the uppercased version of that string. For example, `+foo+` will 
-    become `FOO`.
+   * Symbols in earmufs will be considered globals.
 
-  * UTF-8 entities will be encoded using
-    `punycode <http://en.wikipedia.org/wiki/Punycode>`_ and prefixed with
-    `hy_`. For instance, `⚘` will become `hy_w7h`, `♥` will become `hy_g6h`,
-    and `i♥u` will become `hy_iu_t0x`.
-
-  * Symbols that contain dashes will have them replaced with underscores. For
-    example, `render-template` will become `render_template`.
+   * Symbols between + are considered constants and will be translated to 
+     the uppercased version of that string. For example, `+foo+` will 
+     become `FOO`.
 
 
 Builtins

--- a/eg/sunlight/party-count.hy
+++ b/eg/sunlight/party-count.hy
@@ -8,7 +8,7 @@
         [collections [Counter]])
 
 
-(def *state* (get sys.argv 1))
+(def +state+ (get sys.argv 1))
 
 
 (defn get-legislators [state]

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -222,7 +222,7 @@
   (_numeric_check n)
   (= n 0))
 
-(def *exports* '[cycle dec distinct drop drop-while empty? even? filter float?
+(def +exports+ '[cycle dec distinct drop drop-while empty? even? filter float?
                  inc instance? integer integer? iterable? iterate iterator? neg?
                  none? nth numeric? odd? pos? remove repeat repeatedly second
                  string string? take take-nth take-while zero?])

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -232,8 +232,11 @@ def t_identifier(p):
     if obj.startswith("&"):
         return HyLambdaListKeyword(obj)
 
-    if obj.startswith("*") and obj.endswith("*") and obj not in ("*", "**"):
+    if obj.startswith("+") and obj.endswith("+") and obj not in ("+", "++"):
         obj = obj[1:-1].upper()
+
+    if obj.startswith("*") and obj.endswith("*") and obj not in ("*", "**"):
+        obj = obj[1:-1]
 
     if "-" in obj and obj != "-":
         obj = obj.replace("-", "_")

--- a/tests/lex/test_lex.py
+++ b/tests/lex/test_lex.py
@@ -252,3 +252,11 @@ def test_complex():
     assert entry == HyComplex("1.0j")
     entry = tokenize("(j)")[0][0]
     assert entry == HySymbol("j")
+
+
+def test_python_conversion():
+    """Make sure some conventions are properly translated"""
+    entry = tokenize("questionable? *foo* +bar+")
+    assert entry[0] == "is_questionable"
+    assert entry[1] == "foo"
+    assert entry[2] == "BAR"

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -316,12 +316,12 @@
      (except))
     (assert (= x 0))))
 
-(defn test-earmuffs []
-  "NATIVE: Test earmuffs"
-  (setv *foo* "2")
+(defn test-constants []
+  "NATIVE: Test constants"
+  (setv +foo+ "2")
   (setv foo "3")
-  (assert (= *foo* FOO))
-  (assert (!= *foo* foo)))
+  (assert (= +foo+ FOO))
+  (assert (!= +foo+ foo)))
 
 
 (defn test-threading []


### PR DESCRIPTION
`*foo*` converts to foo now and `+bar+` to `BAR`
*THIS BREAKS CURRENT CODE*, you have been warned
 Also added tests for translation of `*foo*` `+bar+` and `questionable?` symbols