### PR TITLE
Shadow assoc

### DIFF
--- a/hy/core/shadow.hy
+++ b/hy/core/shadow.hy
@@ -60,5 +60,9 @@
         (operator.truediv 1 (get args 0))
         (reduce operator.truediv args)))))
 
+(defn assoc [seq key value]
+  "Shadow assoc for when we need to import / map it against something"
+  (assoc seq key value))
 
-(setv *exports* ['+ '- '* '/])
+
+(setv *exports* ['+ '- '* '/ 'assoc])

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -264,6 +264,15 @@
              "a b c d e")))
 
 
+(defn test-apply-with-shadows []
+  "NATIVE: test apply to call shadowed operators"
+  (assert (= (apply + [1 2]) 3))
+  (assert (= (apply - [1 2]) -1))
+  (setv d {})
+  (apply assoc [d 123 456])
+  (assert (= (get assoc 123) 456)))
+
+
 (defn test-dotted []
   "NATIVE: test dotted invocation"
   (assert (= (.join " " ["one" "two"]) "one two")))


### PR DESCRIPTION
This merges paultag's branch that fixes apply with shadowed operators and adds tests, as well as shadowing assoc.

This #724 and #647.