### PR TITLE
hy/cmdline.py: Add support for running with --spy -i

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -214,8 +214,8 @@ def run_repl(hr=None, spy=False):
     return 0
 
 
-def run_icommand(source):
-    hr = HyREPL()
+def run_icommand(source, spy=False):
+    hr = HyREPL(spy)
     hr.runsource(source, filename='<input>', symbol='single')
     return run_repl(hr)
 
@@ -270,7 +270,7 @@ def cmdline_handler(scriptname, argv):
 
     if options.icommand:
         # User did "hy -i ..."
-        return run_icommand(options.icommand)
+        return run_icommand(options.icommand, spy=options.spy)
 
     if options.args:
         if options.args[0] == "-":

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -76,6 +76,14 @@ def test_bin_hy_icmd():
     assert "figlet" in output
 
 
+def test_bin_hy_icmd_and_spy():
+    ret = run_cmd("hy -i \"(+ [] [])\" --spy", "(+ 1 1)")
+    assert ret[0] == 0
+    output = ret[1]
+
+    assert "([] + [])" in output
+
+
 def test_bin_hy_missing_file():
     ret = run_cmd("hy foobarbaz")
     assert ret[0] == 2


### PR DESCRIPTION
There's no reason why one would need to choose between --spy and -i, so
pass down options.spy to run_icommand, and then to HyREPL, so we can
have both.

Signed-off-by: Gergely Nagy algernon@balabit.hu
