### PR TITLE
Added `ap-map-whenl` to contrib.

### DIFF
--- a/docs/contrib/anaphoric.rst
+++ b/docs/contrib/anaphoric.rst
@@ -90,6 +90,23 @@ determin when to apply the form.
     => (list (ap-map-when even? (* it 2) [1 2 3 4]))
     [1, 4, 3, 8]
 
+.. _ap-map-whenl:
+
+ap-map-whenl
+===========
+
+Usage: ``(ap-map-whenl predfn rep list)``
+
+As ``ap-map-when``, but takes a predicate in lambda form.
+
+.. code-block:: hy
+
+    => (list (ap-map-whenl (odd? it) (* it 2) [1 2 3 4]))
+    [2, 2, 6, 4]
+
+    => (list (ap-map-when (even? it) (* it 2) [1 2 3 4]))
+    [1, 4, 3, 8]
+
 
 .. _ap-filter:
 

--- a/hy/contrib/anaphoric.hy
+++ b/hy/contrib/anaphoric.hy
@@ -61,6 +61,16 @@
          (yield (f it))
          (yield it)))))
 
+(defmacro ap-map-whenl [predfn rep lst]
+  "Yield elements evaluated for each element in the list when the
+  predicate function returns True."
+  `(let [[f (lambda [it] ~rep)]
+         [predf (lambda [it] ~predfn)]]
+     (for [it ~lst]
+       (if (predf it)
+         (yield (f it))
+         (yield it)))))
+
 
 (defmacro ap-filter [form lst]
   "Yield elements returned when the predicate form evaluates to True."

--- a/tests/native_tests/contrib/anaphoric.hy
+++ b/tests/native_tests/contrib/anaphoric.hy
@@ -63,6 +63,11 @@
   (assert-equal (list (ap-map-when even? (* it 2) [1 2 3 4]))
                 [1 4 3 8]))
 
+(defn test-ap-map-whenl []
+  "NATIVE: testing anaphoric map-when (lambda version)"
+  (assert-equal (list (ap-map-whenl (even? it) (* it 2) [1 2 3 4]))
+                [1 4 3 8]))
+
 (defn test-ap-filter []
   "NATIVE: testing anaphoric filter"
   (assert-equal (list (ap-filter (> it 2) [1 2 3 4]))


### PR DESCRIPTION
Added `ap-map-whenl` as an alternative to `ap-map-when` which takes the predicate in lambda form.

I am ready to abandon this PR if some on can tell me of another way to do this :)

    => (require hy.contrib.anaphoric)
    => (setv foo 2)
    
    ;; doesn't work
    => (list (ap-map-when (= it foo) (* it 2) [1 2 1 2]))
    Traceback (most recent call last):
      File "<input>", line 1, in <module>
      File "<input>", line 1, in _hy_anon_fn_1
    TypeError: 'bool' object is not callable

    ;; works
    => (list (ap-map-whenl (= it foo) (* it 2) [1 2 1 2]))
    [1L, 4L, 1L, 4L]
