### PR TITLE
Fix #607, remove return from try when there is a generator inside

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -997,7 +997,10 @@ class HyASTCompiler(object):
     @checkargs(max=1)
     def compile_yield_expression(self, expr):
         expr.pop(0)
-        ret = Result(contains_yield=True)
+        if PY33:
+            ret = Result(contains_yield=False)
+        else:
+            ret = Result(contains_yield=True)
 
         value = None
         if expr != []:

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -3,6 +3,7 @@
         [sys :as systest])
 (import sys)
 
+(import [hy._compat [PY33 PY34]])
 
 (defn test-sys-argv []
   "NATIVE: test sys.argv"
@@ -448,6 +449,29 @@
   (for [y (gen)] (setv ret (+ ret y)))
   (assert (= ret 10)))
 
+(defn test-yield-with-return []
+  "NATIVE: test yield with return"
+  (defn gen [] (yield 3) "goodbye")
+  (if PY33
+    (do (setv gg (gen))
+        (assert (= 3 (next gg)))
+        (try (next gg)
+             (except [e StopIteration] (assert (hasattr e "value"))
+                                       (assert (= (getattr e "value") "goodbye")))))
+    (do (setv gg (gen))
+        (assert (= 3 (next gg)))
+        (try (next gg)
+             (except [e StopIteration] (assert (not (hasattr e "value"))))))))
+
+
+(defn test-yield-in-try []
+  "NATIVE: test yield in try"
+  (defn gen []
+    (let [[x 1]]
+    (try (yield x)
+         (finally (print x)))))
+  (setv output (list (gen)))
+  (assert (= [1] output)))
 
 (defn test-first []
   "NATIVE: test firsty things"


### PR DESCRIPTION
Added the contains_yield attr to 'try' when the body it is
wrapping contains 'yield'.

Should also address #600 and #563
