### PR TITLE
keyword-only arguments

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -441,6 +441,41 @@ Parameters may have the following keywords in front of them:
         => (zig-zag-sum 1 2 3 4 5 6)
         -3
 
+&kwonly
+    .. versionadded:: 0.12.0
+
+    Parameters that can only be called as keywords. Mandatory
+    keyword-only arguments are declared with the argument's name;
+    optional keyword-only arguments are declared as a two-element list
+    containing the argument name followed by the default value (as
+    with `&optional` above).
+
+    .. code-block:: clj
+
+        => (defn compare [a b &kwonly keyfn [reverse false]]
+        ...  (let [[result (keyfn a b)]]
+        ...    (if (not reverse)
+        ...      result
+        ...      (- result))))
+        => (apply compare ["lisp" "python"]
+        ...        {"keyfn" (fn [x y]
+        ...                   (reduce - (map (fn [s] (ord (first s))) [x y])))})
+        -4
+        => (apply compare ["lisp" "python"]
+        ...        {"keyfn" (fn [x y]
+        ...                   (reduce - (map (fn [s] (ord (first s))) [x y])))
+        ...         "reverse" true})
+        4
+
+    .. code-block:: python
+
+        => (compare "lisp" "python")
+        Traceback (most recent call last):
+          File "<input>", line 1, in <module>
+        TypeError: compare() missing 1 required keyword-only argument: 'keyfn'
+
+    Availability: Python 3.
+
 .. _defn-alias / defun-alias:
 
 defn-alias / defun-alias

--- a/tests/native_tests/py3_only_tests.hy
+++ b/tests/native_tests/py3_only_tests.hy
@@ -10,3 +10,29 @@
   (try (raise ValueError :from NameError)
   (except [e [ValueError]]
     (assert (= (type (. e __cause__)) NameError)))))
+
+
+(defn test-kwonly []
+  "NATIVE: test keyword-only arguments"
+  ;; keyword-only with default works
+  (let [[kwonly-foo-default-false (fn [&kwonly [foo false]] foo)]]
+    (assert (= (apply kwonly-foo-default-false) false))
+    (assert (= (apply kwonly-foo-default-false [] {"foo" true}) true)))
+  ;; keyword-only without default ...
+  (let [[kwonly-foo-no-default (fn [&kwonly foo] foo)]
+        [attempt-to-omit-default (try
+                                  (kwonly-foo-no-default)
+                                  (catch [e [Exception]] e))]]
+    ;; works
+    (assert (= (apply kwonly-foo-no-default [] {"foo" "quux"}) "quux"))
+    ;; raises TypeError with appropriate message if not supplied
+    (assert (isinstance attempt-to-omit-default TypeError))
+    (assert (in "missing 1 required keyword-only argument: 'foo'"
+                (. attempt-to-omit-default args [0]))))
+  ;; keyword-only with other arg types works
+  (let [[function-of-various-args
+         (fn [a b &rest args &kwonly foo &kwargs kwargs]
+           (, a b args foo kwargs))]]
+    (assert (= (apply function-of-various-args
+                      [1 2 3 4] {"foo" 5 "bar" 6 "quux" 7})
+               (, 1 2 (, 3 4)  5 {"bar" 6 "quux" 7})))))


### PR DESCRIPTION
I'll be honest; I'm kind of ashamed that this patch for #453 is the result of crude reasoning-by-analogy to how `&optional` is implemented and experimental observations tinkering with `inspect.getfullargspec` and `compile( ... , ast.PyCF_ONLY_AST)`, rather than a deep, crystal-clear understanding of the theory and implementation of Hy and Python's AST.

On the other hand, it seems to actually work&mdash;
```
(hy) zmd@ExpectedReturn:~/Code/hy/hy$ hy --spy
hy 0.10.1 using CPython(default) 3.4.0 on Linux
=> (defn example [a &kwonly b [c nil]]
...   (print a b c))
def example(a, *, b, c=None):
    return print(a, b, c)
=> (example 1 :b 2 :c 3)
example(1, b=2, c=3)
1 2 3
=> (example 1 :b 2)
example(1, b=2)
1 2 None
=> (example 1)
example(1)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: example() missing 1 required keyword-only argument: 'b'
```
What do you think??

(Tests pass locally on Python 3.4.0; I'll leave it to CI to give a verdict for 3.3. Python 2 lacks the underlying PEP 3102 functionality and isn't supported at time of writing, but if desired, maybe we could treat `&kwonly` args as `**kwargs` in that case and raise a [warning](https://docs.python.org/2/library/warnings.html) that the keyword-only-ness won't be enforced under Python 2?)