### PR TITLE
fixed ap-map potential naming conflict

### DIFF
--- a/hy/contrib/anaphoric.hy
+++ b/hy/contrib/anaphoric.hy
@@ -46,9 +46,10 @@
 
 (defmacro ap-map [form lst]
   "Yield elements evaluated in the form for each element in the list."
-  `(let [[f (lambda [it] ~form)]]
-     (for [v ~lst]
-       (yield (f v)))))
+  (let [[v (gensym 'v)] [f (gensym 'f)]]
+    `(let [[~f (lambda [it] ~form)]]
+       (for [~v ~lst]
+         (yield (~f ~v))))))
 
 
 (defmacro ap-map-when [predfn rep lst]

--- a/tests/native_tests/contrib/anaphoric.hy
+++ b/tests/native_tests/contrib/anaphoric.hy
@@ -54,7 +54,9 @@
   (assert-equal (list (ap-map (* it 3) [1 2 3]))
                 [3 6 9])
   (assert-equal (list (ap-map (* it 3) []))
-                []))
+                [])
+  (assert-equal (let [[v 1] [f 1]] (list (ap-map (it v f) [(fn [a b] (+ a b))])))
+                [2]))
 
 (defn test-ap-map-when []
   "NATIVE: testing anaphoric map-when"


### PR DESCRIPTION
this fixes #564 - maybe a bit q&d. Probably better to define ap-map (and other macros in anaphoric.hy) using defmacro/g! ... ?
