### PR TITLE
Proper tail recursion

### DIFF
--- a/docs/contrib/future.rst
+++ b/docs/contrib/future.rst
@@ -1,0 +1,69 @@
+==========
+__future__ features
+==========
+
+.. versionadded:: 0.10.2
+
+Importing from ``__future__`` allows you to add features to
+Hy that are not yet in the main language, due to slowing or
+being harder to debug.
+   
+
+.. _tailrec:
+
+
+``TailRec``
+===========
+
+The ``(import [__future__ [TailRec]])`` command
+gives programmers a simple way to use tail-call optimization
+(TCO) in their Hy code, even for mutually recursive functions.
+
+    A tail call is a subroutine call that happens inside another
+    procedure as its final action; it may produce a return value which
+    is then immediately returned by the calling procedure. If any call
+    that a subroutine performs, such that it might eventually lead to
+    this same subroutine being called again down the call chain, is in
+    tail position, such a subroutine is said to be tail-recursive,
+    which is a special case of recursion. Tail calls are significant
+    because they can be implemented without adding a new stack frame
+    to the call stack. Most of the frame of the current procedure is
+    not needed any more, and it can be replaced by the frame of the
+    tail call. The program can then jump to the called
+    subroutine. Producing such code instead of a standard call
+    sequence is called tail call elimination, or tail call
+    optimization. Tail call elimination allows procedure calls in tail
+    position to be implemented as efficiently as goto statements, thus
+    allowing efficient structured programming.
+
+    -- Wikipedia (http://en.wikipedia.org/wiki/Tail_call)
+
+Example:
+
+.. code-block:: hy
+   
+    (import [__future__ [TailRec]])
+
+    (defn fact [n]
+      (defn facthelper [n acc]
+        (if (= n 0)
+            acc
+            (facthelper (- n 1) (* n acc))))
+      (do
+        (print "Using fact!")
+        (facthelper n 1)))
+
+    (print (fact 10000))
+
+    (defn odd [n]
+      (if (= n 0)
+          False
+          (even (- n 1))))
+
+    (defn even [n]
+      (if (= n 0)
+          True
+          (odd (- n 1))))
+
+    (print (even 1000))
+

--- a/docs/contrib/future.rst
+++ b/docs/contrib/future.rst
@@ -17,7 +17,8 @@ being harder to debug.
 
 The ``(import [__future__ [TailRec]])`` command
 gives programmers a simple way to use tail-call optimization
-(TCO) in their Hy code, even for mutually recursive functions.
+(TCO) in their Hy code, with no need for trampoline or recur.
+Supports mutually recursive functions.
 
     A tail call is a subroutine call that happens inside another
     procedure as its final action; it may produce a return value which

--- a/docs/contrib/index.rst
+++ b/docs/contrib/index.rst
@@ -10,3 +10,4 @@ Contents:
    anaphoric
    loop
    multi
+   future

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1984,7 +1984,7 @@ class HyASTCompiler(object):
                 body += body.expr_as_stmt()
             else:
                 if self.tail_rec:
-                    expression[-1], changed = self.makeTailRec(expression[-1])
+                    expression[-1], changed = self.make_tail_rec(expression[-1])
                     if changed:
                         new_expression = HyExpression([
                             HySymbol("with_decorator"),
@@ -2021,32 +2021,32 @@ class HyASTCompiler(object):
 
         return ret
 
-    def exprToTailCall(self, expr):
+    def expr_to_tail_call(self, expr):
         "Takes an expression, and returns a TailCall of that expression"
         return HyExpression([
             HySymbol("raise"),
             HyExpression([HySymbol("HyTailCall")] + expr),
         ]).replace(expr)
 
-    def makeTailRec(self, body):
+    def make_tail_rec(self, body):
         """ Takes the body of an expression, and returns a tail recursive
             TailCall form of the body """
         if isinstance(body, HyExpression):
             # Only compile expression, names and symbols should just stand
             if body[0] == "if":
-                body[2], changed2 = self.makeTailRec(body[2])
+                body[2], changed2 = self.make_tail_rec(body[2])
                 changed3 = False
                 if len(body) == 4:
-                    body[3], changed3 = self.makeTailRec(body[3])
+                    body[3], changed3 = self.make_tail_rec(body[3])
                 return body, (changed2 or changed3)
             if body[0] == "progn" or body[0] == "do":
-                body[-1], changed = self.makeTailRec(body[-1])
+                body[-1], changed = self.make_tail_rec(body[-1])
                 return body, changed
             elif body[0] in _compile_table.keys():
                 # Bail on all keywords in hy and other special forms
                 return body, False
             else:
-                return self.exprToTailCall(body), True
+                return self.expr_to_tail_call(body), True
         return body, False
 
     @builds("defclass")

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -363,6 +363,7 @@ class HyASTCompiler(object):
     def __init__(self, module_name):
         self.anon_fn_count = 0
         self.anon_var_count = 0
+        self.tail_rec = False
         self.imports = defaultdict(set)
         self.module_name = module_name
         if not module_name.startswith("hy.core"):
@@ -1085,6 +1086,12 @@ class HyASTCompiler(object):
         while len(expr) > 0:
             iexpr = expr.pop(0)
 
+            if iexpr[0] == "__future__" and "TailRec" in iexpr[1]:
+                self.tail_rec = True
+                TRInd = iexpr[1].index("TailRec")
+                iexpr[1].pop(TRInd)
+                if(len(iexpr[1]) == 0):
+                    continue
             if not isinstance(iexpr, (HySymbol, HyList)):
                 raise HyTypeError(iexpr, "(import) requires a Symbol "
                                   "or a List.")
@@ -1944,6 +1951,17 @@ class HyASTCompiler(object):
             if body.contains_yield:
                 body += body.expr_as_stmt()
             else:
+                if self.tail_rec:
+                    expression[-1], changed = self.makeTailRec(expression[-1])
+                    if changed:
+                        new_expression = HyExpression([
+                            HySymbol("with_decorator"),
+                            HySymbol("HyTailRec"),
+                            HyExpression([
+                                called_as,
+                                arglist] + expression)
+                        ]).replace(expression)
+                        return self.compile(new_expression)
                 body += ast.Return(value=body.expr,
                                    lineno=body.expr.lineno,
                                    col_offset=body.expr.col_offset)
@@ -1970,6 +1988,34 @@ class HyASTCompiler(object):
         ret += Result(expr=ast_name, temp_variables=[ast_name, ret.stmts[-1]])
 
         return ret
+
+    def exprToTailCall(self, expr):
+        "Takes an expression, and returns a TailCall of that expression"
+        return HyExpression([
+            HySymbol("raise"),
+            HyExpression([HySymbol("HyTailCall")] + expr),
+        ]).replace(expr)
+
+    def makeTailRec(self, body):
+        """ Takes the body of an expression, and returns a tail recursive
+            TailCall form of the body """
+        if isinstance(body, HyExpression):
+            # Only compile expression, names and symbols should just stand
+            if body[0] == "if":
+                body[2], changed2 = self.makeTailRec(body[2])
+                changed3 = False
+                if len(body) == 4:
+                    body[3], changed3 = self.makeTailRec(body[3])
+                return body, (changed2 or changed3)
+            if body[0] == "progn" or body[0] == "do":
+                body[-1], changed = self.makeTailRec(body[-1])
+                return body, changed
+            elif body[0] in _compile_table.keys():
+                # Bail on all keywords in hy and other special forms
+                return body, False
+            else:
+                return self.exprToTailCall(body), True
+        return body, False
 
     @builds("defclass")
     @checkargs(min=1)

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1984,7 +1984,8 @@ class HyASTCompiler(object):
                 body += body.expr_as_stmt()
             else:
                 if self.tail_rec:
-                    expression[-1], changed = self.make_tail_rec(expression[-1])
+                    expression[-1], changed = self.make_tail_rec(
+                        expression[-1])
                     if changed:
                         new_expression = HyExpression([
                             HySymbol("with_decorator"),

--- a/hy/core/__init__.py
+++ b/hy/core/__init__.py
@@ -1,4 +1,5 @@
 STDLIB = [
     "hy.core.language",
+    "hy.core.tailrec",
     "hy.core.shadow"
 ]

--- a/hy/core/tailrec.hy
+++ b/hy/core/tailrec.hy
@@ -1,0 +1,30 @@
+
+(defclass HyTailCall [Exception]
+  "An exeception to implement Proper Tail Recursion"
+  [[--init--
+    (fn [self __TCFunc &rest args &kwargs kwargs]
+       (setv self.func __TCFunc)
+       (setv self.args args)
+       (setv self.kwargs kwargs)
+      nil)]])
+
+(defn HyTailRec [func]
+  """A decorator that takes functions that end in raise HyTailCall(func, *args, **kwargs)
+     and makes them tail recursive"""
+  (if (hasattr func "__nonTCO")
+      func
+      (do
+       (defn funcwrapper [&rest args &kwargs kwargs]
+        (setv funcwrapper.__nonTCO func)
+        (setv tc (apply HyTailCall (cons func (list args)) kwargs))
+        (while True
+          (try (if (hasattr tc.func "__nonTCO")
+                       (setv ret (apply tc.func.__nonTCO (list tc.args) tc.kwargs))
+                       (setv ret (apply tc.func (list tc.args) tc.kwargs)))
+               (catch [err HyTailCall]
+                 (setv tc err))
+               (else (break))))
+        ret)
+       funcwrapper)))
+
+(setv *exports* '[HyTailCall HyTailRec])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,6 +20,7 @@ from .native_tests.contrib.meth import *  # noqa
 from .native_tests.contrib.walk import *  # noqa
 from .native_tests.contrib.multi import *  # noqa
 from .native_tests.contrib.curry import *  # noqa
+from .native_tests.tailrec import *  # noqa
 
 if PY3:
     from .native_tests.py3_only_tests import *  # noqa

--- a/tests/native_tests/tailrec.hy
+++ b/tests/native_tests/tailrec.hy
@@ -17,8 +17,3 @@
                 (facthelper (- n 1) (* n acc))))
          (facthelper n 1))
         (assert (< 0 (fact 1000)))))
-
-
-
-
-

--- a/tests/native_tests/tailrec.hy
+++ b/tests/native_tests/tailrec.hy
@@ -1,0 +1,24 @@
+(import [__future__ [TailRec]])
+
+(defn test-mutualtailrec []
+    "Testing whether tail recursion in mutually recursive functions work"
+    (do
+        (defn tcodd [n] (if (= n 0) False (tceven (- n 1))))
+        (defn tceven [n] (if (= n 0) True (tcodd (- n 1))))
+        (assert (tceven 1000))))
+
+(defn test-selfrecur []
+    "Testing whether tail recusion in self recursive functions work"
+    (do
+        (defn fact [n]
+         (defn facthelper [n acc]
+            (if (= n 0)
+                acc
+                (facthelper (- n 1) (* n acc))))
+         (facthelper n 1))
+        (assert (< 0 (fact 1000)))))
+
+
+
+
+


### PR DESCRIPTION
I've added support for Proper tail recursion in Hy. It's optional, and can be enabled with an

    (import [__future__ [TailRec]])

in the Hy source where it is needed. Benefits can be seen for example in the tests, where we can use *mutual recursive* functions (not just self recurring, as the current loop macro implements) on much larger   values without hitting a recursion depth exceeded exception.

Needs a little more work before it can be in Hy proper, as it does not work while bootstrapping (since the TailCall mechanism itself is written in Hy).