### PR TITLE
Added loop/recur macro for tail-call optimization

### DIFF
--- a/docs/contrib/index.rst
+++ b/docs/contrib/index.rst
@@ -8,3 +8,4 @@ Contents:
    :maxdepth: 3
 
    anaphoric
+   loop

--- a/docs/contrib/loop.rst
+++ b/docs/contrib/loop.rst
@@ -1,0 +1,56 @@
+==========
+loop/recur
+==========
+
+.. versionadded:: 0.9.13
+
+The loop/recur macro gives programmers a simple way to use tail-call
+optimization (TCO) in their Hy code.
+
+    A tail call is a subroutine call that happens inside another
+    procedure as its final action; it may produce a return value which
+    is then immediately returned by the calling procedure. If any call
+    that a subroutine performs, such that it might eventually lead to
+    this same subroutine being called again down the call chain, is in
+    tail position, such a subroutine is said to be tail-recursive,
+    which is a special case of recursion. Tail calls are significant
+    because they can be implemented without adding a new stack frame
+    to the call stack. Most of the frame of the current procedure is
+    not needed any more, and it can be replaced by the frame of the
+    tail call. The program can then jump to the called
+    subroutine. Producing such code instead of a standard call
+    sequence is called tail call elimination, or tail call
+    optimization. Tail call elimination allows procedure calls in tail
+    position to be implemented as efficiently as goto statements, thus
+    allowing efficient structured programming.
+
+    -- Wikipedia (http://en.wikipedia.org/wiki/Tail_call)
+                  
+Macros
+======
+
+.. _loop:
+
+loop
+-----
+
+``loop`` establishes a recursion point. With ``loop``, ``recur``
+rebinds the variables set in the recursion point and sends code
+execution back to that recursion point. If ``recur`` is used in a
+non-tail position, an exception is thrown.
+
+Usage: `(loop bindings &rest body)`
+
+Example:
+
+.. code-block:: clojure
+
+    (require hy.contrib.loop)
+
+    (defn factorial [n]
+      (loop [[i n] [acc 1]]
+        (if (zero? i)
+          acc
+          (recur (dec i) (* acc i)))))
+
+    (factorial 1000)

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -1,0 +1,79 @@
+;;; Hy tail-call optimization
+;;
+;; Copyright (c) 2014 Clinton Dreisbach <clinton@dreisbach.us>
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a
+;; copy of this software and associated documentation files (the "Software"),
+;; to deal in the Software without restriction, including without limitation
+;; the rights to use, copy, modify, merge, publish, distribute, sublicense,
+;; and/or sell copies of the Software, and to permit persons to whom the
+;; Software is furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+;; THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;; DEALINGS IN THE SOFTWARE.
+;;
+;;; The loop/recur macro allows you to construct functions that use tail-call
+;;; optimization to allow arbitrary levels of recursion.
+
+(defn --trampoline-- [f]
+  "Wrap f function and make it tail-call optimized."
+  ;; Takes the function "f" and returns a wrapper that may be used for tail-
+  ;; recursive algorithms. Note that the returned function is not side-effect
+  ;; free and should not be called from anywhere else during tail recursion.
+
+  (setv result None)
+  ;; We have to put this in a list because of Python's
+  ;; weirdness around local variables.
+  ;; Assigning directly to it later would cause it to
+  ;; shadow in a new scope.
+  (setv active [False])
+  (setv accumulated [])
+
+  (fn [&rest args]
+    (.append accumulated args)
+    (when (not (first active))
+      (assoc active 0 True)
+      (while (> (len accumulated) 0)
+        (setv result (apply f (.pop accumulated))))
+      (assoc active 0 False)
+      result)))
+
+(defn recursive-replace [old-term new-term body]
+  "Recurses through lists of lists looking for old-term and replacing it with new-term."
+  ((type body)
+   (list-comp (cond
+               [(= term old-term) new-term]
+               [(instance? hy.HyList term)
+                (recursive-replace old-term new-term term)]
+               [True term]) [term body])))
+
+(defmacro loop [bindings &rest body]
+  ;; Use inside functions like so:
+  ;; (defun factorial [n]
+  ;;   (loop [[i n]
+  ;;          [acc 1]]
+  ;;         (if (= i 0)
+  ;;           acc
+  ;;           (recur (dec i) (* acc i)))))
+  ;;
+  ;; If recur is used in a non-tail-call position, None is returned, which
+  ;; causes chaos. Fixing this to detect if recur is in a tail-call position
+  ;; and erroring if not is a giant TODO.
+  (with-gensyms [recur-fn]
+    (let [[fnargs (map (fn [x] (first x)) bindings)]
+          [initargs (map second bindings)]
+          [new-body (recursive-replace 'recur recur-fn body)]]
+      `(do
+        (import [hy.contrib.loop [--trampoline--]])
+        (def ~recur-fn
+          (--trampoline-- (fn [~@fnargs]
+                            ~@new-body)))
+        (~recur-fn ~@initargs)))))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,4 +14,5 @@ from .native_tests.core import *  # noqa
 from .native_tests.reader_macros import *  # noqa
 from .native_tests.with_test import *  # noqa
 from .native_tests.contrib.anaphoric import *  # noqa
+from .native_tests.contrib.loop import *  # noqa
 from .contrib.test_meth import *  # noqa

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -1,0 +1,46 @@
+(require hy.contrib.loop)
+(import sys)
+
+(defn tco-sum [x y]
+  (loop [[x x] [y y]]
+        (cond
+         [(> y 0) (recur (inc x) (dec y))]
+         [(< y 0) (recur (dec x) (inc y))]
+         [True x])))
+
+(defn non-tco-sum [x y]
+  (cond
+   [(> y 0) (inc (non-tco-sum x (dec y)))]
+   [(< y 0) (dec (non-tco-sum x (inc y)))]
+   [True x]))
+
+(defn test-loop []
+  ;; non-tco-sum should fail
+  (try
+   (setv n (non-tco-sum 100 10000))
+   (catch [e RuntimeError]
+     (assert true))
+   (else
+    (assert false)))
+
+  ;; tco-sum should not fail
+  (try
+   (setv n (tco-sum 100 10000))
+   (catch [e RuntimeError]
+     (assert false))
+   (else
+    (assert (= n 10100)))))
+
+(defn test-recur-in-wrong-loc []
+  (defn bad-recur [n]
+    (loop [[i n]]
+          (if (= i 0)
+            0
+            (inc (recur (dec i))))))
+
+  (try
+   (bad-recur 3)
+   (catch [e TypeError]
+     (assert true))
+   (else
+    (assert false))))


### PR DESCRIPTION
In the Clojure programming language, automatic tail-call optimization does not exist, as the JVM makes it quite difficult. In order to have TCO, they have a macro called [loop/recur](http://clojure.org/special_forms#Special Forms--%28recur exprs*%29). `loop` establishes a recursion point, while `recur` rebinds the variables set in the recursion point and sends code execution back to that recursion point.

This PR adds `loop/recur` for Hy, slightly altered to be more Hythonic. An example:

``` clojure
(require hy.contrib.loop)

(defn factorial [n]
  (loop [[i n] [acc 1]]
        (if (zero? i)
          acc
          (recur (dec i) (* acc i)))))

(factorial 1000)
;=> 402387260077093773543702433923003985719374864210714632543799910429938512398629020592044208486969404800479988610197196058631666872994808558901323829669944590997424504087073759918823627727188732519779505950995276120874975462497043601418278094646496291056393887437886487337119181045825783647849977012476632889835955735432513185323958463075557409114262417474349347553428646576611667797396668820291207379143853719588249808126867838374559731746136085379534524221586593201928090878297308431392844403281231558611036976801357304216168747609675871348312025478589320767169132448426236131412508780208000261683151027341827977704784635868170164365024153691398281264810213092761244896359928705114964975419909342221566832572080821333186116811553615836546984046708975602900950537616475847728421889679646244945160765353408198901385442487984959953319101723355556602139450399736280750137837615307127761926849034352625200015888535147331611702103968175921510907788019393178114194545257223865541461062892187960223838971476088506276862967146674697562911234082439208160153780889893964518263243671616762179168909779911903754031274622289988005195444414282012187361745992642956581746628302955570299024324153181617210465832036786906117260158783520751516284225540265170483304226143974286933061690897968482590125458327168226458066526769958652682272807075781391858178889652208164348344825993266043367660176999612831860788386150279465955131156552036093988180612138558600301435694527224206344631797460594682573103790084024432438465657245014402821885252470935190620929023136493273497565513958720559654228749774011413346962715422845862377387538230483865688976461927383814900140767310446640259899490222221765904339901886018566526485061799702356193897017860040811889729918311021171229845901641921068884387121855646124960798722908519296819372388642614839657382291123125024186649353143970137428531926649875337218940694281434118520158014123344828015051399694290153483077644569099073152433278288269864602789864321139083506217095002597389863554277196742822248757586765752344220207573630569498825087968928162753848863396909959826280956121450994871701244516461260379029309120889086942028510640182154399457156805941872748998094254742173582401063677404595741785160829230135358081840096996372524230560855903700624271243416909004153690105933983835777939410970027753472000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000L
```

HECK YES RIGHT

What else does this PR need? Tests and docs. They will be forthcoming.
