### PR TITLE
HyMacroExpansionError shouldn't truncate message

### DIFF
--- a/hy/macros.py
+++ b/hy/macros.py
@@ -200,8 +200,7 @@ def macroexpand_1(tree, module_name):
                         e.expression = tree
                     raise
                 except Exception as e:
-                    msg = "`" + str(tree[0]) + "' " + \
-                          " ".join(str(e).split()[1:])
+                    msg = "expanding `" + str(tree[0]) + "': " + repr(e)
                     raise HyMacroExpansionError(tree, msg)
                 obj.replace(tree)
                 return obj


### PR DESCRIPTION
For example:

```
$ hy
hy 0.10.1 using CPython(default) 2.7.8 on Darwin
=> (defmacro hi [] (raise (TypeError "This message will be truncated")))
=> (hi)
  File "<input>", line 1, column 1

  (hi)
  ^--^
HyMacroExpansionError: `hi' message will be truncated
```
