### PR TITLE
Fix for readline REPL problem Darwin Python3

### DIFF
--- a/hy/completer.py
+++ b/hy/completer.py
@@ -41,7 +41,7 @@ except ImportError:
     except ImportError:
         docomplete = False
 
-if sys.platform == 'darwin':
+if sys.platform == 'darwin' and 'libedit' in readline.__doc__:
     readline_bind = "bind ^I rl_complete"
 else:
     readline_bind = "tab: complete"


### PR DESCRIPTION
On OS X Mavericks, the Hy REPL doesn't allow the 'b' character when
running with Python 3.3. This appears to be a common problem
for Darwin and readline as mentioned in this post

http://superuser.com/questions/297527/cant-type-the-b-letter-in-python-shell-in-os-x
