### PR TITLE
Add support for 'exec' when running on python2

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2138,6 +2138,27 @@ class HyASTCompiler(object):
 
         return self.compile(expr)
 
+    if not PY3:
+        @builds("exec")
+        @checkargs(min=1, max=3)
+        def compile_exec(self, expression):
+            expression.pop(0)  # "exec"
+            body = self.compile(expression.pop(0)).expr
+            if len(expression) > 0:
+                global_vars = self.compile(expression.pop(0)).expr
+                if len(expression) > 0:
+                    local_vars = self.compile(expression.pop(0)).expr
+                else:
+                    local_vars = None
+            else:
+                global_vars = local_vars = None
+            ret = ast.Exec(lineno=expression.start_line,
+                           col_offset=expression.start_column,
+                           body=body,
+                           globals=global_vars,
+                           locals=local_vars)
+            return ret
+
     @builds("eval_and_compile")
     def compile_eval_and_compile(self, expression):
         expression[0] = HySymbol("progn")

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -810,6 +810,23 @@
       (do
        (if false false false)))))
 
+(defn test-exec []
+  "NATIVE: test exec"
+  ;; python2 'exec' affects local scope by default, but python3
+  ;; affects a local dictionary argument
+  (if-python2
+   (do
+     (exec "test_val=1")
+     (assert (= test-val 1))
+     (exec "def test_fun(): return 10")
+     (assert (= (test-fun) 10)))
+   ())
+  ;; The local dict form should work for python2 and 3
+  (setv local-dict (locals))
+  (exec "other_val=1" (globals) local-dict)
+  (assert (= 1 (get local-dict "other_val")))
+  (exec "def other_fun(): return 10" (globals) local-dict)
+  (assert (= 10 ((get local-dict "other_fun")))))
 
 (defn test-eval []
   "NATIVE: test eval"


### PR DESCRIPTION
`exec` is a statement in python 2, so this adds a special case in the compiler to handle it. Fixes #749. Generally there is a discrepancy between `exec` and `eval` in hy. The former evaluates python expressions while the latter evaluates quoted s-expressions. If `exec` is the standard way to execute python (without a separate module), perhaps a note of this should be added to the docs. I would be happy to add that to this PR if that would be appropriate.

One interesting possibility would be to extend `eval` to evaluate strings as python expressions while maintaining its current behavior. This would not break any existing code, but would allow eval to work as a python programming would expect.