### PR TITLE
hy/lex/parser.py: Mungle (.foo? bar) a bit better

### DIFF
--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -254,7 +254,7 @@ def t_identifier(p):
 
         return p
 
-    obj = mangle(obj)
+    obj = ".".join([mangle(part) for part in obj.split(".")])
 
     return HySymbol(obj)
 

--- a/tests/lex/test_lex.py
+++ b/tests/lex/test_lex.py
@@ -294,3 +294,11 @@ def test_lex_mangling_qmark():
     assert entry == [HySymbol("?")]
     entry = tokenize("im?foo")
     assert entry == [HySymbol("im?foo")]
+    entry = tokenize(".foo?")
+    assert entry == [HySymbol(".is_foo")]
+    entry = tokenize("foo.bar?")
+    assert entry == [HySymbol("foo.is_bar")]
+    entry = tokenize("foo?.bar")
+    assert entry == [HySymbol("is_foo.bar")]
+    entry = tokenize(".foo?.bar.baz?")
+    assert entry == [HySymbol(".is_foo.bar.is_baz")]


### PR DESCRIPTION
I have a class, to which I want to add an `is_foo` function, and would like to be able to call it from Hy like `(.foo? bar)`, these patch series make that happen. The series begins with refactoring, continues with tests, and adds the actual support for identifier-part mungling in the last one.

The sample code I'd love to have supported:

``` clojure
(defclass Foo [object]
  [[foo? (fn [_] true)]])

(.foo? (Foo)) ;; => true
```
