### PR TITLE
Allow specification of global table and module name for (eval ...)

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -639,7 +639,10 @@ doto
 eval
 ----
 
-``eval`` evaluates a quoted expression and returns the value.
+``eval`` evaluates a quoted expression and returns the value. The optional
+second and third arguments specify the dictionary of globals to use and the
+module name. The globals dictionary defaults to ``(local)`` and the module name
+defaults to the name of the current module.
 
 .. code-block:: clj
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -696,15 +696,22 @@ class HyASTCompiler(object):
                           "`%s' can't be used at the top-level" % expr[0])
 
     @builds("eval")
-    @checkargs(exact=1)
+    @checkargs(min=1, max=3)
     def compile_eval(self, expr):
         expr.pop(0)
 
-        ret = self.compile(HyExpression(
-            [HySymbol("hy_eval")] + expr +
-            [HyExpression([HySymbol("locals")])] +
-            [HyString(self.module_name)]).replace(expr)
-        )
+        elist = [HySymbol("hy_eval")] + [expr[0]]
+        if len(expr) >= 2:
+            elist.append(expr[1])
+        else:
+            elist.append(HyExpression([HySymbol("locals")]))
+
+        if len(expr) == 3:
+            elist.append(expr[2])
+        else:
+            elist.append(HyString(self.module_name))
+
+        ret = self.compile(HyExpression(elist).replace(expr))
 
         ret.add_imports("hy.importer", ["hy_eval"])
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -827,6 +827,20 @@
   (assert (= 27 (eval (+ (quote (*)) (* [(quote 3)] 3)))))
   (assert (= None (eval (quote (print ""))))))
 
+(defn test-eval-globals []
+  "NATIVE: test eval with explicit global dict"
+  (assert (= 'bar (eval (quote foo) {'foo 'bar})))
+  (assert (= 1 (let [[d {}]] (eval '(setv x 1) d) (eval (quote x) d))))
+  (let [[d1 {}]
+        [d2 {}]]
+    (eval '(setv x 1) d1)
+    (try
+      (do
+         ; this should fail with a name error
+         (eval (quote x) d2)
+         (assert False "We shouldn't have arrived here"))
+      (catch [e Exception]
+        (assert (isinstance e NameError))))))
 
 (defn test-import-syntax []
   "NATIVE: test the import syntax."


### PR DESCRIPTION
Proof of concept for #809. I need this for a Hy-only nREPL implementation.