### PR TITLE
Fix #639: Shadow '+' to handle string/list concatenation

### DIFF
--- a/hy/core/shadow.hy
+++ b/hy/core/shadow.hy
@@ -26,9 +26,12 @@
 
 (defn + [&rest args]
   "Shadow + operator for when we need to import / map it against something"
-  (if (= (len args) 0)
-    0
-    (sum args)))  ; shortcut here.
+  (let [[count (len args)]]
+    (if (zero? count)
+      (raise (TypeError "Need at least 1 argument to add/concatenate"))
+      (if (= count 1)
+        (get args 0)
+        (reduce operator.add args)))))
 
 
 (defn - [&rest args]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,7 @@ from .native_tests.when import *  # noqa
 from .native_tests.with_decorator import *  # noqa
 from .native_tests.core import *  # noqa
 from .native_tests.reader_macros import *  # noqa
+from .native_tests.shadow import *  # noqa
 from .native_tests.with_test import *  # noqa
 from .native_tests.contrib.anaphoric import *  # noqa
 from .native_tests.contrib.loop import *  # noqa

--- a/tests/native_tests/shadow.hy
+++ b/tests/native_tests/shadow.hy
@@ -1,11 +1,22 @@
-
-
 (defn test-shadow-addition []
   "NATIVE: test shadow addition"
   (let [[x +]]
-    (assert (= (x) 0))
+    (assert (try
+             (x)
+             (catch [TypeError] True)
+             (else (throw AssertionError))))
     (assert (= (x 1 2 3 4) 10))
-    (assert (= (x 1 2 3 4 5) 15))))
+    (assert (= (x 1 2 3 4 5) 15))
+    ; with strings
+    (assert (= (x "a")
+               "a"))
+    (assert (= (x "a" "b" "c")
+               "abc"))
+    ; with lists
+    (assert (= (x ["a"])
+               ["a"]))
+    (assert (= (x ["a"] ["b"] ["c"])
+               ["a" "b" "c"]))))
 
 
 (defn test-shadow-subtraction []


### PR DESCRIPTION
The PR fixes #639.

``` hy
=> (let [[op +]] (op 1 2 3))  ; note: this is NOT equivalent to (+ 1 2 3)
6
=> (let [[op +]] (op "a" "b" "c"))
'abc'
=> (let [[op +]] (op ["a"] ["b"] ["c"]))
['a', 'b', 'c']
=> (reduce + ["a" "b" "c"])
'abc'
=> (reduce + [["a"] ["b"] ["c"]])
['a', 'b', 'c']
```

`TypeError` will be raised if there are no arguments rather than returning `0` because there is no single default value that would satisfy all types `+` can handle.

``` hy
=> (let [[op +]] (op))
```

``` py
Traceback (most recent call last):
  ...
TypeError: Need at least 1 argument to add/concatenate
```

The shadow tests were not included in the test suite for some reason. They are now.

Thanks for reviewing in advance.
