### PR TITLE
coroutines with async and await syntax

### DIFF
--- a/eg/asyncio/echo-server.hy
+++ b/eg/asyncio/echo-server.hy
@@ -1,0 +1,29 @@
+;; adapted from the example in PEP 492
+;; https://www.python.org/dev/peps/pep-0492/#working-example
+
+(import asyncio)
+
+(defasync replhy-server []
+  (print "Replhy Server listening on localhost:8000!")
+  (await (asyncio.start-server handle-connection "localhost" 8000)))
+
+(defasync handle-connection [reader writer]
+  (print "New connection ...")
+
+  (while true
+    ;; XXX TODO: make it possible for this to be `(let [[data (await
+    ;; (.read reader 8192))]]` ... and so on. At time of writing,
+    ;; that's a `SyntaxError: 'await' outside async function`
+    ;; (presumably because the Hy `let` binding gets compiled to an
+    ;; ordinary non-async Python function).
+    (setv data (await (.read reader 8192)))
+    (if-not data
+       (break))
+    (print (.format "Sending {:.10}... back!" (repr data)))
+    (.write writer data)))
+
+(defmain [&rest args]
+  (let [[loop (asyncio.get-event-loop)]]
+    (.run-until-complete loop (replhy-server))
+    (try (.run-forever loop)
+         (finally (.close loop)))))

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -49,6 +49,15 @@
   `(setv ~name (fn ~lambda-list ~@body)))
 
 
+(defmacro defasync [name lambda-list &rest body]
+  "define an async function `name` with signature `lambda-list` and body `body`"
+  (if (not (= (type name) HySymbol))
+    (macro-error name "defasync takes a name as first argument"))
+  (if (not (isinstance lambda-list HyList))
+    (macro-error name "defasync takes a parameter list as second argument"))
+  `(setv ~name (async-fn ~lambda-list ~@body)))
+
+
 (defmacro let [variables &rest body]
   "Execute `body` in the lexical context of `variables`"
   (setv macroed_variables [])

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -27,7 +27,7 @@ from hy.compiler import hy_compile
 from hy.errors import HyCompileError, HyTypeError
 from hy.lex.exceptions import LexException
 from hy.lex import tokenize
-from hy._compat import PY3
+from hy._compat import PY3, PY35
 
 import ast
 
@@ -271,6 +271,15 @@ def test_ast_good_yield():
 def test_ast_bad_yield():
     "Make sure AST can't compile invalid yield"
     cant_compile("(yield 1 2)")
+
+
+def test_ast_defasync():
+    """Make sure we can compile async function definitions if Python
+    supports doing so."""
+    if PY35:
+        code = can_compile("(defasync foo [] (await bar))")
+        assert type(code.body[0]) == ast.AsyncFunctionDef
+        assert type(code.body[0].body[0].value) == ast.Await
 
 
 def test_ast_good_import_from():


### PR DESCRIPTION
This pull request proposes preliminary support for [PEP 492](https://www.python.org/dev/peps/pep-0492/) coroutine functions in Hy under Python 3.5+, with a new `async-fn` compiler primitive, a `defasync` macro (corresponding to `async def` in Python), and an `await` expression. This draft at time of writing (46115fc9f) has some limitations: as the comment in the included echo server example (a straightforward port from [the example in the PEP](https://www.python.org/dev/peps/pep-0492/#working-example)) notes, `await` doesn't work inside of `let` bindings; the `async for` and `async with` statments are not yet supported; and getting `hy --spy` to work with the new syntax required some (manual, not part of the commit) tinkering to install [astor](https://github.com/berkerpeksag/astor) from master (which includes some supporting work not yet on PyPI) ... but the basic idea seems sound:

```
(hy35) zmd@ExpectedReturn:~/Code/hy35/hy$ hy --spy
hy 0.11.0 using CPython(default) 3.5.0a4+ on Linux
=> (defasync rah [] (print "rah!"))
async def rah():
    return print('rah!')
=> (rah)
rah()
<coroutine object rah at 0x7f9c1095dc50>
=> 
sys:1: RuntimeWarning: coroutine 'rah' was never awaited
(hy35) zmd@ExpectedReturn:~/Code/hy35/hy$ hy eg/asyncio/echo-server.hy &
[1] 8460
(hy35) zmd@ExpectedReturn:~/Code/hy35/hy$ Replhy Server listening on localhost:8000!

(hy35) zmd@ExpectedReturn:~/Code/hy35/hy$ telnet localhost 8000
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
New connection ...
Hello PEP 492 world
Sending b'Hello PE... back!
Hello PEP 492 world
```
Developed against python/cpython@c4766cf15.