### PR TITLE
Corrected --spy cmdoption (I think)

### DIFF
--- a/docs/language/cli.rst
+++ b/docs/language/cli.rst
@@ -20,7 +20,7 @@ Command line options
 
 .. cmdoption:: --spy
 
-   Print equivalent Hy code before executing. For example::
+   Print equivalent Python code before executing. For example::
 
     => (defn salutationsnm [name] (print (+ "Hy " name "!")))
     def salutationsnm(name):


### PR DESCRIPTION
For the --spy commmand line option, it currently says `Print equivalent Hy code...`. Now, I haven't actually gotten around to installing Hy on my computer yet, so I haven't had a chance to test this out to make sure, but from the looks of the code example, it looks as though it is printing out the equivalent Python code of the executed Hy code, not the other way around. This would certainly make more sense. As such, I have changed the word 'Hy' to 'Python' so that the documentation more accurately reflects what (one assumes) is going on.
