### PR TITLE
Document (defmacro-alias)

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -445,6 +445,32 @@ between the operands.
   => (infix (1 + 1))
   2
 
+.. _defmacro-alias:
+
+defmacro-alias
+--------------
+
+`defmacro-alias` is used to define macros with multiple names
+(aliases). The general format is `(defmacro-alias [names] [parameters]
+expr)`. It creates multiple macros with the same parameter list and
+body, under the specified list of names.
+
+The following example defines two macros, both of which allow the user
+to write code in infix notation.
+
+.. code-block:: clj
+
+  => (defmacro-alias [infix infi] [code]
+  ...  (quasiquote (
+  ...    (unquote (get code 1))
+  ...    (unquote (get code 0))
+  ...    (unquote (get code 2)))))
+
+  => (infix (1 + 1))
+  2
+  => (infi (1 + 1))
+  2
+
 .. _defmacro/g!:
 
 defmacro/g!


### PR DESCRIPTION
This fixes the `(defmacro)` syntax in the API docs, and also adds docs for `(defmacro-alias)`
