### PR TITLE
Fix anaphoric macro `ap-if`

### DIFF
--- a/hy/contrib/anaphoric.hy
+++ b/hy/contrib/anaphoric.hy
@@ -25,8 +25,9 @@
 ;;; These macros make writing functional programs more concise
 
 
-(defmacro ap-if (test-form &rest args)
-  `(let [[it ~test-form]] (if it ~@args)))
+(defmacro ap-if [test-form then-form &optional else-form]
+  `(let [[it ~test-form]]
+     (if it ~then-form ~else-form)))
 
 
 (defmacro ap-each [lst &rest body]


### PR DESCRIPTION
The updated macro definition explicitly states all mandatory and all optional parameters. Hence, supplying the wrong number of arguments will give a more helpful error message.

I should probably mention that it is exactly the macro definition given in _On Lisp_ by Paul Graham.