### PR TITLE
contrib.walk: Coerce non-list iterables into list form

### DIFF
--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -1,6 +1,6 @@
 ;;; Hy AST walker
 ;;
-;; Copyright (c) 2014  Gergely Nagy <algernon@madhouse-project.org>
+;; Copyright (c) 2014, 2015  Gergely Nagy <algernon@madhouse-project.org>
 ;;
 ;; Permission is hereby granted, free of charge, to any person obtaining a
 ;; copy of this software and associated documentation files (the "Software"),
@@ -37,6 +37,8 @@
                  (inner (rest form))))]
    [(instance? list form)
     ((type form) (outer (HyExpression (map inner form))))]
+   [(coll? form)
+    (walk inner outer (list form))]
    [true (outer form)]))
 
 (defn postwalk [f form]

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -24,6 +24,12 @@
                nil))
     (assert (= acc [walk-form]))))
 
+(defn test-walk-iterators []
+  (let [[acc []]]
+    (assert (= (walk (fn [x] (* 2 x)) (fn [x] x)
+                     (drop 1 [1 [2 [3 [4]]]]))
+               [[2 [3 [4]] 2 [3 [4]]]]))))
+
 (defn test-macroexpand-all []
   (assert (= (macroexpand-all '(with [a b c] (for [d c] foo)))
              '(with* [a] (with* [b] (with* [c] (do (for* [d c] foo))))))))


### PR DESCRIPTION
Expressions can sometimes contain itertools.islice objects, which we can only walk if we force them into a list. To do this, the walk function has to be taught that collections that are not instances of list should be forced into a list.
