### PR TITLE
faster distinct: maintain seen items in a set

### DIFF
--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -75,12 +75,12 @@
 (defn distinct [coll]
   "Return a generator from the original collection with duplicates
    removed"
-  (let [[seen []] [citer (iter coll)]]
+  (let [[seen (set)] [citer (iter coll)]]
     (for* [val citer]
       (if (not_in val seen)
         (do
          (yield val)
-         (.append seen val))))))
+         (.add seen val))))))
 
 (defn drop [count coll]
   "Drop `count` elements from `coll` and yield back the rest"


### PR DESCRIPTION
- hy/core/language.hy: maintain the seen items in a set instead of a
  list in `distinct`. This is much faster for lookups.

As a test calling 

``` clj
(profile/cpu (list (distinct (* (list (range 1000)) 1000))))
```

in my PC takes about 8.7 s in the list version. The set version takes about 0.068 s 
