### PR TITLE
add support for Python 3.5 infix matrix multiplication

### DIFF
--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -42,6 +42,7 @@ PY27 = sys.version_info >= (2, 7)
 PY3 = sys.version_info[0] >= 3
 PY33 = sys.version_info >= (3, 3)
 PY34 = sys.version_info >= (3, 4)
+PY35 = sys.version_info >= (3, 5)
 
 if PY3:
     str_type = str

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ long_description = """Hy is a Python <--> Lisp layer. It helps
 make things work nicer, and lets Python and the Hy lisp variant play
 nice together. """
 
-install_requires = ['rply>=0.7.0', 'astor>=0.3', 'clint>=0.4']
+install_requires = ['rply>=0.7.0', 'astor>=0.5', 'clint>=0.4']
 if sys.version_info[:2] < (2, 7):
     install_requires.append('argparse>=1.2.1')
     install_requires.append('importlib>=1.0.2')

--- a/tests/native_tests/mathematics.hy
+++ b/tests/native_tests/mathematics.hy
@@ -1,3 +1,5 @@
+(import [hy._compat [PY35]])
+
 (setv square (fn [x]
                (* x x)))
 
@@ -140,3 +142,52 @@
 (defn overflow-int-to-long []
   "NATIVE: test if int does not raise an overflow exception"
   (assert (integer? (+ 1 1000000000000000000000000))))
+
+
+(defclass HyTestMatrix [list]
+  [[--matmul--
+    (fn [self other]
+      (let [[n (len self)]
+            [m (len (. other [0]))]
+            [result []]]
+        (for [i (range m)]
+          (let [[result-row []]]
+            (for [j (range n)]
+              (let [[dot-product 0]]
+                (for [k (range (len (. self [0])))]
+                  (+= dot-product (* (. self [i] [k])
+                                     (. other [k] [j]))))
+                (.append result-row dot-product)))
+            (.append result result-row)))
+        result))]])
+
+(def first-test-matrix (HyTestMatrix [[1 2 3]
+                                      [4 5 6]
+                                      [7 8 9]]))
+
+(def second-test-matrix (HyTestMatrix [[2 0 0]
+                                       [0 2 0]
+                                       [0 0 2]]))
+
+(def product-of-test-matrices (HyTestMatrix [[ 2  4  6]
+                                             [ 8 10 12]
+                                             [14 16 18]]))
+
+(defn test-matmul []
+  "NATIVE: test matrix multiplication"
+  (if PY35
+    (assert (= (@ first-test-matrix second-test-matrix)
+               product-of-test-matrices))
+    ;; Python <= 3.4
+    (let [[matmul-attempt (try (@ first-test-matrix second-test-matrix)
+                               (catch [e [Exception]] e))]]
+      (assert (isinstance matmul-attempt NameError)))))
+
+(defn test-augassign-matmul []
+  "NATIVE: test augmented-assignment matrix multiplication"
+  (let [[matrix first-test-matrix]
+        [matmul-attempt (try (@= matrix second-test-matrix)
+                              (catch [e [Exception]] e))]]
+    (if PY35
+      (assert (= product-of-test-matrices matrix))
+      (assert (isinstance matmul-attempt NameError)))))


### PR DESCRIPTION
*Conditional* on berkerpeksag/astor#17&mdash;

Python 3.5 will have a new commercial-at infix operator with the magic
methods \_\_matmul\_\_, \_\_rmatmul\_\_, and \_\_imatmul\_\_, unused as yet in the
standard library, but intended to represent matrix multiplication in
numerical code; see PEP 465 (https://www.python.org/dev/peps/pep-0465/)
for details. This commit (developed against Python 3.5 alpha 3) brings
support for this operator to Hy when running under Python 3.5 (or,
hypothetically as yet, greater). For Hy under Python <= 3.4, attempting
to use `@` in function-call position currently results in a NameError;
this commit does not change that behavior.

This is intended to resolve #668.