### PR TITLE
Reader macros are now actually macros!

### DIFF
--- a/docs/language/readermacros.rst
+++ b/docs/language/readermacros.rst
@@ -24,18 +24,27 @@ Syntax
     => #^1+2+3+4+3+2
     1+2+3+4+3+2
 
+Hy got no literal for tuples. Lets say you dislike `(, ...)` and want something
+else. This is a problem reader macros are able to solve in a neat way.
+
+::
+
+    => (defreader t [expr] `(, ~@expr))
+    => #t(1 2 3)
+    (1, 2, 3)
+
+You could even do like clojure, and have a litteral for regular expressions!
+
+::
+
+    => (import re)
+    => (defreader r [expr] `(re.compile ~expr))
+    => #r".*"
+    <_sre.SRE_Pattern object at 0xcv7713ph15#>
+
 
 Implementation
 ==============
-
-Hy uses ``defreader`` to define the reader symbol, and ``#`` as the dispatch
-character. ``#`` expands into ``(dispatch_reader_macro ...)`` where the symbol
-and expression is quoted, and then passed along to the correct function::
-
-    => (defreader ^ ...)
-    => #^()
-    ;=> (dispatch_reader_macro '^ '())
-
 
 ``defreader`` takes a single character as symbol name for the reader macro,
 anything longer will return an error. Implementation wise, ``defreader``
@@ -47,13 +56,16 @@ lambda in a dict with its module name and symbol.
     => (defreader ^ [expr] (print expr))
     ;=> (with_decorator (hy.macros.reader ^) (fn [expr] (print expr)))
 
-
-Anything passed along is quoted, thus given to the function defined.
+``#`` expands into ``(dispatch_reader_macro ...)`` where the symbol
+and expression is passed to the correct function.
 
 ::
 
+    => #^()
+    ;=> (dispatch_reader_macro ^ ())
     => #^"Hello"
     "Hello"
+
 
 .. warning::
    Because of a limitation in Hy's lexer and parser, reader macros can't

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -181,13 +181,3 @@
       (setv -args (cdr (car -args))))
 
     `(apply ~-fun [~@-args] (dict (sum ~-okwargs [])))))
-
-
-(defmacro dispatch-reader-macro [char &rest body]
-  "Dispatch a reader macro based on the character"
-  (import [hy.macros])
-  (setv str_char (get char 1))
-  (if (not (in str_char hy.macros._hy_reader_chars))
-    (raise (hy.compiler.HyTypeError char (.format "There is no reader macro with the character `{0}`" str_char))))
-  `(do (import [hy.macros [_hy_reader]])
-       ((get (get _hy_reader --name--) ~char) ~(get body 0))))

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -154,8 +154,8 @@ def term_unquote_splice(p):
 @set_quote_boundaries
 def hash_reader(p):
     st = p[0].getstr()[1]
-    str_object = HyExpression([HySymbol("quote"), HyString(st)])
-    expr = HyExpression([HySymbol("quote"), p[1]])
+    str_object = HyString(st)
+    expr = p[1]
     return HyExpression([HySymbol("dispatch_reader_macro"), str_object, expr])
 
 

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -43,7 +43,6 @@ EXTRA_MACROS = [
 
 _hy_macros = defaultdict(dict)
 _hy_reader = defaultdict(dict)
-_hy_reader_chars = set()
 
 
 def macro(name):
@@ -85,8 +84,6 @@ def reader(name):
             module_name = None
         _hy_reader[module_name][name] = fn
 
-        # Ugly hack to get some error handling
-        _hy_reader_chars.add(name)
         return fn
     return _
 
@@ -209,3 +206,20 @@ def macroexpand_1(tree, module_name):
 
         return ntree
     return tree
+
+
+def reader_macroexpand(char, tree, module_name):
+    """Expand the reader macro "char" with argument `tree`."""
+    load_macros(module_name)
+
+    if not char in _hy_reader[module_name]:
+        raise HyTypeError(
+            char,
+            "`{0}' is not a reader macro in module '{1}'".format(
+                char,
+                module_name,
+            ),
+        )
+
+    expr = _hy_reader[module_name][char](tree)
+    return _wrap_value(expr).replace(tree)

--- a/tests/lex/test_lex.py
+++ b/tests/lex/test_lex.py
@@ -258,7 +258,7 @@ def test_reader_macro():
     """Ensure reader macros are handles properly"""
     entry = tokenize("#^()")
     assert entry[0][0] == HySymbol("dispatch_reader_macro")
-    assert entry[0][1] == HyExpression([HySymbol("quote"), HyString("^")])
+    assert entry[0][1] == HyString("^")
     assert len(entry[0]) == 3
 
 

--- a/tests/native_tests/reader_macros.hy
+++ b/tests/native_tests/reader_macros.hy
@@ -23,10 +23,14 @@
   (assert (= #+2 3)))
 
 
-(defn test-reader-macro-compile-docstring []
-  "Test if we can compile with a docstring"
-  (try
-    (defreader d []
-      "Compiles with docstrings")
-    (except [Exception] 
-            (assert False))))
+(defn test-reader-macros-macros []
+  "Test if defreader is actually a macro"
+  (defreader t [expr]
+    `(, ~@expr))
+
+  (def a #t[1 2 3])
+
+  (assert (= (type a) tuple))
+  (assert (= (, 1 2 3) a)))
+
+


### PR DESCRIPTION
So, after a slipup from my side, reader macros wasnt really macros. So after i got stuck, @olasd solved the problem, and i wrote up a test and fixed up the readermacro's section in the docs. Also added a few examples.
