### PR TITLE
Fix typos in tutorial docs

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -337,7 +337,7 @@ which is equivalent to::
   with open("/tmp/data.in") as f:
       print f.read()
 
-And yes, we do have Lisp comprehensions!  In Python you might do::
+And yes, we do have List comprehensions!  In Python you might do::
 
   odds_squared = [
     pow(num, 2)


### PR DESCRIPTION
1. It was mistyped as lisP comprehensions instead of lisT comprehensions (Unless it was intended as a pun :wink:)

> ~~2. Function was defined as `optional-arg` but used as `optional_arg`~~

Reverted this change after discussions with @theanalyst and @berkerpeksag 