### PR TITLE
Introducing the with-redefs macro

### DIFF
--- a/tests/native_tests/foo.hy
+++ b/tests/native_tests/foo.hy
@@ -1,0 +1,5 @@
+(setv --doc-- "A fake module for testing module import behavior")
+
+(defn mypermutations [x]
+  (import itertools)
+  (itertools.permutations x))


### PR DESCRIPTION
Ported from clojure ; used for mocking out a library function during testing