### PR TITLE
Code examples in ``assoc'' now get highlighted by Pygments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,3 +60,4 @@
 * Shrayas Rajagopal <shrayasr@gmail.com>
 * Shenyang Zhao <dev@zsy.im>
 * Zack M. Davis <code@zackmdavis.net>
+* Adrià Garriga Alonso <adria@monkingme.com>


### PR DESCRIPTION
And I added myself to AUTHORS.

Not sure if commenting the output, but having it coloured, looks better