### PR TITLE
Add a dedicated `lisp-if-not` / `lif-not` macro

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -818,14 +818,18 @@ any numeric type, empty sequence and empty dictionary are considered `False`.
 Everything else is considered `True`.
 
 
-lisp-if / lif
--------------
+lisp-if / lif and lisp-if-not / lif-not
+---------------------------------------
 
 .. versionadded:: 0.10.0
 
+.. versionadded:: 0.10.2
+   lisp-if-not / lif-not
+
 For those that prefer a more lisp-y if clause, we have lisp-if, or lif.  This
 *only* considers None/nil as false!  All other values of python
-"falseiness" are considered true.
+"falseiness" are considered true.  Conversely, we have lisp-if-not or lif-not,
+in parallel to if / if-not, which reverses the comparison.
 
 
 .. code-block:: clj
@@ -840,12 +844,20 @@ For those that prefer a more lisp-y if clause, we have lisp-if, or lif.  This
     "false"
     => (lisp-if None "true" "false")
     "false"
+    => (lisp-if-not nil "true" "false")
+    "true"
+    => (lisp-if-not None "true" "false")
+    "true"
+    => (lisp-if-not False "true" "false")
+    "false"
 
     ; And, same thing
     => (lif True "true" "false")
     "true"
     => (lif nil "true" "false")
     "false"
+    => (lif-not None "true" "false")
+    "true"
 
 
 import

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -153,6 +153,10 @@
   "Like `if`, but anything that is not None/nil is considered true."
   `(if (is-not ~test nil) ~@branches))
 
+(defmacro-alias [lisp-if-not lif-not] [test &rest branches]
+  "Like `if-not`, but anything that is not None/nil is considered true."
+  `(if (is ~test nil) ~@branches))
+
 
 (defmacro when [test &rest body]
   "Execute `body` when `test` is true"

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -206,6 +206,24 @@
   (assert (= (lif nil "true" "false") "false"))
   (assert (= (lif 0 "true" "false") "true")))
 
+(defn test-lisp-if-not []
+  "test that lisp-if-not works as expected"
+  ; nil is false
+  (assert (= (lisp-if-not None "false" "true") "false"))
+  (assert (= (lisp-if-not nil "false" "true") "false"))
+
+  ; But everything else is True!  Even falsey things.
+  (assert (= (lisp-if-not True "false" "true") "true"))
+  (assert (= (lisp-if-not False "false" "true") "true"))
+  (assert (= (lisp-if-not 0 "false" "true") "true"))
+  (assert (= (lisp-if-not "some-string" "false" "true") "true"))
+  (assert (= (lisp-if-not "" "false" "true") "true"))
+  (assert (= (lisp-if-not (+ 1 2 3) "false" "true") "true"))
+
+  ; Just to be sure, test the alias lif-not
+  (assert (= (lif-not nil "false" "true") "false"))
+  (assert (= (lif-not 0 "false" "true") "true")))
+
 
 (defn test-defn-alias []
   (defn-alias [tda-main tda-a1 tda-a2] [] :bazinga)


### PR DESCRIPTION
This is in parallel to `if` / `if-not` (so not without precedent). :)

There are a few things here I wasn't completely sure about, like the blurb in the docs and the copied/swapped tests (that seemed like kind of an ugly thing to do, even if it's effective).

Of course, I'm quite happy to amend as requested, or even just close this out if it's something nobody else likes! :smile:
