### PR TITLE
Fix RST code-block rendering for (read) examples and add more complex example of (read) usage

### DIFF
--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -930,6 +930,24 @@ parsed.
    => (eval (apply read [] {"from_file" buffer}))
    1
 
+   => ; assuming "example.hy" contains:
+   => ;   (print "hello")
+   => ;   (print "hyfriends!")
+   => (with [[f (open "example.hy")]]
+   ...   (try
+   ...     (while true
+   ...            (let [[exp (read f)]]
+   ...              (do
+   ...                (print "OHY" exp)
+   ...                (eval exp))))
+   ...     (catch [e EOFError]
+   ...            (print "EOF!"))))
+   OHY ('print' 'hello')
+   hello
+   OHY ('print' 'hyfriends!')
+   hyfriends!
+   EOF!
+
 
 .. _remove-fn:
 


### PR DESCRIPTION
Without the blank line after `.. code-block:: hy`, the entire block is ignored instead of rendered.

While I was in there, I added a more complex example of `(read)` usage from a file, highlighting one way `EOFError` can be used.

Of course, I'm happy to amend and improve/iterate, even if it turns out nobody but me likes such a verbose example and it needs to just be purged and trim this PR down to just that first commit (since the first commit is definitely a lot less controversial, being that it's a RST syntax fix and some very minor whitespace changes).
