### PR TITLE
hy/core/macros.hy: Add defn-alias / defun-alias

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -352,6 +352,8 @@ below:
     Meow
 
 
+.. _defn:
+
 defn / defun
 ------------
 
@@ -421,6 +423,29 @@ Parameters may have following keywords in front of them:
         8
         => (zig-zag-sum 1 2 3 4 5 6)
         -3
+
+.. _defn-alias / defun-alias:
+
+defn-alias / defun-alias
+------------------------
+
+.. versionadded:: 0.9.13
+
+The `defn-alias` and `defun-alias` macros are much like `defn`_ above,
+with the difference that instead of defining a function with a single
+name, these can also define aliases. Other than taking a list of
+symbols for function names as the first parameter, `defn-alias` and
+`defun-alias` have no other differences compared to `defn` and
+`defun`.
+
+.. code-block:: clj
+
+  => (defn-alias [main-name alias] []
+  ...  (print "Hello!"))
+  => (main-name)
+  "Hello!"
+  => (alias)
+  "Hello!"
 
 .. _defmacro:
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -181,3 +181,14 @@
       (setv -args (cdr (car -args))))
 
     `(apply ~-fun [~@-args] (dict (sum ~-okwargs [])))))
+
+
+(defmacro-alias [defn-alias defun-alias] [names lambda-list &rest body]
+  "define one function with several names"
+  (let [[main (first names)]
+        [aliases (rest names)]]
+    (setv ret `(do (defn ~main ~lambda-list ~@body)))
+    (for* [name aliases]
+          (.append ret
+                   `(setv ~name ~main)))
+    ret))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -176,3 +176,11 @@
   (assert (in ":res_" s1))
   (assert (in ":res_" s2))
   (assert (not (= s1 s2))))
+
+(defn test-defn-alias []
+  (defn-alias [tda-main tda-a1 tda-a2] [] :bazinga)
+  (defun-alias [tda-main tda-a1 tda-a2] [] :bazinga)
+  (assert (= (tda-main) :bazinga))
+  (assert (= (tda-a1) :bazinga))
+  (assert (= (tda-a2) :bazinga))
+  (assert (= tda-main tda-a1 tda-a2)))


### PR DESCRIPTION
In the same vein as defmacro-alias, this implements defn-alias /
defun-alias, which does essentially the same thing as defmacro-alias,
but for functions.

Signed-off-by: Gergely Nagy algernon@balabit.hu
