### PR TITLE
Remove astor from requirements-dev.txt.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
-astor
 tox
 nose
 Sphinx


### PR DESCRIPTION
This is not necessary since 870c136.
