### PR TITLE
Typo fix in docs

### DIFF
--- a/docs/language/readermacros.rst
+++ b/docs/language/readermacros.rst
@@ -48,7 +48,7 @@ Implementation
 
 ``defreader`` takes a single character as symbol name for the reader macro,
 anything longer will return an error. Implementation wise, ``defreader``
-expands into a lambda covered with a decorator, this decorater saves the
+expands into a lambda covered with a decorator, this decorator saves the
 lambda in a dict with its module name and symbol.
 
 ::


### PR DESCRIPTION
Small one character typo fix that I noticed whilst reading the docs.
