### PR TITLE
Fix errors on Python 3.

### DIFF
--- a/hy/errors.py
+++ b/hy/errors.py
@@ -21,6 +21,8 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+from hy._compat import PY3
+
 import traceback
 
 
@@ -137,7 +139,10 @@ class HyTypeError(TypeError):
                                  (self.__class__.__name__,
                                   self.message))
 
-        return result.encode('utf-8')
+        if not PY3:
+            return result.encode('utf-8')
+        else:
+            return result
 
 
 class HyMacroExpansionError(HyTypeError):


### PR DESCRIPTION
Some unicode issues were fixed for Python 2 in 75748eb05dc5e38a88da2fa3789e9aa629ac65fc
but broke pretty much all Python 3 exceptions in Hy.

This re-fixes bug #483.
