### PR TITLE
Fix up quoting keywords.

### DIFF
--- a/hy/models/keyword.py
+++ b/hy/models/keyword.py
@@ -29,5 +29,8 @@ class HyKeyword(HyObject, str_type):
     """
 
     def __new__(cls, value):
-        obj = str_type.__new__(cls, "\uFDD0" + value)
+        if not value.startswith("\uFDD0"):
+            value = "\uFDD0" + value
+
+        obj = str_type.__new__(cls, value)
         return obj

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -983,3 +983,8 @@
   (assert (is bar (get foo 1)))
   (setv (. foo [1] test) "hello")
   (assert (= (getattr (. foo [1]) "test") "hello")))
+
+(defn test-keyword-quoting []
+  "NATIVE: test keyword quoting magic"
+  (assert (= :foo "\ufdd0:foo"))
+  (assert (= `:foo "\ufdd0:foo")))


### PR DESCRIPTION
Fixes this:

=> :foo
'\ufdd0:foo'
=> `:foo
'\ufdd0\ufdd0:foo'
