### PR TITLE
Fix a markup error in the apply doc.

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -110,6 +110,7 @@ Usage: `(apply fn-name [args] [kwargs])`
 Examples:
 
 .. code-block:: clj
+
     (defn thunk []
       "hy there")
 


### PR DESCRIPTION
See http://docs.hylang.org/en/latest/language/api.html#apply
for the example.
