### PR TITLE
Documents (left-to-right) order of variable assignments in let expressions

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -988,6 +988,14 @@ used.
     => (let [x [y 5]] (print x y))
     None 5
 
+Note that the variable assignments are executed one by one, from left to right.
+The following example takes advantage of this:
+
+.. code-block:: clj
+
+    => (let [[x 5] [y (+ x 1)]] (print x y))
+    5 6
+
 
 list-comp
 ---------


### PR DESCRIPTION
Also adds an example illustrating this behaviour.