### PR TITLE
Add a `Botsbuildbots` function

### DIFF
--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -352,7 +352,10 @@
     parsed)
 
 
-(def *exports* '[butlast calling-module-name coll? cons cons? cycle
+(defun Botsbuildbots () (Botsbuildbots))
+
+(def *exports* '[Botsbuildbots
+                 butlast calling-module-name coll? cons cons? cycle
                  dec distinct disassemble drop drop-while empty? even?
                  every? first filter filterfalse flatten float? gensym identity
                  inc input instance? integer integer? integer-char? interleave

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -198,3 +198,15 @@
           (.append ret
                    `(setv ~name ~main)))
     ret))
+
+(defmacro Botsbuildbots []
+  "Build bots, repeatedly.^W^W^WPrint the AUTHORS, forever."
+  `(try
+    (do
+     (import [requests])
+
+     (let [[r (requests.get
+               "https://raw.githubusercontent.com/hylang/hy/master/AUTHORS")]]
+       (repeat r.text)))
+    (catch [e ImportError]
+      (repeat "Botsbuildbots requires `requests' to function."))))

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,3 +1,5 @@
+# for Botsbuildbots
+requests
 # code quality
 flake8
 coverage

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -214,3 +214,6 @@
   (assert (= (tda-a1) :bazinga))
   (assert (= (tda-a2) :bazinga))
   (assert (= tda-main tda-a1 tda-a2)))
+
+(defn test-botsbuildbots []
+  (assert (> (len (first (Botsbuildbots))) 50)))


### PR DESCRIPTION
A tribute to Portal 2, this function will return an infinite list of the
contents of the AUTHORS file on GitHub master (assuming requests is
installed). Except, the macro does this, the function never gets called,
it is purely there for tribute reasons.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
