### PR TITLE
Make and/or short-circuit

### DIFF
--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -767,7 +767,11 @@
   (let [[and123 (and 1 2 3)]
         [and-false (and 1 False 3)]]
     (assert (= and123 3))
-    (assert (= and-false False))))
+    (assert (= and-false False)))
+  ; short circuiting
+  (setv a 1)
+  (and 0 (setv a 2))
+  (assert (= a 1)))
 
 
 (defn test-or []
@@ -777,7 +781,11 @@
         [or-none-true (or False False)]]
     (assert (= or-all-true 1))
     (assert (= or-some-true "hello"))
-    (assert (= or-none-true False))))
+    (assert (= or-none-true False)))
+  ; short circuiting
+  (setv a 1)
+  (or 1 (setv a 2))
+  (assert (= a 1)))
 
 
 (defn test-if-return-branching []

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -765,9 +765,13 @@
 (defn test-and []
   "NATIVE: test the and function"
   (let [[and123 (and 1 2 3)]
-        [and-false (and 1 False 3)]]
+        [and-false (and 1 False 3)]
+        [and-true (and)]
+        [and-single (and 1)]]
     (assert (= and123 3))
-    (assert (= and-false False)))
+    (assert (= and-false False))
+    (assert (= and-true True))
+    (assert (= and-single 1)))
   ; short circuiting
   (setv a 1)
   (and 0 (setv a 2))
@@ -778,10 +782,14 @@
   "NATIVE: test the or function"
   (let [[or-all-true (or 1 2 3 True "string")]
         [or-some-true (or False "hello")]
-        [or-none-true (or False False)]]
+        [or-none-true (or False False)]
+        [or-false (or)]
+        [or-single (or 1)]]
     (assert (= or-all-true 1))
     (assert (= or-some-true "hello"))
-    (assert (= or-none-true False)))
+    (assert (= or-none-true False))
+    (assert (= or-false nil))
+    (assert (= or-single 1)))
   ; short circuiting
   (setv a 1)
   (or 1 (setv a 2))


### PR DESCRIPTION
This basically wraps statements into a function call. It *only* wraps statements, so `(and 1 1)` will still be compiled to just `1 and 1`.

Closes #233 and #766.
