### PR TITLE
Rename slots to attribute/attr

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2003,12 +2003,12 @@ class HyASTCompiler(object):
             except TypeError:
                 raise HyTypeError(
                     expression,
-                    "Wrong argument type for defclass slots definition.")
+                    "Wrong argument type for defclass attributes definition.")
             for b in body_expression:
                 if len(b) != 2:
                     raise HyTypeError(
                         expression,
-                        "Wrong number of argument in defclass slot.")
+                        "Wrong number of argument in defclass attribute.")
                 body += self._compile_assign(b[0], b[1],
                                              b.start_line, b.start_column)
                 body += body.expr_as_stmt()

--- a/tests/native_tests/defclass.hy
+++ b/tests/native_tests/defclass.hy
@@ -20,16 +20,16 @@
   (assert (not (isinstance (A) D))))
 
 
-(defn test-defclass-slots []
-  "NATIVE: test defclass slots"
+(defn test-defclass-attrs []
+  "NATIVE: test defclass attributes"
   (defclass A []
     [[x 42]])
   (assert (= A.x 42))
   (assert (= (getattr (A) "x")  42)))
 
 
-(defn test-defclass-slots-fn []
-  "NATIVE: test defclass slots with fn"
+(defn test-defclass-attrs-fn []
+  "NATIVE: test defclass attributes with fn"
   (defclass B []
     [[x 42]
      [y (fn [self value]
@@ -52,7 +52,7 @@
 
 
 (defn test-defclass-no-fn-leak []
-  "NATIVE: test defclass slots with fn"
+  "NATIVE: test defclass attributes with fn"
   (defclass A []
     [[x (fn [] 1)]])
   (try


### PR DESCRIPTION
There has been an implicit agreement that Hy is just Python. It also makes more sense in the Python world.
