### PR TITLE
Reader macros docs!

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -397,6 +397,25 @@ So ``g!a`` would become ``(gensym "a")``.
 
    Section :ref:`using-gensym`
 
+defreader
+---------
+
+.. versionadded:: 0.9.12
+
+`defreader` defines a reader macro, enabling you to restructure or
+modify syntax.
+
+.. code-block:: clj
+
+    => (defreader ^ [expr] (print expr))
+    => #^(1 2 3 4)
+    (1 2 3 4)
+    => #^"Hello"
+    "Hello"
+
+.. seealso::
+
+    Section :ref:`Reader Macros <reader-macros>`
 
 del
 ---

--- a/docs/language/index.rst
+++ b/docs/language/index.rst
@@ -11,3 +11,4 @@ Contents:
    api
    core
    internals
+   readermacros

--- a/docs/language/readermacros.rst
+++ b/docs/language/readermacros.rst
@@ -1,0 +1,60 @@
+.. _reader-macros:
+=============
+Reader Macros
+=============
+
+Reader macros gives LISP the power to modify and alter syntax on the fly. 
+You don't want polish notation? A reader macro can easily do just that. Want 
+clojure's way of having a regex? Reader macros can also do this easily.
+
+
+Syntax
+======
+
+.. code-block:: clj
+
+    => (defreader ^ [expr] (print expr))
+    => #^(1 2 3 4)
+    (1 2 3 4)
+    => #^"Hello"
+    "Hello"
+    => #^1+2+3+4+3+2
+    1+2+3+4+3+2
+
+
+Implementation
+==============
+
+Hy uses `defreader` to define the reader symbol, and `#` as the dispatch character. 
+`#` expands into `(dispatch_reader_macro ...)` where the symbol and expression is 
+quoted, and then passed along to the correct function.
+
+.. code-block:: clj
+
+    => (defreader ^ ...)
+    => #^()
+    ;=> (dispatch_reader_macro '^ '())
+
+
+`defreader` takes a single character as symbol name for the reader macro, anything 
+longer will return an error. Implementation wise, `defreader` expands into a 
+lambda covered with a decorator, this decorater saves the lambda in a dict with 
+its module name and symbol.
+
+.. code-block:: clj
+
+    => (defreader ^ [expr] (print expr))
+    ;=> (with_decorator (hy.macros.reader ^) (fn [expr] (print expr)))
+
+
+Anything passed along is quoted, thus given to the function defined.
+
+.. code-block:: clj
+
+    => #^"Hello"
+    "Hello"
+
+
+.. warning::
+    Because of a limitation in Hy's lexer and parser, reader macros can't redefine 
+    defined syntax such as `()[]{}`. This will most likely be adressed in the future.

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1866,7 +1866,7 @@ class HyASTCompiler(object):
         expression.pop(0)
         name = expression.pop(0)
         NOT_READERS = [":", "&"]
-        if name in NOT_READERS:
+        if name in NOT_READERS or len(name) > 1:
             raise NameError("%s can't be used as a macro reader symbol" % name)
         if not isinstance(name, HySymbol):
             raise HyTypeError(name,


### PR DESCRIPTION
Added docs, hopefully without any spelling errors (@hylang/hyl soon?).
Also fixed a bug where defreader would accept names longer then one letter.

Have to expand the documentation later with some better examples of usage.
