### PR TITLE
hy/compiler.py: import only handles HySymbol and HyList, bail on others

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1034,6 +1034,10 @@ class HyASTCompiler(object):
         while len(expr) > 0:
             iexpr = expr.pop(0)
 
+            if not isinstance(iexpr, (HySymbol, HyList)):
+                raise HyTypeError(iexpr, "(import) requires a Symbol "
+                                  "or a List.")
+
             if isinstance(iexpr, HySymbol):
                 rimports += _compile_import(expr, iexpr)
                 continue

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -1,4 +1,5 @@
 from hy.importer import import_file_to_module, import_buffer_to_ast, MetaLoader
+from hy.errors import HyTypeError
 import os
 import ast
 
@@ -27,3 +28,16 @@ def test_imports():
 
     assert _import_test() == "Error"
     assert _import_test() is not None
+
+
+def test_import_error_reporting():
+    "Make sure that (import) reports errors correctly."
+
+    def _import_error_test():
+        try:
+            import_buffer_to_ast("(import \"sys\")", '')
+        except HyTypeError:
+            return "Error reported"
+
+    assert _import_error_test() == "Error reported"
+    assert _import_error_test() is not None


### PR DESCRIPTION
When (import) encounters anything but a HySymbol or HyList, raise an
exception, as that is not valid in Hy. Previously, anything other than a
HySymbol or HyList was simply ignored, turning that particular import
into a no-op, which was both wrong and confusing.

Reported-by: Richard Parsons richard.lee.parsons@gmail.com
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
