### PR TITLE
Docs for PRs

### DIFF
--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -92,6 +92,12 @@ Write docs---docs are good! Even this doc!
 Core Development Rules
 ======================
 
+Pull requests are good!
+
+Before you submit a PR, please run the tests and check your code against the style guide.  You can do both these things at once::
+
+    $ make d
+
 All incoming changes need to be acked by 2 different members of Hylang's
 core team. Additional review is clearly welcome, but we need a minimum of
 2 signoffs for any change.


### PR DESCRIPTION
Adding a process note on PRs to run `make` before submitting.

I couldn't get the docs to build with the current design - `make html` in the docs folder yielded the old RTD design, not the snazzy new one.  Let me know if I'm missing a config or something there.
