### PR TITLE
Make ci builds faster by splitting requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+cache:
+  - $HOME/.pip-cache
 # command to install dependencies
 install:
-  - pip install -r requirements-dev.txt
-  - pip install coveralls
+  - pip install -r requirements-travis.txt --download-cache $HOME/.pip-cache
+  - pip install coveralls --download-cache $HOME/.pip-cache
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi  # needs for running tests
   - pip install --allow-all-external -e .
 # command to run tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,7 @@
+-r requirements-travis.txt
 # test tools
 nose
 tox
-
-# code quality
-flake8
-coverage
 
 # documentation
 Pygments>=1.6

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,0 +1,3 @@
+# code quality
+flake8
+coverage


### PR DESCRIPTION
Make travis builds faster by splitting requirements into
requirements-travis.txt, which contains all the requirements necessary
for running tests, documentation related packages are omitted and added
as a part of requirements-dev.txt

Additionally .travis.yml is modified to cache pip downloads, though this
feature is yet to be rolled out for the free tier
