### PR TITLE
move imports and operators to satisfy new version of pep8 checker

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -692,8 +692,9 @@ class HyASTCompiler(object):
         expr.pop(0)
 
         ret = self.compile(HyExpression(
-            [HySymbol("hy_eval")] + expr + [HyExpression([HySymbol("locals")])]
-            + [HyString(self.module_name)]).replace(expr)
+            [HySymbol("hy_eval")] + expr +
+            [HyExpression([HySymbol("locals")])] +
+            [HyString(self.module_name)]).replace(expr)
         )
 
         ret.add_imports("hy.importer", ["hy_eval"])

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -25,11 +25,15 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import contextlib
 import os
 import re
 import sys
-from contextlib import contextmanager
-from hy._compat import string_types
+
+import hy.macros
+import hy.compiler
+from hy._compat import builtins, string_types
+
 
 docomplete = True
 
@@ -47,12 +51,6 @@ if sys.platform == 'darwin' and 'libedit' in readline.__doc__:
     readline_bind = "bind ^I rl_complete"
 else:
     readline_bind = "tab: complete"
-
-
-import hy.macros
-import hy.compiler
-
-from hy._compat import builtins
 
 
 class Completer(object):
@@ -129,7 +127,7 @@ class Completer(object):
             return None
 
 
-@contextmanager
+@contextlib.contextmanager
 def completion(completer=None):
     delims = "()[]{} "
     if not completer:

--- a/tests/compilers/test_compiler.py
+++ b/tests/compilers/test_compiler.py
@@ -22,15 +22,15 @@
 import ast
 import sys
 
-if sys.version_info[0] <= 2 and sys.version_info[1] <= 6:
-    import unittest2 as unittest
-else:
-    import unittest
-
 from hy import compiler
 from hy.models.expression import HyExpression
 from hy.models.list import HyList
 from hy.models.symbol import HySymbol
+
+if sys.version_info[0] <= 2 and sys.version_info[1] <= 6:
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class CompilerTest(unittest.TestCase):

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -136,8 +136,7 @@ def test_hy2py():
                     continue
                 else:
                     i += 1
-                    ret = run_cmd("hy2py -s -a "
-                                  + os.path.join(dirpath, f))
+                    ret = run_cmd("hy2py -s -a " + os.path.join(dirpath, f))
                     assert ret[0] == 0, f
                     assert len(ret[1]) > 1, f
                     assert len(ret[2]) == 0, f


### PR DESCRIPTION
jcrocholl/pep8 (used by flake8, used in Hy's continuous integration builds) introduced an imports-at-top-of-file check in 1.6.0 and a line-breaks-around-binary-operators check in 1.6.2. This commit makes nonfunctional changes to bring the Hy codebase in compliance with this tool, and should fix #764.

(Alternatively, if the way things were is judged superior, it would surely be possible to configure pep8/flake8 to ignore the specific unwanted warnings.)