### PR TITLE
Implement drop-last (and reimplement butlast)

### DIFF
--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -6,6 +6,31 @@ Hy Core
 Core Functions
 ===============
 
+.. _butlast-fn:
+
+butlast
+-------
+
+Usage: ``(butlast coll)``
+
+Returns an iterator of all but the last item in ``coll``.
+
+.. code-block:: hy
+
+   => (list (butlast (range 10)))
+   [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+   => (list (butlast [1]))
+   []
+
+   => (list (butlast []))
+   []
+
+   => (import itertools)
+   => (list (take 5 (butlast (itertools.count 10))))
+   [10, 11, 12, 13, 14]
+
+
 .. _is-coll-fn:
 
 coll?

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -38,7 +38,7 @@
 
 (defn butlast [coll]
   "Returns coll except of last element."
-  (itertools.islice coll 0 (dec (len coll))))
+  (drop-last 1 coll))
 
 (defn coll? [coll]
   "Checks whether item is a collection"

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -38,6 +38,19 @@
   (assert-false (coll? "abc"))
   (assert-false (coll? 1)))
 
+(defn test-butlast []
+  "NATIVE: testing butlast function"
+  (assert-equal (list (butlast (range 10)))
+                [0 1 2 3 4 5 6 7 8])
+  (assert-equal (list (butlast [1]))
+                [])
+  (assert-equal (list (butlast []))
+                [])
+  ; with an infinite sequence
+  (import itertools)
+  (assert-equal (list (take 5 (butlast (itertools.count 10))))
+                [10 11 12 13 14]))
+
 (defn test-cycle []
   "NATIVE: testing cycle"
   (assert-equal (list (cycle [])) [])


### PR DESCRIPTION
This PR implements `drop-last`.

I have also reimplemented `butlast` in terms of `drop-last` in order to make it work well with lazy/infinite sequences. The problem with the current implementation is that it would only work well with fully realised collections or iterators that implement `__len__` which can be problematic in some cases. Please consider the following examples.

``` hy
=> (butlast (interleave (range 10) (range 10 20)))
```

``` python
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/microamp/devel/projs/hy/hy/core/language.hy", line 41, in butlast
    (itertools.islice coll 0 (dec (len coll))))
TypeError: object of type 'itertools.chain' has no len()
```

``` hy
=> (import itertools)
=> (take 5 (butlast (itertools.count)))
```

``` python
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/microamp/devel/projs/hy/hy/core/language.hy", line 41, in butlast
    (itertools.islice coll 0 (dec (len coll))))
TypeError: object of type 'itertools.count' has no len()
```

Please find the new tests to see how `drop-last`/`butlast` handle lazy/infinite sequences now.

Thanks for reviewing in advance.
