### PR TITLE
Fix error when 'let' context contains a non-symbol non-list

### DIFF
--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -58,7 +58,9 @@
        (if (!= (len variable) 2)
          (macro-error variable "let variable assignments must contain two items"))
        (.append macroed-variables `(setv ~(get variable 0) ~(get variable 1))))
-      (.append macroed-variables `(setv ~variable None))))
+      (if (isinstance variable HySymbol)
+        (.append macroed-variables `(setv ~variable None))
+        (macro-error variable "let lexical context element must be a list or symbol"))))
   `((fn []
      ~@macroed-variables
      ~@body)))

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -328,6 +328,24 @@ def test_ast_invalid_for():
     cant_compile("(for* [a 1] (else 1 2))")
 
 
+def test_ast_valid_let():
+    "Make sure AST can compile valid let"
+    can_compile("(let [])")
+    can_compile("(let [a b])")
+    can_compile("(let [[a 1]])")
+    can_compile("(let [[a 1] b])")
+
+
+def test_ast_invalid_let():
+    "Make sure AST can't compile invalid let"
+    cant_compile("(let 1)")
+    cant_compile("(let [1])")
+    cant_compile("(let [[a 1 2]])")
+    cant_compile("(let [[]])")
+    cant_compile("(let [[a]])")
+    cant_compile("(let [[1]])")
+
+
 def test_ast_expression_basics():
     """ Ensure basic AST expression conversion works. """
     code = can_compile("(foo bar)").body[0]


### PR DESCRIPTION
Currently, attempting to use the 'let' macro with a lexical context containing an element which is neither a list nor a symbol generates an internal compiler error. For example,

```
=> (let [1])
```

Generates

```
hy.errors.HyCompileError: Internal Compiler Bug 😱
⤷ TypeError: Can't assign / delete a <class '_ast.Num'> object
```

This change calls 'macro-error' if the user attempts to use such a context.
