### PR TITLE
Adopt a Code of Conduct

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,6 @@
+Contributor Guidelines
+======================
+
 Contributions are welcome & greatly appreciated, every little bit
 helps in making Hy more awesome.
 
@@ -40,3 +43,42 @@ Pull requests are great! We love them; here is a quick guide:
 
 - For documentation & other trivial changes, we're good to merge after one
   ACK. We've got low coverage, so it'd be great to keep that barrier low.
+
+Contributor Code of Conduct
+===========================
+
+As contributors and maintainers of this project, we pledge to respect
+all people who contribute through reporting issues, posting feature
+requests, updating documentation, submitting pull requests or patches,
+and other activities.
+
+We are committed to making participation in this project a
+harassment-free experience for everyone, regardless of level of
+experience, gender, gender identity and expression, sexual
+orientation, disability, personal appearance, body size, race,
+ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of
+sexual language or imagery, derogatory comments or personal attacks,
+trolling, public or private harassment, insults, or other
+unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct. Project
+maintainers who do not follow the Code of Conduct may be removed from
+the project team.
+
+This code of conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its
+community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by opening an issue or contacting one or more of the
+project maintainers.
+
+This Code of Conduct is adapted from the `Contributor Covenant`_,
+version 1.1.0, available at
+http://contributor-covenant.org/version/1/1/0/.
+
+.. _Contributor Covenant: http://contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Project
 * Quickstart: http://hylang.org/en/latest/quickstart.html
 * Bug reports: We have no bugs! Your bugs are your own! (https://github.com/hylang/hy/issues)
 * License: MIT (Expat)
+* Contributor Guidelines & Code of Conduct: https://github.com/hylang/hy/blob/master/CONTRIBUTING.rst


### PR DESCRIPTION
Include the text of the Contributor Covenant (1.1.0) in CONTRIBUTING.rst, and add a link to the document to README.md.
