### PR TITLE
Adding a simple `identity' function

### DIFF
--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -137,6 +137,24 @@ Raises ``TypeError`` if ``(not (numeric? x))``.
    True
 
 
+.. _identity-fn:
+
+identity
+--------
+
+Usage: ``(identity x)``
+
+Returns argument supplied to the function
+
+.. code-block:: clojure
+
+   => (identity 4)
+   4
+
+   => (list (map identity [1 2 3 4]))
+   [1 2 3 4]
+
+
 .. _inc-fn:
 
 inc

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -157,6 +157,10 @@
   "Return first item from `coll`"
   (get coll 0))
 
+(defn identity [x]
+  "Returns the argument unchanged"
+  x)
+
 (defn inc [n]
   "Increment n by 1"
   (_numeric-check n)
@@ -310,10 +314,9 @@
   (_numeric_check n)
   (= n 0))
 
-(def *exports* '[calling-module-name coll? cycle dec distinct
-		 disassemble drop drop-while empty? even? filter flatten
-		 float? gensym inc instance? integer integer? iterable?
-		 iterate iterator? macroexpand macroexpand-1 neg? nil?
-		 none?  nth numeric? odd? pos? remove repeat repeatedly
-		 second string string? take take-nth take-while zero?
-         first rest])
+(def *exports* '[calling-module-name coll? cycle dec distinct disassemble
+                 drop drop-while empty? even? first filter flatten float?
+                 gensym identity inc instance? integer integer? iterable?
+                 iterate iterator? macroexpand macroexpand-1 neg? nil?
+                 none? nth numeric? odd? pos? remove repeat repeatedly
+                 rest second string string? take take-nth take-while zero?])

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -181,6 +181,12 @@
   (assert (not (= s2 s3)))
   (assert (not (= (str s2) (str s3)))))
 
+(defn test-identity []
+  "NATIVE: testing the identity function"
+  (assert (= 4 (identity 4)))
+  (assert (= "hy" (identity "hy")))
+  (assert (= [1 2] (identity [1 2]))))
+
 (defn test-inc []
   "NATIVE: testing the inc function"
   (assert-equal 3 (inc 2))


### PR DESCRIPTION
- hy/core/language.hy: Adding a simple `identity` function that returns
  the argument supplied to it
- docs/language/core.rst: Updated docs with identity function
