### PR TITLE
Can use lambdas with :keyword argument passing

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -462,6 +462,7 @@ class HyASTCompiler(object):
                     raise HyCompileError(msg.format(kw=str(expr)))
 
                 compiled_value = self.compile(value)
+                ret += compiled_value
 
                 # no unicode for py2 in ast names
                 keyword = str(expr[2:])

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1140,7 +1140,8 @@
   (assert (= (kwtest :key "value") {"key" "value"}))
   (assert (= (kwtest :key-with-dashes "value") {"key_with_dashes" "value"}))
   (assert (= (kwtest :result (+ 1 1)) {"result" 2}))
-  (assert (= (kwtest :key (kwtest :key2 "value")) {"key" {"key2" "value"}})))
+  (assert (= (kwtest :key (kwtest :key2 "value")) {"key" {"key2" "value"}}))
+  (assert (= ((get (kwtest :key (fn [x] (* x 2))) "key") 3) 6)))
 
 (defmacro identify-keywords [&rest elts]
   `(list


### PR DESCRIPTION
As reported in issue #748, there was a bug in which passing a lambda as the value of a :keyword argument would fail—

```
$ hy --spy
hy 0.10.1 using CPython(default) 3.4.0 on Linux
=> (sorted (range 10) :key (fn [x] (- x)))
from hy.core.language import range
sorted(range(10), key=_hy_anon_fn_1)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
NameError: name '_hy_anon_fn_1' is not defined
```

The function call would appear in the generated AST without being preceded by the appropriate function definition corresponding to the anonymous function argument value in the Hy source, causing either a NameError (as in the example above), or erroneous reuse of whatever function was already pointed to by the `_hy_anon_fn_` name referenced in the list of keywords passed to `ast.Call`.

This commit aims to fix the problem by handling it in same way that the expression/statement gap is bridged many other places in the compiler, by adding the compiled value of the keyword argument to the Result object being built during `_compile_collect`, with the understanding that any Python statements implied by the argument value will be appropriately preserved therein.

With this change, the example call above behaves as expected—

```
$ hy --spy
hy 0.10.1 using CPython(default) 3.4.0 on Linux
=> (sorted (range 10) :key (fn [x] (- x)))
from hy.core.language import range

def _hy_anon_fn_1(x):
    return (- x)
sorted(range(10), key=_hy_anon_fn_1)
[9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
```

A new assertion is added to the native `test-keywords` test, which fails as expected against master—

```
======================================================================
ERROR: Check keyword use in function calls
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/zmd/Code/hy/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/zmd/Code/hy/lib/python3.4/site-packages/nose/util.py", line 619, in newfunc
    return func(*arg, **kw)
  File "/home/zmd/Code/hy/hy/tests/native_tests/language.hy", line 1144, in test_keywords
    (assert (= ((get (kwtest :key (fn [x] (* x 2))) "key") 3) 6)))
NameError: name '_hy_anon_fn_167' is not defined
```

but passes with the change to `_compile_collect`.