### PR TITLE
Type annotations for fn/lambda

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1894,14 +1894,21 @@ class HyASTCompiler(object):
         arglist = expression.pop(0)
         ret, args, defaults, stararg, kwargs = self._parse_lambda_list(arglist)
 
+
         if PY34:
             # Python 3.4+ requires that args are an ast.arg object, rather
             # than an ast.Name or bare string.
-            args = [ast.arg(arg=ast_str(x),
-                            annotation=None,  # Fix me!
-                            lineno=x.start_line,
-                            col_offset=x.start_column) for x in args]
-
+            ret_args = []
+            for x in args:
+                ann = None
+                if isinstance(x, HyList):
+                    x, ann = x
+                    ann_ret = self.compile(ann)
+                ret_args.append(ast.arg(arg=ast_str(x),
+                                    annotation= ann_ret._expr if ann else None,
+                                    lineno=x.start_line,
+                                    col_offset=x.start_column))
+            args = ret_args
             # XXX: Beware. Beware. This wasn't put into the parse lambda
             # list because it's really just an internal parsing thing.
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1899,7 +1899,7 @@ class HyASTCompiler(object):
         if PY34:
             # Python 3.4+ requires that args are an ast.arg object, rather
             # than an ast.Name or bare string.
-            if expression[0] == "_>":
+            if len(expression) > 0 and expression[0] == "_>":
                 expression.pop(0)
                 return_ann = self.compile(expression.pop(0))._expr
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1894,10 +1894,15 @@ class HyASTCompiler(object):
         arglist = expression.pop(0)
         ret, args, defaults, stararg, kwargs = self._parse_lambda_list(arglist)
 
+        return_ann = None
 
         if PY34:
             # Python 3.4+ requires that args are an ast.arg object, rather
             # than an ast.Name or bare string.
+            if expression[0] == "_>":
+                expression.pop(0)
+                return_ann = self.compile(expression.pop(0))._expr
+
             ret_args = []
             for x in args:
                 ann = None
@@ -1956,13 +1961,21 @@ class HyASTCompiler(object):
                              col_offset=expression.start_column)
 
         name = self.get_anon_fn()
-
-        ret += ast.FunctionDef(name=name,
-                               lineno=expression.start_line,
-                               col_offset=expression.start_column,
-                               args=args,
-                               body=body.stmts,
-                               decorator_list=[])
+        if return_ann:
+            ret += ast.FunctionDef(name=name,
+                                   lineno=expression.start_line,
+                                   col_offset=expression.start_column,
+                                   args=args,
+                                   body=body.stmts,
+                                   decorator_list=[],
+                                   returns=return_ann)
+        else:
+            ret += ast.FunctionDef(name=name,
+                                   lineno=expression.start_line,
+                                   col_offset=expression.start_column,
+                                   args=args,
+                                   body=body.stmts,
+                                   decorator_list=[])
 
         ast_name = ast.Name(id=name,
                             arg=name,

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1908,11 +1908,11 @@ class HyASTCompiler(object):
                 ann = None
                 if isinstance(x, HyList):
                     x, ann = x
-                    ann_ret = self.compile(ann)
+                    ann_ret = self.compile(ann)._expr
                 ret_args.append(ast.arg(arg=ast_str(x),
-                                    annotation= ann_ret._expr if ann else None,
-                                    lineno=x.start_line,
-                                    col_offset=x.start_column))
+                                        annotation=ann_ret if ann else None,
+                                        lineno=x.start_line,
+                                        col_offset=x.start_column))
             args = ret_args
             # XXX: Beware. Beware. This wasn't put into the parse lambda
             # list because it's really just an internal parsing thing.


### PR DESCRIPTION
Beta stage.
=======
Reff #640  

 `optional` and `kwargs` does not work as syntax isn't really decided upon, and we can't annotate return values as it needs macro changes.
Current approach checks for a `HyList` as given var and destructs this. Passing the annotations through `self.compile` pulling out `_expr` from the `Result()` object. This way the types are rather "dynamic" when passed along.


```hy
=> (defn a [[y int]] (print "lol"))
=> a.--annotations--
{'y': <class 'int'>}

=> (defn a [[y "HEYHO LETS GO!"]] (print "lol"))
=> a.--annotations--
{'y': 'HEYHO LETS GO!'}

=> (defn a [[y (lambda [[x "Just wanna get hy"]] (print "Heyho!"))]] (print "lol"))
=> a.--annotations--
{'y': <function <lambda> at 0x7f4939167598>}
```

The current(?) syntax i imagen we could use is (adding with comment below, ninja edit)

```hy
(defn foo [[x int] &optional [[a str] "Hey"]] -> int
  (+ 3 4))
```




CC: @hylang/core 
Comments, code review, rate and hate!

:shipit: 