### PR TITLE
Add macro expansion in defclass

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,4 @@
 * Ed Singleton <singletoned@gmail.com>
 * Kevin Yap <me@kevinyap.ca>
 * Matthías Páll Gissurarson <mpg@mpg.is>
+* Nathan Woodrow <woodrow.nathan@gmail.com>

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2006,6 +2006,8 @@ class HyASTCompiler(object):
                     expression,
                     "Wrong argument type for defclass attributes definition.")
             for b in body_expression:
+                if isinstance(b, HyExpression):
+                    b = macroexpand(b, self.module_name)
                 if len(b) != 2:
                     raise HyTypeError(
                         expression,

--- a/tests/native_tests/defclass.hy
+++ b/tests/native_tests/defclass.hy
@@ -83,3 +83,11 @@
   (assert (= mL.x 1))
   (assert (in "begin" mL.__doc__))
   (assert (in "end" mL.__doc__)))
+
+(defn test-defclass-macroexpand []
+  "NATIVE: test defclass with macro expand"
+  (defmacro M [] `[x (fn [self x] (setv self._x x))])
+  (defclass A [] [(M)])
+  (setv a (A))
+  (a.x 1)
+  (assert (= a._x 1)))


### PR DESCRIPTION
Allows for macro expansion in `defclass`

Currently Hy fails with `HyTypeError: Wrong number of argument in defclass attribute` when using macros.
