### PR TITLE
Fix #497;&rest in macros wraps around hyexpression

### DIFF
--- a/hy/macros.py
+++ b/hy/macros.py
@@ -115,7 +115,7 @@ _wrappers = {
     str_type: HyString,
     dict: lambda d: HyDict(_wrap_value(x) for x in sum(d.items(), ())),
     list: lambda l: HyList(_wrap_value(x) for x in l),
-    tuple: lambda t: HyList(_wrap_value(x) for x in t),
+    tuple: lambda t: HyExpression(_wrap_value(x) for x in t),
     type(None): lambda foo: HySymbol("None"),
 }
 

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -32,7 +32,7 @@
 (assert (= (a-list) [1 2]))
 
 (defmacro a-tuple [&rest b] b)
-(assert (= (a-tuple 1 2) [1 2]))
+(assert (= (a-tuple + 1 2) 3))
 
 (defmacro a-dict [] {1 2})
 (assert (= (a-dict) {1 2}))


### PR DESCRIPTION
Wrapping tuple around HyExpression; this will probably lead to
interesting inceptions?

``` clj
(defmacro a [&rest b] b)
(a + 1 2 3) ;=> 3
```

Not completely sure if this is how we should go about 
