### PR TITLE
anaphoric: fix first & last when predicates fail

### DIFF
--- a/hy/contrib/anaphoric.hy
+++ b/hy/contrib/anaphoric.hy
@@ -84,18 +84,20 @@
 
 (defmacro ap-first [predfn lst]
   "Yield the first element that passes `predfn`"
-  `(let [[n (gensym)]]
-     (ap-each ~lst (when ~predfn (setv n it) (break)))
-     n))
+  (with-gensyms [n]
+    `(let [[~n None]]
+       (ap-each ~lst (when ~predfn (setv ~n it) (break)))
+       ~n)))
 
 
 (defmacro ap-last [predfn lst]
   "Yield the last element that passes `predfn`"
-  `(let [[n (gensym)]]
-     (ap-each ~lst (none? n)
-	      (when ~predfn
-		(setv n it)))
-	n))
+  (with-gensyms [n]
+    `(let [[~n None]]
+       (ap-each ~lst (none? ~n)
+                (when ~predfn
+                  (setv ~n it)))
+       ~n)))
 
 
 (defmacro ap-reduce [form lst &optional [initial-value None]]

--- a/tests/native_tests/contrib/anaphoric.hy
+++ b/tests/native_tests/contrib/anaphoric.hy
@@ -87,12 +87,14 @@
 (defn test-ap-first []
   "NATIVE: testing anaphoric first"
   (assert-equal (ap-first (> it 5) (range 10)) 6)
-  (assert-equal (ap-first (even? it) [1 2 3 4]) 2))
+  (assert-equal (ap-first (even? it) [1 2 3 4]) 2)
+  (assert-equal (ap-first (> it 10) (range 10)) None))
 
 (defn test-ap-last []
   "NATIVE: testing anaphoric last"
   (assert-equal (ap-last (> it 5) (range 10)) 9)
-  (assert-equal (ap-last (even? it) [1 2 3 4]) 4))
+  (assert-equal (ap-last (even? it) [1 2 3 4]) 4)
+  (assert-equal (ap-last (> it 10) (range 10)) None))
 
 (defn test-ap-reduce []
   "NATIVE: testing anaphoric reduce"


### PR DESCRIPTION
- hy/contrib/anaphoric.hy: `ap-first` and `ap-last` now handle cases
  when failure happens for the predicate. Thanks to @tutorto for
  reporting this bug
