### PR TITLE
bin/hy2py: Add a bunch of command-line options

### DIFF
--- a/bin/hy2py
+++ b/bin/hy2py
@@ -1,24 +1,39 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from hy.importer import (import_file_to_ast, import_file_to_hst)
 
-from hy.importer import (import_file_to_ast, import_file_to_module,
-                         import_file_to_hst)
+import argparse
+import sys
 
 import astor.codegen
-import sys
 
 module_name = "<STDIN>"
 
-hst = import_file_to_hst(sys.argv[1])
-print(str(hst).encode("utf-8"))
-print("")
-print("")
-_ast = import_file_to_ast(sys.argv[1], module_name)
-print("")
-print("")
-print(astor.dump(_ast).encode("utf-8"))
-print("")
-print("")
-print(astor.codegen.to_source(_ast).encode("utf-8"))
+parser = argparse.ArgumentParser(
+    prog="hy2py",
+    usage="%(prog)s [options] FILE",
+    formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument("--with-source", "-s", action="store_true",
+                    help="Show the parsed source structure")
+parser.add_argument("--with-ast", "-a", action="store_true",
+                    help="Show the generated AST")
+parser.add_argument("--without-python", "-np", action="store_true",
+                    help="Do not show the python code generated from the AST")
+parser.add_argument('args', nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
 
-import_file_to_module(module_name, sys.argv[1])
+options = parser.parse_args(sys.argv[1:])
+
+if options.with_source:
+    hst = import_file_to_hst(options.args[0])
+    print(str(hst).encode("utf-8"))
+    print()
+    print()
+
+_ast = import_file_to_ast(options.args[0], module_name)
+if options.with_ast:
+    print(astor.dump(_ast).encode("utf-8"))
+    print()
+    print()
+
+if not options.without_python:
+    print(astor.codegen.to_source(_ast).encode("utf-8"))

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -126,7 +126,7 @@ def test_hy2py():
         for f in filenames:
             if f.endswith(".hy"):
                 i += 1
-                ret = run_cmd("bin/hy2py " + os.path.join(dirpath, f))
+                ret = run_cmd("bin/hy2py -s -a " + os.path.join(dirpath, f))
                 assert ret[0] == 0, f
                 assert len(ret[1]) > 1, f
                 assert len(ret[2]) == 0, f


### PR DESCRIPTION
The hy2py tool has been very useful for me, but most of the time, it's
only a part of its output that one is interested in. The whole output,
with source code, AST and python code together is one big monstrosity.
So instead of printing all that, lets have a few handy command-line
options to control which part gets printed.

By default, only the generated python source is, as that's what the name
of the tool implies.

Also, don't run it. That's what hy is for.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
