### PR TITLE
Fixes a long-standing bug in import under Python 3.3 and later.

### DIFF
--- a/hy/importer.py
+++ b/hy/importer.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2013 Paul Tagliamonte <paultag@debian.org>
-# Copyright (c) 2013 Bob Tolbert <bob@tolbert.org>
+# Copyright (c) 2013, 2014 Bob Tolbert <bob@tolbert.org>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -209,5 +209,5 @@ class MetaImporter(object):
             return MetaLoader(path)
 
 
-sys.meta_path.append(MetaImporter())
+sys.meta_path.insert(0, MetaImporter())
 sys.path.insert(0, "")

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -1,5 +1,5 @@
 ;; Copyright (c) 2013 Paul Tagliamonte <paultag@debian.org>
-;; Copyright (c) 2013 Bob Tolbert <bob@tolbert.org>
+;; Copyright (c) 2013, 2014 Bob Tolbert <bob@tolbert.org>
 
 ;; Permission is hereby granted, free of charge, to any person obtaining a
 ;; copy of this software and associated documentation files (the "Software"),
@@ -597,3 +597,8 @@
   (assert (not (keyword? ":foo")))
   (assert (not (keyword? 1)))
   (assert (not (keyword? nil))))
+
+(defn test-import-init-hy []
+  "NATIVE: testing import of __init__.hy"
+  (import tests.resources.bin)
+  (assert (in "_null_fn_for_import_test" (dir tests.resources.bin))))

--- a/tests/resources/bin/__init__.hy
+++ b/tests/resources/bin/__init__.hy
@@ -1,0 +1,2 @@
+(defn -null-fn-for-import-test []
+  pass)


### PR DESCRIPTION
Our MetaImporter was being inserted at the end of sys.meta_path.
For Python prior to 3.3, this was fine since sys.meta_path
was empty by default. As of the completion of PEP 302 in Py3.3 and
later, there are several importers registered by default. One of
these was trying (and failing) to import simple Hy modules,
resulting in a failure to import anything inside **init**.hy.

This change simply inserts the Hy-specific importer at the front
of the list.

This was noted in issue #620 (great catch @algernon)
