### PR TITLE
Display python version & platform at repl startup

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -203,6 +203,7 @@ def run_file(filename):
 
 
 def run_repl(hr=None, spy=False):
+    import platform
     sys.ps1 = "=> "
     sys.ps2 = "... "
 
@@ -210,10 +211,15 @@ def run_repl(hr=None, spy=False):
         if not hr:
             hr = HyREPL(spy)
 
-        hr.interact("{appname} {version}".format(
-            appname=hy.__appname__,
-            version=hy.__version__
-        ))
+        hr.interact("{appname} {version} using "
+                    "{py}({build}) {pyversion} on {os}".format(
+                        appname=hy.__appname__,
+                        version=hy.__version__,
+                        py=platform.python_implementation(),
+                        build=platform.python_build()[0],
+                        pyversion=platform.python_version(),
+                        os=platform.system()
+                    ))
 
     return 0
 


### PR DESCRIPTION
Displays the python version & platform information at repl startup something like

```
hy 0.10.0 using Python 3.3.3 (default, Dec  8 2013, 14:51:59) 
[GCC 4.8.2] on linux
=>
```

Mostly trivial info, and probably only makes sense if you end up creating virtualenvs\ pip installing and don't remember which python ;)
