### PR TITLE
Fixed some unicode errors in python2

### DIFF
--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -58,3 +58,20 @@ if PY3:
 else:
     def raise_empty(t, *args):
         raise t(*args)
+
+
+# Taken from `future` module: https://pypi.python.org/pypi/future/
+# (MIT licensed). Moved here to avoid dependency. Consider just
+# importing `future.utils`.
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if not PY3:
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -47,7 +47,7 @@ from hy.models.expression import HyExpression
 from hy.models.string import HyString
 from hy.models.symbol import HySymbol
 
-from hy._compat import builtins, PY3
+from hy._compat import builtins, PY3, str_type
 
 
 class HyQuitter(object):
@@ -93,7 +93,7 @@ class HyREPL(code.InteractiveConsole):
             if e.source is None:
                 e.source = source
                 e.filename = filename
-            sys.stderr.write(str(e))
+            sys.stderr.write(str_type(e))
             return False
 
         try:
@@ -106,7 +106,7 @@ class HyREPL(code.InteractiveConsole):
                 e.source = source
                 e.filename = filename
             if SIMPLE_TRACEBACKS:
-                sys.stderr.write(str(e))
+                sys.stderr.write(str_type(e))
             else:
                 self.showtraceback()
             return False
@@ -177,10 +177,13 @@ SIMPLE_TRACEBACKS = True
 
 def run_command(source):
     try:
+        if not PY3:
+            # TODO: Encoding type should depend on locale.
+            source = source.decode('utf-8')
         import_buffer_to_module("__main__", source)
     except (HyTypeError, LexException) as e:
         if SIMPLE_TRACEBACKS:
-            sys.stderr.write(str(e))
+            sys.stderr.write(str_type(e))
             return 1
         raise
     except Exception:
@@ -206,7 +209,7 @@ def run_file(filename):
         import_file_to_module("__main__", filename)
     except (HyTypeError, LexException) as e:
         if SIMPLE_TRACEBACKS:
-            sys.stderr.write(str(e))
+            sys.stderr.write(str_type(e))
             return 1
         raise
     except Exception:

--- a/hy/errors.py
+++ b/hy/errors.py
@@ -21,11 +21,13 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+
 import traceback
 
 from clint.textui import colored
 
-from hy._compat import PY3
+from hy._compat import str_type
 
 
 class HyError(Exception):
@@ -99,14 +101,11 @@ class HyTypeError(TypeError):
             result += '  %s\n' % colored.red("".join(source[-1]))
             result += '  %s\n' % colored.green('-'*(end-1) + '^')
 
-        result += colored.yellow("%s: %s\n\n" %
-                                 (self.__class__.__name__,
-                                  self.message))
+        result += str_type(colored.yellow("%s: %s\n\n" %
+                                          (self.__class__.__name__,
+                                           self.message)))
 
-        if not PY3:
-            return result.encode('utf-8')
-        else:
-            return result
+        return result
 
 
 class HyMacroExpansionError(HyTypeError):

--- a/hy/errors.py
+++ b/hy/errors.py
@@ -27,9 +27,10 @@ import traceback
 
 from clint.textui import colored
 
-from hy._compat import str_type
+from hy._compat import str_type, python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class HyError(Exception):
     """
     Generic Hy error. All internal Exceptions will be subclassed from this
@@ -45,7 +46,7 @@ class HyCompileError(HyError):
 
     def __str__(self):
         if isinstance(self.exception, HyTypeError):
-            return str(self.exception)
+            return str_type(self.exception)
         if self.traceback:
             tb = "".join(traceback.format_tb(self.traceback)).strip()
         else:
@@ -55,6 +56,7 @@ class HyCompileError(HyError):
                   self.exception, tb))
 
 
+@python_2_unicode_compatible
 class HyTypeError(TypeError):
     def __init__(self, expression, message):
         super(HyTypeError, self).__init__(message)

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -200,7 +200,7 @@ def macroexpand_1(tree, module_name):
                         e.expression = tree
                     raise
                 except Exception as e:
-                    msg = "expanding `" + str(tree[0]) + "': " + repr(e)
+                    msg = "expanding `" + str_type(tree[0]) + "': " + repr(e)
                     raise HyMacroExpansionError(tree, msg)
                 obj.replace(tree)
                 return obj

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -18,6 +18,8 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+
 from hy.models.expression import HyExpression
 from hy.models.string import HyString
 from hy.models.symbol import HySymbol

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -25,7 +25,7 @@ from __future__ import unicode_literals
 from hy import HyString
 from hy.models import HyObject
 from hy.compiler import hy_compile
-from hy.errors import HyCompileError, HyTypeError
+from hy.errors import HyCompileError, HyTypeError, HyMacroExpansionError
 from hy.lex.exceptions import LexException
 from hy.lex import tokenize
 from hy._compat import PY3, str_type
@@ -422,16 +422,17 @@ def test_ast_unicode_strings():
     assert _compile_string("\xc3\xa9") == "\xc3\xa9"
 
 
-def test_unicode_compile_error():
+def test_unicode_exception_messages():
     """Ensure we can generate error messages containing unicode."""
     try:
         hy_compile(tokenize("(defmacro ❤ () (throw Exception)) (❤)"),
                    "__main__")
         assert False
-    except HyTypeError as e:
+    except HyMacroExpansionError as e:
         assert isinstance(e.expression, HyObject)
-        assert e.message
-        assert str_type(e)
+        message = str_type(e)
+        assert '❤' in message
+        assert "Exception()" in message
 
 
 def test_compile_error():

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 # Copyright (c) 2013 Paul Tagliamonte <paultag@debian.org>
 # Copyright (c) 2013 Julien Danjou <julien@danjou.info>
 #
@@ -27,7 +28,7 @@ from hy.compiler import hy_compile
 from hy.errors import HyCompileError, HyTypeError
 from hy.lex.exceptions import LexException
 from hy.lex import tokenize
-from hy._compat import PY3
+from hy._compat import PY3, str_type
 
 import ast
 
@@ -419,6 +420,18 @@ def test_ast_unicode_strings():
     assert _compile_string("test") == "test"
     assert _compile_string("\u03b1\u03b2") == "\u03b1\u03b2"
     assert _compile_string("\xc3\xa9") == "\xc3\xa9"
+
+
+def test_unicode_compile_error():
+    """Ensure we can generate error messages containing unicode."""
+    try:
+        hy_compile(tokenize("(defmacro ❤ () (throw Exception)) (❤)"),
+                   "__main__")
+        assert False
+    except HyTypeError as e:
+        assert isinstance(e.expression, HyObject)
+        assert e.message
+        assert str_type(e)
 
 
 def test_compile_error():

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -88,7 +88,7 @@ def test_bin_hy_cmd_unicode_output():
     # work when done manually from terminal, and fail when called with
     # run_cmd(). To pass the test in python2, encoding must be set
     # manually.
-    code = """
+    code = """\
     (import sys)
     (when (= (get sys.version_info 0) 2)
       (import locale codecs)


### PR DESCRIPTION
# What

Fixed UnicodeEncodeError when compiler is reporting
HyMacroExpansionError with macro containing unicode.

Added decoding of command line arguments passed with "-c" to fix
UnicodeDecodeError caused by args containing unicode.

# Why

## Macroexpansion error reporting error
### Expected:
    $  ./hy
    hy 0.10.1 using CPython(default) 3.3.5 on Linux
    => (defmacro bug❤ (x)
    ...   (throw Exception))
    => 
    => (bug❤ foo)
      File "<input>", line 1, column 1
    
      (bug❤ foo)
      ^--------^
    HyMacroExpansionError: expanding `bug❤': Exception()


### Got:
    $ ./hy
    hy 0.10.1 using CPython(default) 2.7.7 on Linux
    => (defmacro bug❤ (x)
    ...   (throw Exception))
    => 
    => (bug❤ foo)
    Traceback (most recent call last):
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 2211, in hy_compile
        result = compiler.compile(tree)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 420, in compile
        ret = self.compile_atom(_type, tree)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 412, in compile_atom
        ret = _compile_table[atom_type](self, atom)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 564, in compile_raw_list
        ret = self._compile_branch(entries)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 451, in _compile_branch
        return _branch(self.compile(expr) for expr in exprs)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 305, in _branch
        results = list(results)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 451, in <genexpr>
        return _branch(self.compile(expr) for expr in exprs)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 432, in compile
        raise_empty(HyCompileError, e, sys.exc_info()[2])
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/_compat.py", line 60, in raise_empty
        raise t(*args)
    HyCompileError: Internal Compiler Bug 😱
    ⤷ UnicodeEncodeError: 'ascii' codec can't encode character u'\u2764' in position 3: ordinal not in range(128)
    Compilation traceback:
    File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 420, in compile
        ret = self.compile_atom(_type, tree)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 412, in compile_atom
        ret = _compile_table[atom_type](self, atom)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/compiler.py", line 1724, in compile_expression
        expression = macroexpand(expression, self.module_name)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/macros.py", line 174, in macroexpand
        tree = macroexpand_1(tree, module_name)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/macros.py", line 203, in macroexpand_1
        msg = "expanding `" + str(tree[0]) + "': " + repr(e)
    => 

## Command line args error

    $ ./hy -c '(defn bug❤ (x) 0)' # all unicode stuff is borked
    Traceback (most recent call last):
      File "./hy", line 9, in <module>
        load_entry_point('hy==0.10.1', 'console_scripts', 'hy')()
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/cmdline.py", line 334, in hy_main
        sys.exit(cmdline_handler("hy", sys.argv))
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/cmdline.py", line 304, in cmdline_handler
        return run_command(options.command)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/cmdline.py", line 180, in run_command
        import_buffer_to_module("__main__", source)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/importer.py", line 89, in import_buffer_to_module
        _ast = import_buffer_to_ast(buf, module_name)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/importer.py", line 58, in import_buffer_to_ast
        return hy_compile(import_buffer_to_hst(buf), module_name)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/importer.py", line 47, in import_buffer_to_hst
        return tokenize(buf + "\n")
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/lex/__init__.py", line 33, in tokenize
        return parser.parse(lexer.lex(buf))
      File "/home/user/.local/lib64/python2.7/site-packages/rply/parser.py", line 22, in parse
        current_state = self._reduce_production(t, symstack, statestack, state)
      File "/home/user/.local/lib64/python2.7/site-packages/rply/parser.py", line 76, in _reduce_production
        value = p.func(targ)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/lex/parser.py", line 52, in wrapped
        ret = fun(p)
      File "/home/user/.local/lib64/python2.7/site-packages/hy-0.10.1-py2.7.egg/hy/lex/parser.py", line 287, in t_identifier
        return HySymbol(obj)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3: ordinal not in range(128)