### PR TITLE
All our code(-blocks) is belong to us.

### DIFF
--- a/docs/contrib/anaphoric.rst
+++ b/docs/contrib/anaphoric.rst
@@ -48,7 +48,7 @@ Usage: ``(ap-each-while list pred body)``
 Evaluate the form for each element where the predicate form returns
 True.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (ap-each-while [1 2 3 4 5 6] (< it 4) (print it))
    1
@@ -66,7 +66,7 @@ The anaphoric form of map works just like regular map except that
 instead of a function object it takes a Hy form. The special name,
 ``it`` is bound to the current object from the list in the iteration.
 
-.. code-block:: clojure
+.. code-block:: hy
 
     => (list (ap-map (* it 2) [1 2 3]))
     [2, 4, 6]
@@ -82,7 +82,7 @@ Usage: ``(ap-map-when predfn rep list)``
 Evaluate a mapping over the list using a predicate function to
 determin when to apply the form.
 
-.. code-block:: clojure
+.. code-block:: hy
 
     => (list (ap-map-when odd? (* it 2) [1 2 3 4]))
     [2, 2, 6, 4]
@@ -102,7 +102,7 @@ As with ``ap-map`` we take a special form instead of a function to
 filter the elements of the list. The special name ``it`` is bound to
 the current element in the iteration.
 
-.. code-block:: clojure
+.. code-block:: hy
 
     => (list (ap-filter (> (* it 2) 6) [1 2 3 4 5]))
     [4, 5]
@@ -119,7 +119,7 @@ This function does the opposite of ``ap-filter``, it rejects the
 elements passing the predicate . The special name ``it`` is bound to
 the current element in the iteration.
 
-.. code-block:: clojure
+.. code-block:: hy
 
     => (list (ap-reject (> (* it 2) 6) [1 2 3 4 5]))
     [1, 2, 3]
@@ -135,7 +135,7 @@ Usage ``(ap-dotimes n body)``
 This function evaluates the body *n* times, with the special
 variable ``it`` bound from *0* to *1-n*. It is useful for side-effects.
 
-.. code-block:: clojure
+.. code-block:: hy
 
     => (setv n [])
     => (ap-dotimes 3 (.append n it))
@@ -154,7 +154,7 @@ This function returns the first element that passes the predicate or
 ``None``, with the special variable ``it`` bound to the current element in
 iteration.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    =>(ap-first (> it 5) (range 10))
    6
@@ -171,7 +171,7 @@ This function returns the last element that passes the predicate or
 ``None``, with the special variable ``it`` bound to the current element in
 iteration.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    =>(ap-last (> it 5) (range 10))
    9
@@ -191,7 +191,7 @@ supplied so the function will be applied to initial value and the
 first element instead. This exposes the element being iterated as
 ``it`` and the current accumulated value as ``acc``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    =>(ap-reduce (+ it acc) (range 10))
    45

--- a/docs/contrib/loop.rst
+++ b/docs/contrib/loop.rst
@@ -43,7 +43,7 @@ Usage: `(loop bindings &rest body)`
 
 Example:
 
-.. code-block:: clojure
+.. code-block:: hy
 
     (require hy.contrib.loop)
 

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -1220,14 +1220,14 @@ with-gensyms
 `with-gensym` form is used to generate a set of :ref:`gensym` for use
 in a macro.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (with-gensyms [a b c]
      ...)
 
 expands to:
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (let [[a (gensym)
          [b (gensym)

--- a/docs/language/cli.rst
+++ b/docs/language/cli.rst
@@ -57,7 +57,7 @@ Command line options
    Compile Hy code to Python bytecode. For example, save the
    following code as ``hyname.hy``:
 
-   .. code-block:: clojure
+   .. code-block:: hy
 
       (defn hy-hy [name]
         (print (+ "Hy " name "!")))

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -17,7 +17,7 @@ Usage: ``(coll? x)``
 
 Returns true if argument is iterable and not a string.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (coll? [1 2 3 4])
    True
@@ -38,7 +38,7 @@ Usage: ``(cons a b)``
 
 Returns a fresh :ref:`cons cell <hycons>` with car `a` and cdr `b`.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (setv a (cons 'hd 'tl))
 
@@ -58,7 +58,7 @@ Usage: ``(cons? foo)``
 
 Checks whether ``foo`` is a :ref:`cons cell <hycons>`.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (setv a (cons 'hd 'tl))
 
@@ -82,7 +82,7 @@ Return one less than x. Equivalent to ``(- x 1)``.
 
 Raises ``TypeError`` if ``(not (numeric? x))``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (dec 3)
    2
@@ -106,7 +106,7 @@ Usage: ``(disassemble tree &optional [codegen false])``
 Dump the Python AST for given Hy ``tree`` to standard output. If *codegen*
 is ``true`` function prints Python code instead.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (disassemble '(print "Hello World!"))
    Module(
@@ -126,7 +126,7 @@ Usage: ``(empty? coll)``
 
 Return True if ``coll`` is empty, i.e. ``(= 0 (len coll))``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (empty? [])
    True
@@ -149,7 +149,7 @@ Usage: ``(every? pred coll)``
 
 Return True if ``(pred x)`` is logical true for every ``x`` in ``coll``, otherwise False. Return True if ``coll`` is empty.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (every? even? [2 4 6])
    True
@@ -173,7 +173,7 @@ Usage: ``(float? x)``
 
 Return True if x is a float.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (float? 3.2)
    True
@@ -193,7 +193,7 @@ Return True if x is even.
 
 Raises ``TypeError`` if ``(not (numeric? x))``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (even? 2)
    True
@@ -214,7 +214,7 @@ Usage: ``(identity x)``
 
 Returns argument supplied to the function
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (identity 4)
    4
@@ -234,7 +234,7 @@ Return one more than x. Equivalent to ``(+ x 1)``.
 
 Raises ``TypeError`` if ``(not (numeric? x))``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (inc 3)
    4
@@ -255,7 +255,7 @@ Usage: ``(instance? CLASS x)``
 
 Return True if x is an instance of CLASS.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (instance? float 1.0)
    True
@@ -281,7 +281,7 @@ Usage: ``(integer? x)``
 Return True if x is an integer. For Python 2, this is
 either ``int`` or ``long``. For Python 3, this is ``int``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (integer? 3)
    True
@@ -300,7 +300,7 @@ Usage: ``(iterable? x)``
 Return True if x is iterable. Iterable objects return a new iterator
 when ``(iter x)`` is called. Contrast with :ref:`iterator?-fn`.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => ;; works for strings
    => (iterable? (str "abcde"))
@@ -334,7 +334,7 @@ Return True if x is an iterator. Iterators are objects that return
 themselves as an iterator when ``(iter x)`` is called.
 Contrast with :ref:`iterable?-fn`.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => ;; doesn't work for a list
    => (iterator? [1 2 3 4 5])
@@ -360,7 +360,7 @@ Usage: ``(list* head &rest tail)``
 Generate a chain of nested cons cells (a dotted list) containing the
 arguments. If the argument list only has one element, return it.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list* 1 2 3 4)
    (1 2 3 . 4)
@@ -385,7 +385,7 @@ Usage: ``(macroexpand form)``
 
 Returns the full macro expansion of form.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (macroexpand '(-> (a b) (x y)))
    (u'x' (u'a' u'b') u'y')
@@ -404,7 +404,7 @@ Usage: ``(macroexpand-1 form)``
 
 Returns the single step macro expansion of form.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (macroexpand-1 '(-> (a b) (-> (c d) (e f))))
    (u'_>' (u'a' u'b') (u'c' u'd') (u'e' u'f'))
@@ -420,7 +420,7 @@ Return True if x is less than zero (0).
 
 Raises ``TypeError`` if ``(not (numeric? x))``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (neg? -2)
    True
@@ -441,7 +441,7 @@ Usage: ``(nil? x)``
 
 Return True if x is nil/None.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (nil? nil)
    True
@@ -470,7 +470,7 @@ Usage: ``(none? x)``
 
 Return True if x is None.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (none? None)
    True
@@ -498,7 +498,7 @@ Return the `nth` item in a collection, counting from 0. Unlike
 ``get``, ``nth`` works on both iterators and iterables. Returns ``None``
 if the `n` is outside the range of `coll`.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (nth [1 2 4 7] 1)
    2
@@ -522,7 +522,7 @@ Usage: ``(numeric? x)``
 Return True if x is a numeric, as defined in the Python
 numbers module class ``numbers.Number``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (numeric? -2)
    True
@@ -545,7 +545,7 @@ Return True if x is odd.
 
 Raises ``TypeError`` if ``(not (numeric? x))``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (odd? 13)
    True
@@ -568,7 +568,7 @@ Return True if x is greater than zero (0).
 
 Raises ``TypeError`` if ``(not (numeric? x))``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (pos? 3)
    True
@@ -590,7 +590,7 @@ Usage: ``(second coll)``
 Return the second member of ``coll``. Equivalent to
 ``(get coll 1)``
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (second [0 1 2])
    1
@@ -607,7 +607,7 @@ Usage: ``(some pred coll)``
 
 Return True if ``(pred x)`` is logical true for any ``x`` in ``coll``, otherwise False. Return False if ``coll`` is empty.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (some even? [2 4 6])
    True
@@ -631,7 +631,7 @@ Usage: ``(string? x)``
 
 Return True if x is a string.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (string? "foo")
    True
@@ -648,7 +648,7 @@ Usage: ``(zero? x)``
 
 Return True if x is zero (0).
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (zero? 3)
    False
@@ -671,7 +671,7 @@ iterator.
 We can use the canonical infinite Fibonacci number generator
 as an example of how to use some of these functions.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (defn fib []
      (setv a 0)
@@ -683,7 +683,7 @@ as an example of how to use some of these functions.
 
 Note the ``(while true ...)`` loop. If we run this in the REPL,
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (fib)
    <generator object fib at 0x101e642d0>
@@ -694,7 +694,7 @@ work until we consume it. Trying something like this is not recommend as
 the infinite loop will run until it consumes all available RAM, or
 in this case until I killed it.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (fib))
    [1]    91474 killed     hy
@@ -703,7 +703,7 @@ in this case until I killed it.
 To get the first 10 Fibonacci numbers, use :ref:`take-fn`. Note that
 :ref:`take-fn` also returns a generator, so I create a list from it.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (take 10 (fib)))
    [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
@@ -711,7 +711,7 @@ To get the first 10 Fibonacci numbers, use :ref:`take-fn`. Note that
 
 To get the Fibonacci number at index 9, (starting from 0):
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (nth (fib) 9)
    34
@@ -744,7 +744,7 @@ Usage: ``(distinct coll)``
 
 Returns an iterator containing only the unique members in ``coll``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (distinct [ 1 2 3 4 3 5 2 ]))
    [1, 2, 3, 4, 5]
@@ -765,7 +765,7 @@ Usage: ``(drop n coll)``
 
 Return an iterator, skipping the first ``n`` members of ``coll``
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (drop 2 [1 2 3 4 5]))
    [3, 4, 5]
@@ -789,7 +789,7 @@ Usage: ``(drop-while pred coll)``
 Return an iterator, skipping members of ``coll`` until ``pred``
 is False.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (drop-while even? [2 4 7 8 9]))
    [7, 8, 9]
@@ -812,7 +812,7 @@ Return an iterator for all items in ``coll`` that pass the predicate ``pred``.
 
 See also :ref:`remove-fn`.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (filter pos? [1 2 3 -4 5 -7]))
    [1, 2, 3, 5]
@@ -832,7 +832,7 @@ Usage: ``(flatten coll)``
 Return a single list of all the items in ``coll``, by flattening all
 contained lists and/or tuples.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (flatten [1 2 [3 4] 5])
    [1, 2, 3, 4, 5]
@@ -850,7 +850,7 @@ Usage: ``(iterate fn x)``
 
 Return an iterator of `x`, `fn(x)`, `fn(fn(x))`.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (take 5 (iterate inc 5)))
    [5, 6, 7, 8, 9]
@@ -871,7 +871,7 @@ predicate, ``pred``, removed.
 
 See also :ref:`filter-fn`.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (remove odd? [1 2 3 4 5 6 7]))
    [2, 4, 6]
@@ -893,7 +893,7 @@ Usage: ``(repeat x)``
 
 Return an iterator (infinite) of ``x``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (take 6 (repeat "s")))
    [u's', u's', u's', u's', u's', u's']
@@ -908,7 +908,7 @@ Usage: ``(repeatedly fn)``
 
 Return an iterator by calling ``fn`` repeatedly.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (import [random [randint]])
 
@@ -925,7 +925,7 @@ Usage: ``(take n coll)``
 
 Return an iterator containing the first ``n`` members of ``coll``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (take 3 [1 2 3 4 5]))
    [1, 2, 3]
@@ -945,7 +945,7 @@ Usage: ``(take-nth n coll)``
 
 Return an iterator containing every ``nth`` member of ``coll``.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (take-nth 2 [1 2 3 4 5 6 7]))
    [1, 3, 5, 7]
@@ -969,7 +969,7 @@ Usage: ``(take-while pred coll)``
 
 Return an iterator from ``coll`` as long as predicate, ``pred`` returns True.
 
-.. code-block:: clojure
+.. code-block:: hy
 
    => (list (take-while pos? [ 1 2 3 -4 5]))
    [1, 2, 3]

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -389,7 +389,7 @@ expression is positive, zero or negative.
 
 A first pass might be someting like:
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (defmacro nif [expr pos-form zero-form neg-form]
      `(let [[obscure-name ~expr]]
@@ -404,7 +404,7 @@ this is no guarantee.
 The method :ref:`gensym` is designed to generate a new, unique symbol for just
 such an occasion. A much better version of ``nif`` would be:
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (defmacro nif [expr pos-form zero-form neg-form]
      (let [[g (gensym)]]
@@ -417,14 +417,14 @@ This is an easy case, since there is only one symbol. But if there is
 a need for several gensym's there is a second macro :ref:`with-gensyms` that
 basically expands to a series of ``let`` statements:
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (with-gensyms [a b c]
      ...)
 
 expands to:
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (let [[a (gensym)
          [b (gensym)
@@ -433,7 +433,7 @@ expands to:
 
 so our re-written ``nif`` would look like:
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (defmacro nif [expr pos-form zero-form neg-form]
      (with-gensyms [g]
@@ -448,7 +448,7 @@ remainder of the symbol. So ``g!a`` would become ``(gensym "a")``.
 
 Our final version of ``nif``, built with ``defmacro/g!`` becomes:
 
-.. code-block:: clojure
+.. code-block:: hy
 
    (defmacro/g! nif [expr pos-form zero-form neg-form]
      `(let [[~g!res ~expr]]

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,242 @@
+@ECHO OFF
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set BUILDDIR=_build
+set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+set I18NSPHINXOPTS=%SPHINXOPTS% .
+if NOT "%PAPER%" == "" (
+	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
+	set I18NSPHINXOPTS=-D latex_paper_size=%PAPER% %I18NSPHINXOPTS%
+)
+
+if "%1" == "" goto help
+
+if "%1" == "help" (
+	:help
+	echo.Please use `make ^<target^>` where ^<target^> is one of
+	echo.  html       to make standalone HTML files
+	echo.  dirhtml    to make HTML files named index.html in directories
+	echo.  singlehtml to make a single large HTML file
+	echo.  pickle     to make pickle files
+	echo.  json       to make JSON files
+	echo.  htmlhelp   to make HTML files and a HTML help project
+	echo.  qthelp     to make HTML files and a qthelp project
+	echo.  devhelp    to make HTML files and a Devhelp project
+	echo.  epub       to make an epub
+	echo.  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter
+	echo.  text       to make text files
+	echo.  man        to make manual pages
+	echo.  texinfo    to make Texinfo files
+	echo.  gettext    to make PO message catalogs
+	echo.  changes    to make an overview over all changed/added/deprecated items
+	echo.  xml        to make Docutils-native XML files
+	echo.  pseudoxml  to make pseudoxml-XML files for display purposes
+	echo.  linkcheck  to check all external links for integrity
+	echo.  doctest    to run all doctests embedded in the documentation if enabled
+	goto end
+)
+
+if "%1" == "clean" (
+	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
+	del /q /s %BUILDDIR%\*
+	goto end
+)
+
+
+%SPHINXBUILD% 2> nul
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "html" (
+	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/html.
+	goto end
+)
+
+if "%1" == "dirhtml" (
+	%SPHINXBUILD% -b dirhtml %ALLSPHINXOPTS% %BUILDDIR%/dirhtml
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/dirhtml.
+	goto end
+)
+
+if "%1" == "singlehtml" (
+	%SPHINXBUILD% -b singlehtml %ALLSPHINXOPTS% %BUILDDIR%/singlehtml
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/singlehtml.
+	goto end
+)
+
+if "%1" == "pickle" (
+	%SPHINXBUILD% -b pickle %ALLSPHINXOPTS% %BUILDDIR%/pickle
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; now you can process the pickle files.
+	goto end
+)
+
+if "%1" == "json" (
+	%SPHINXBUILD% -b json %ALLSPHINXOPTS% %BUILDDIR%/json
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; now you can process the JSON files.
+	goto end
+)
+
+if "%1" == "htmlhelp" (
+	%SPHINXBUILD% -b htmlhelp %ALLSPHINXOPTS% %BUILDDIR%/htmlhelp
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; now you can run HTML Help Workshop with the ^
+.hhp project file in %BUILDDIR%/htmlhelp.
+	goto end
+)
+
+if "%1" == "qthelp" (
+	%SPHINXBUILD% -b qthelp %ALLSPHINXOPTS% %BUILDDIR%/qthelp
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; now you can run "qcollectiongenerator" with the ^
+.qhcp project file in %BUILDDIR%/qthelp, like this:
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\hy.qhcp
+	echo.To view the help file:
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\hy.ghc
+	goto end
+)
+
+if "%1" == "devhelp" (
+	%SPHINXBUILD% -b devhelp %ALLSPHINXOPTS% %BUILDDIR%/devhelp
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished.
+	goto end
+)
+
+if "%1" == "epub" (
+	%SPHINXBUILD% -b epub %ALLSPHINXOPTS% %BUILDDIR%/epub
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The epub file is in %BUILDDIR%/epub.
+	goto end
+)
+
+if "%1" == "latex" (
+	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; the LaTeX files are in %BUILDDIR%/latex.
+	goto end
+)
+
+if "%1" == "latexpdf" (
+	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+	cd %BUILDDIR%/latex
+	make all-pdf
+	cd %BUILDDIR%/..
+	echo.
+	echo.Build finished; the PDF files are in %BUILDDIR%/latex.
+	goto end
+)
+
+if "%1" == "latexpdfja" (
+	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+	cd %BUILDDIR%/latex
+	make all-pdf-ja
+	cd %BUILDDIR%/..
+	echo.
+	echo.Build finished; the PDF files are in %BUILDDIR%/latex.
+	goto end
+)
+
+if "%1" == "text" (
+	%SPHINXBUILD% -b text %ALLSPHINXOPTS% %BUILDDIR%/text
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The text files are in %BUILDDIR%/text.
+	goto end
+)
+
+if "%1" == "man" (
+	%SPHINXBUILD% -b man %ALLSPHINXOPTS% %BUILDDIR%/man
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The manual pages are in %BUILDDIR%/man.
+	goto end
+)
+
+if "%1" == "texinfo" (
+	%SPHINXBUILD% -b texinfo %ALLSPHINXOPTS% %BUILDDIR%/texinfo
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The Texinfo files are in %BUILDDIR%/texinfo.
+	goto end
+)
+
+if "%1" == "gettext" (
+	%SPHINXBUILD% -b gettext %I18NSPHINXOPTS% %BUILDDIR%/locale
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The message catalogs are in %BUILDDIR%/locale.
+	goto end
+)
+
+if "%1" == "changes" (
+	%SPHINXBUILD% -b changes %ALLSPHINXOPTS% %BUILDDIR%/changes
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.The overview file is in %BUILDDIR%/changes.
+	goto end
+)
+
+if "%1" == "linkcheck" (
+	%SPHINXBUILD% -b linkcheck %ALLSPHINXOPTS% %BUILDDIR%/linkcheck
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Link check complete; look for any errors in the above output ^
+or in %BUILDDIR%/linkcheck/output.txt.
+	goto end
+)
+
+if "%1" == "doctest" (
+	%SPHINXBUILD% -b doctest %ALLSPHINXOPTS% %BUILDDIR%/doctest
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Testing of doctests in the sources finished, look at the ^
+results in %BUILDDIR%/doctest/output.txt.
+	goto end
+)
+
+if "%1" == "xml" (
+	%SPHINXBUILD% -b xml %ALLSPHINXOPTS% %BUILDDIR%/xml
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The XML files are in %BUILDDIR%/xml.
+	goto end
+)
+
+if "%1" == "pseudoxml" (
+	%SPHINXBUILD% -b pseudoxml %ALLSPHINXOPTS% %BUILDDIR%/pseudoxml
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The pseudo-XML files are in %BUILDDIR%/pseudoxml.
+	goto end
+)
+
+:end

--- a/make.bat
+++ b/make.bat
@@ -27,7 +27,9 @@ if "%1" == "help" (
 
 if "%1" == "docs" (
 :docs
-    echo.docs not yet supported under Windows
+    cd docs
+    make.bat html
+    cd ..
 goto :EOF
 )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 tox
 nose
+Pygments>=1.6
 Sphinx
 coverage


### PR DESCRIPTION
This change updates to Pygments 1.6,  which supports Hy code.

All code-blocks in the documentation have been changed from
clojure to hy.

Also added docs/make.bat for Windows, so the top-level docs
target now works on Windows as well.
