### PR TITLE
slice overshadow corrections as hysymbol change

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -603,7 +603,7 @@ del
   => (setv test (list (range 10)))
   => test
   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-  => (del (slice test 2 4)) ;; remove items from 2 to 4 excluded
+  => (del (cut test 2 4)) ;; remove items from 2 to 4 excluded
   => test
   [0, 1, 4, 5, 6, 7, 8, 9]
   => (setv dic {"foo" "bar"})
@@ -1111,16 +1111,16 @@ expression.
     {1, 3, 5}
 
 
-slice
+cut
 -----
 
-`slice` can be used to take a subset of a list and create a new list from it.
-The form takes at least one parameter specifying the list to slice. Two
+`cut` can be used to take a subset of a list and create a new list from it.
+The form takes at least one parameter specifying the list to cut. Two
 optional parameters can be used to give the start and end position of the
 subset. If they are not supplied, default value of None will be used instead.
 Third optional parameter is used to control step between the elements.
 
-`slice` follows the same rules as the Python counterpart. Negative indecies are
+`cut` follows the same rules as the Python counterpart. Negative indecies are
 counted starting from the end of the list.
 Some examples of
 usage:
@@ -1129,19 +1129,19 @@ usage:
 
     => (def collection (range 10))
 
-    => (slice collection)
+    => (cut collection)
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-    => (slice collection 5)
+    => (cut collection 5)
     [5, 6, 7, 8, 9]
 
-    => (slice collection 2 8)
+    => (cut collection 2 8)
     [2, 3, 4, 5, 6, 7]
 
-    => (slice collection 2 8 2)
+    => (cut collection 2 8 2)
     [2, 4, 6]
 
-    => (slice collection -4 -2)
+    => (cut collection -4 -2)
     [6, 7]
 
 

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -195,7 +195,7 @@ expressions are made of Python lists wrapped in a
  - ``(cons something some-list)`` is ``((type some-list) (+ [something]
    some-list))`` (if ``some-list`` inherits from ``list``).
  - ``(get (cons a b) 0)`` is ``a``
- - ``(slice (cons a b) 1)`` is ``b``
+ - ``(cut (cons a b) 1)`` is ``b``
 
 Hy supports a dotted-list syntax, where ``'(a . b)`` means ``(cons 'a
 'b)`` and ``'(a b . c)`` means ``(cons 'a (cons 'b 'c))``. If the

--- a/eg/lxml/parse-tumblr.hy
+++ b/eg/lxml/parse-tumblr.hy
@@ -20,6 +20,6 @@
   (for [post (.xpath (get-rss-feed tumblr) "//item/title")]
     (print post.text)))
 
-(if (slice argv 2)
+(if (cut argv 2)
   (print-posts (get argv 2))
   (print-posts "this-plt-life"))

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1195,9 +1195,9 @@ class HyASTCompiler(object):
             col_offset=expr.start_column,
             targets=del_targets)
 
-    @builds("slice")
+    @builds("cut")
     @checkargs(min=1, max=4)
-    def compile_slice_expression(self, expr):
+    def compile_cut_expression(self, expr):
         expr.pop(0)  # index
         val = self.compile(expr.pop(0))  # target
 
@@ -1480,7 +1480,7 @@ class HyASTCompiler(object):
 
                 # We then pass the other arguments to the function
                 expr[0] = HyExpression(
-                    [HySymbol("slice"), tempvar, HyInteger(1)]
+                    [HySymbol("cut"), tempvar, HyInteger(1)]
                 ).replace(expr[0])
 
         ret += self.compile(call)

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -57,7 +57,7 @@
 
 (defmacro cdr [thing]
   "Get all the elements of a thing, except the first"
-  `(slice ~thing 1))
+  `(cut ~thing 1))
 
 
 (defmacro cond [&rest branches]
@@ -104,7 +104,7 @@
    [(empty? args) `(do ~@body)]
    [(= (len args) 2)  `(for* [~@args] ~@body)]
    [true 
-    (let [[alist (slice args 0 nil 2)]]
+    (let [[alist (cut args 0 nil 2)]]
       `(for* [(, ~@alist) (genexpr (, ~@alist) [~@args])] ~@body))]))
 
 
@@ -171,7 +171,7 @@
 (defmacro defmacro/g! [name args &rest body]
   (let [[syms (list (distinct (filter (fn [x] (and (hasattr x "startswith") (.startswith x "g!"))) (flatten body))))]]
     `(defmacro ~name [~@args]
-       (let ~(HyList (map (fn [x] `[~x (gensym (slice '~x 2))]) syms))
+       (let ~(HyList (map (fn [x] `[~x (gensym (cut '~x 2))]) syms))
             ~@body))))
 
 

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -262,18 +262,18 @@ def test_ast_bad_get():
     cant_compile("(get 1)")
 
 
-def test_ast_good_slice():
-    "Make sure AST can compile valid slice"
-    can_compile("(slice x)")
-    can_compile("(slice x y)")
-    can_compile("(slice x y z)")
-    can_compile("(slice x y z t)")
+def test_ast_good_cut():
+    "Make sure AST can compile valid cut"
+    can_compile("(cut x)")
+    can_compile("(cut x y)")
+    can_compile("(cut x y z)")
+    can_compile("(cut x y z t)")
 
 
-def test_ast_bad_slice():
-    "Make sure AST can't compile invalid slice"
-    cant_compile("(slice)")
-    cant_compile("(slice 1 2 3 4 5)")
+def test_ast_bad_cut():
+    "Make sure AST can't compile invalid cut"
+    cant_compile("(cut)")
+    cant_compile("(cut 1 2 3 4 5)")
 
 
 def test_ast_good_take():

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -501,11 +501,11 @@
   (assert (= (car [1 2 3 4 5]) 1)))
 
 
-(defn test-slice []
-  "NATIVE: test slice"
-  (assert (= (slice [1 2 3 4 5] 1) [2 3 4 5]))
-  (assert (= (slice [1 2 3 4 5] 1 3) [2 3]))
-  (assert (= (slice [1 2 3 4 5]) [1 2 3 4 5])))
+(defn test-cut []
+  "NATIVE: test cut"
+  (assert (= (cut [1 2 3 4 5] 1) [2 3 4 5]))
+  (assert (= (cut [1 2 3 4 5] 1 3) [2 3]))
+  (assert (= (cut [1 2 3 4 5]) [1 2 3 4 5])))
 
 
 (defn test-take []


### PR DESCRIPTION
This is a new correction to slicing that renames the slice operation to cut, modifying all appropriate tests.
The HySymbol("slice") is now HySymbol("cut").

No other functionality was changed.

A much simpler solution than the stuff that I did before :smile: 

The previous pull request associated with this is #508 which was a response to #505 and previously mentioned in #381.
The majority of discussion on the topic was in #508.