### PR TITLE
dotimes implementation similiar to common lisp

### DIFF
--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -183,13 +183,10 @@
     `(apply ~-fun [~@-args] (dict (sum ~-okwargs [])))))
 
 (defmacro dotimes [spec &rest body]
-  (unless (and  (>= (len spec) 2) (isinstance spec HyList))
+  (unless (and (isinstance spec HyList) (<= 2 (len spec) 3))
     (macro-error spec "`dotimes' needs a spec of the form [var num &optional result]"))
-
-  (unless (pos? (second spec))
-    (macro-error (second spec) "`dotimes' needs a positive num as second arg"))
-
   `(do
     (for* [~(first spec) (range ~(second spec))]
       ~@body)
-    ~@(rest (rest spec))))
+    (setv ~(car spec) (inc ~(car spec)))
+    ~@(slice spec 2)))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -179,7 +179,7 @@
 
 (defn test-dotimes []
   ;; initially checking examples given in hyperspec
-  (assert (= (dotimes [temp-one 10 temp-one] nil) 9)) ; explicit nil for py3
+  (assert (= (dotimes [temp-one 10 temp-one] nil) 10)) ; explicit nil for py3
   (setv temp-two 0)
   (defmacro incf [x] `(setv ~x (inc ~x)))
   (assert (= (dotimes [temp-one 10 true] (incf temp-two)) true))


### PR DESCRIPTION
hy/core/macros.hy: Implementation of dotimes according to hyperspec
here an optional result form can be added in spec which will be returned
finally

The clojure like `dotimes` is similiar except that we don't have an optional result, 
however in python mostly `(for [i (range n)] ..)`  does that mostly, so I went ahead 
with a cl like implementation  

Docs are yet to be added, if the implementation is ok, I will add them 
