### PR TITLE
Add in an AST workaround for Macros.

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1722,6 +1722,10 @@ class HyASTCompiler(object):
     def compile_expression(self, expression):
         # Perform macro expansions
         expression = macroexpand(expression, self.module_name)
+
+        if isinstance(expression, ast.AST):
+            return expression
+
         if not isinstance(expression, HyExpression):
             # Go through compile again if the type changed.
             return self.compile(expression)

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -31,6 +31,7 @@ from hy._compat import str_type, long_type
 from hy.errors import HyTypeError, HyMacroExpansionError
 
 from collections import defaultdict
+import ast
 import sys
 
 CORE_MACROS = [
@@ -203,6 +204,13 @@ def macroexpand_1(tree, module_name):
                     msg = "`" + str(tree[0]) + "' " + \
                           " ".join(str(e).split()[1:])
                     raise HyMacroExpansionError(tree, msg)
+
+                if isinstance(obj, ast.AST):
+                    obj.lineno = tree.start_line
+                    obj.col_offset = tree.start_column
+                    ast.fix_missing_locations(obj)
+                    return obj
+
                 obj.replace(tree)
                 return obj
 


### PR DESCRIPTION
WIP:

```hy
(defmacro defmacro/ast [name args &rest body]
  `(defmacro ~name [~@args]
     (import [hy.compiler [HyASTCompiler]])
     (let [[compiler (HyASTCompiler "name")]]
        ~@body)))


(defmacro/ast testing []
  (import ast)
  (apply ast.Name [] {"ctx" (ast.Load)
                      "id" "name"}))


(print (testing))
```