### PR TITLE
prevent PEP 448 from breaking the world

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1554,12 +1554,28 @@ class HyASTCompiler(object):
             stargs = expr.pop(0)
             if stargs is not None:
                 stargs = self.compile(stargs)
-                ret.expr.starargs = stargs.force_expr
+                if PY35:
+                    stargs_expr = stargs.force_expr
+                    ret.expr.args.append(
+                        ast.Starred(stargs_expr, ast.Load(),
+                                    lineno=stargs_expr.lineno,
+                                    col_offset=stargs_expr.col_offset)
+                    )
+                else:
+                    ret.expr.starargs = stargs.force_expr
                 ret = stargs + ret
 
         if expr:
             kwargs = self.compile(expr.pop(0))
-            ret.expr.kwargs = kwargs.force_expr
+            if PY35:
+                kwargs_expr = kwargs.force_expr
+                ret.expr.keywords.append(
+                    ast.keyword(None, kwargs_expr,
+                                lineno=kwargs_expr.lineno,
+                                col_offset=kwargs_expr.col_offset)
+                )
+            else:
+                ret.expr.kwargs = kwargs.force_expr
             ret = kwargs + ret
 
         return ret

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -4,7 +4,7 @@
         [operator [or_]])
 (import sys)
 
-(import [hy._compat [PY33 PY34]])
+(import [hy._compat [PY33 PY34 PY35]])
 
 (defn test-sys-argv []
   "NATIVE: test sys.argv"
@@ -1047,8 +1047,11 @@
 
 (defn test-disassemble []
   "NATIVE: Test the disassemble function"
-  (assert (= (disassemble '(do (leaky) (leaky) (macros)))
-             "Module(\n    body=[\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[], starargs=None, kwargs=None))])"))
+  (if PY35
+    (assert (= (disassemble '(do (leaky) (leaky) (macros)))
+               "Module(\n    body=[Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[]))])"))
+    (assert (= (disassemble '(do (leaky) (leaky) (macros)))
+               "Module(\n    body=[\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[], starargs=None, kwargs=None))])")))
   (assert (= (disassemble '(do (leaky) (leaky) (macros)) true)
              "leaky()\nleaky()\nmacros()")))
 


### PR DESCRIPTION
Approximately seven hours ago, some AST changes [landed in Python](https://hg.python.org/cpython/rev/a65f685ba8c0) that had some alarming consequences for Hy's behavior, consequences such as this—
```
$ nosetests
..............E..E....E.........E............E......F....F.E...E.........E..E.......................................F............................F..EE..........FF.......................1
.................F.........................
...F..................F..................................................................................................................................FF..FF.

[failure details redacted ...]

Ran 388 tests in 44.353s

FAILED (errors=11, failures=13)
```

—and this—

```
hy 0.10.1 using CPython(default) 3.5.0a4+ on Linux
=> (defn all-the-args [&rest args &kwargs kwargs] (, args kwargs))
=> (apply all-the-args [1 2 3] {"four" 5})
((), {})
```

This pull request proposes the addition of some version conditionals to `compile_apply_expression` to restore sane behavior with bleeding-edge Python.