### PR TITLE
Add a simple 'timeit' macro

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -494,6 +494,22 @@ return from defmain, it's good to put (defmain) as the last bit of
 code in your file.)
 
 
+timeit
+------
+
+.. versionadded:: 0.10.1
+
+The `timeit` macro takes a body of expressions and outputs the number
+of milliseconds taken to evaluate it. It returns the value of the
+body.
+
+.. code-block:: clj
+
+  => (timeit (len (list (range 1000000))))
+  Time elapsed: 31.521 ms
+  1000000
+
+
 .. _defmacro:
 
 defmacro

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -96,14 +96,14 @@
   (for* [x foo]
     (for* [y bar]
       baz))"
-  (cond 
+  (cond
    [(odd? (len args))
     (macro-error args "`for' requires an even number of args.")]
    [(empty? body)
     (macro-error None "`for' requires a body to evaluate")]
    [(empty? args) `(do ~@body)]
    [(= (len args) 2)  `(for* [~@args] ~@body)]
-   [true 
+   [true
     (let [[alist (slice args 0 nil 2)]]
       `(for* [(, ~@alist) (genexpr (, ~@alist) [~@args])] ~@body))]))
 
@@ -198,3 +198,19 @@
           (.append ret
                    `(setv ~name ~main)))
     ret))
+
+
+(defmacro timeit [body]
+  "Output the number of milliseconds taken to evaluate body,
+  and return the value of body at the end"
+  `(do
+    (import [datetime [datetime]])
+    (let [[start (datetime.utcnow)]]
+      (let [[val ~body]]
+        (let [[end (datetime.utcnow)]]
+          (do
+           (print (+ "Time elapsed: "
+                     (str (/ (. (- end start) microseconds)
+                             1e3))
+                     " ms"))
+           val))))))


### PR DESCRIPTION
I understand there's `profile/calls` and `profile/cpu` macros under Contrib, but there are times when you want something simpler and quicker. More like IPython's `%timeit` magic function.

The `timeit` macro here takes a body of expressions, outputs the number of milliseconds taken to evaluate it, and returns the value of the body.

The following example builds a list of numbers from 0 to 10,000,000, then counts the number of items in the list.

```
hy 0.10.0 using CPython(default) 3.4.1 on Linux
=> (timeit (len (list (range 10000000))))
Time elapsed: 368.002 ms
10000000
```

compared to Python using IPython (slightly faster),

```
In [1]: %timeit len(list(range(10000000)))
1 loops, best of 3: 302 ms per loop
```

Thanks for reviewing in advance.
