### PR TITLE
defmacro/g! and HyObject#startswith

### DIFF
--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -169,7 +169,7 @@
     ~@body))
 
 (defmacro defmacro/g! [name args &rest body]
-  (let [[syms (list (distinct (filter (fn [x] (.startswith x "g!")) (flatten body))))]]
+  (let [[syms (list (distinct (filter (fn [x] (and (hasattr x "startswith") (.startswith x "g!"))) (flatten body))))]]
     `(defmacro ~name [~@args]
        (let ~(HyList (map (fn [x] `[~x (gensym (slice '~x 2))]) syms))
             ~@body))))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -188,7 +188,12 @@
   (setv s2 (to_source _ast2))
   (assert (in ":res_" s1))
   (assert (in ":res_" s2))
-  (assert (not (= s1 s2))))
+  (assert (not (= s1 s2)))
+
+  ;; defmacro/g! didn't like numbers initially because they
+  ;; don't have a startswith method and blew up during expansion
+  (setv macro2 "(defmacro/g! two-point-zero [] `(+ (float 1) 1.0))")
+  (assert (import_buffer_to_ast macro2 "foo")))
 
 
 (defn test-if-not []


### PR DESCRIPTION
Currently, defmacro/g! doesn't respond well when it comes across a
HyObject that doesn't respond to the instance method startswith (e.g.
HyInteger, HyFloat, etc.). This updates defmacro/g! to be a little
safer when searching for the gensyms it needs to create.

Let me know if there's any stylistic changes you guys want or if my commit message even explains things correctly. Also, let me know where I can throw a test or 2 at this.
