### PR TITLE
compiler: Fix the keyword argument needs a value exception

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -459,7 +459,7 @@ class HyASTCompiler(object):
                     value = next(exprs_iter)
                 except StopIteration:
                     msg = "Keyword argument {kw} needs a value"
-                    raise HyCompileError(msg.format(kw=str(expr)))
+                    raise HyCompileError(msg.format(kw=str(expr[1:])))
 
                 compiled_value = self.compile(value)
                 ret += compiled_value


### PR DESCRIPTION
When reporting the error that a keyword argument is missing a value, strip the leading \0xfdd0 from the keyword, so it actually prints instead of raising another exception that shadows the former.

Fixes #821.
