### PR TITLE
Add function partials

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -99,6 +99,18 @@ appends it as the last argument. The following code demonstrates this:
     5 10
 
 
+$
+-
+
+`$` takes a function and multiple argument and applies the function to those arguments. It's equilavent ``functools.partial``.
+
+.. code-block:: clj
+   
+  => (import operator)
+  => (def myinc ($ operator.add 1))
+  => (print (myinc 7)) ; 8
+
+
 apply
 -----
 
@@ -559,6 +571,26 @@ So ``g!a`` would become ``(gensym "a")``.
 .. seealso::
 
    Section :ref:`using-gensym`
+
+defp
+----
+
+`defp` defines a function that returns a function. When called, any excess arguments passed to the function will be passed to its return value. For example, this:
+
+.. code-block:: clj
+   
+   (defp test [a b] (fn [c d] (+ a b c d)))
+   (test 1 2 3 4) ; 10
+
+is equilavent to:
+
+.. code-block:: clj
+  
+  (def test [a b] (fn [c d] (+ a b c d)))
+  ((test 1 2) 3 4) ; 10
+
+In the bottom example, ``test`` returns a function that returns a value. In the top example, the same thing occurs, except that calling the second function is hidden. Note that it does work with functions that take a variable number of arguments.
+
 
 defreader
 ---------

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -194,3 +194,16 @@
           (.append ret
                    `(setv ~name ~main)))
     ret))
+
+(defmacro $ [func &rest args]
+  "Return a partial function object"
+  `(.partial (__import__ "functools") ~func ~@args))
+
+(defmacro defp [f args &rest body]
+  "Return a function that takes its excess arguments and applies them to the function that the original function returned"
+  (def arglen (HyInteger (len args)))
+  (with-gensyms [fargs]
+    `(defn ~f [&rest ~fargs]
+      (apply
+        (apply (fn [~@args] ~@body) (slice ~fargs 0 ~arglen))
+        (slice ~fargs ~arglen)))))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -102,7 +102,7 @@
 
 (defn test-yield-from []
   "NATIVE: testing yield from"
-  
+
   (try
    (eval
     '(do (defn yield-from-test []
@@ -227,3 +227,14 @@
   (assert (= (tda-a1) :bazinga))
   (assert (= (tda-a2) :bazinga))
   (assert (= tda-main tda-a1 tda-a2)))
+
+(defn test-f-partial []
+  (import functools)
+  (defn test [a b] (+ a b))
+  (def a (functools.partial test 1 2))
+  (def b ($ test 1 2))
+  (assert (= (b) 3)))
+
+(defn test-defp []
+  (defp add [a] (fn [b] (+ a b)))
+  (assert (= (add 1 2) 3)))


### PR DESCRIPTION
In Haskell, when a function returns a function, all the excess arguments from the first function get forwarded to the second function. This adds that to Hy using the `defp` macro. This also adds `$` as a shorthand alias for `functool.partial`.
