### PR TITLE
Start of working relative imports

### DIFF
--- a/hy/importer.py
+++ b/hy/importer.py
@@ -196,14 +196,23 @@ class MetaLoader(object):
 
 
 class MetaImporter(object):
+
+    modules = []
+
+
     def find_on_path(self, fullname):
         fls = ["%s/__init__.hy", "%s.hy"]
         dirpath = "/".join(fullname.split("."))
+        self.modules.append(dirpath)
 
         for pth in sys.path:
             pth = os.path.abspath(pth)
             for fp in fls:
                 composed_path = fp % ("%s/%s" % (pth, dirpath))
+                if os.path.exists(composed_path):
+                    return composed_path
+            for mod in self.modules:
+                composed_path = fp % ("%s%s" % (mod, dirpath))
                 if os.path.exists(composed_path):
                     return composed_path
 

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -82,7 +82,7 @@ def import_file_to_module(module_name, fpath):
                 e.source = fp.read()
             e.filename = fpath
         raise
-    except Exception:
+    except Exception as e:
         sys.modules.pop(module_name, None)
         raise
     return mod
@@ -188,10 +188,20 @@ class MetaLoader(object):
         if ispkg:
             mod.__path__ = []
             mod.__package__ = fullname
+        if fullname[0] == ".":
+            mod.__name__ = "something.test1"
+            mod.__package__ = os.path.dirname(self.path).split("/")[-1]
         else:
             mod.__package__ = fullname.rpartition('.')[0]
 
+
         sys.modules[fullname] = mod
+        print("----")
+        print(fullname)
+        print(dir(mod))
+        print(sys.modules[fullname].__name__)
+        print(sys.modules[fullname].__file__)
+        print(sys.modules[fullname].__package__)
         return mod
 
 
@@ -214,7 +224,7 @@ class MetaImporter(object):
             for mod in self.modules:
                 composed_path = fp % ("%s%s" % (mod, dirpath))
                 if os.path.exists(composed_path):
-                    return composed_path
+                    return os.path.realpath(composed_path)
 
     def find_module(self, fullname, path=None):
         path = self.find_on_path(fullname)


### PR DESCRIPTION
The hack is essentially to store any modules we have looked at before and use it as a backup solution. Not the best solution, but out of ideas.

Currently there is a bug that i'm not able to debug, but it sort-off works tho.
```
heyho
Nope
Traceback (most recent call last):
  File "/home/fox/.virtualenvs/hy/bin/hy", line 9, in <module>
    load_entry_point('hy==0.11.0', 'console_scripts', 'hy')()
  File "/home/fox/.virtualenvs/hy/lib/python3.4/site-packages/hy-0.11.0-py3.4.egg/hy/cmdline.py", line 347, in hy_main
    sys.exit(cmdline_handler("hy", sys.argv))
  File "/home/fox/.virtualenvs/hy/lib/python3.4/site-packages/hy-0.11.0-py3.4.egg/hy/cmdline.py", line 335, in cmdline_handler
    return run_file(options.args[0])
  File "/home/fox/.virtualenvs/hy/lib/python3.4/site-packages/hy-0.11.0-py3.4.egg/hy/cmdline.py", line 210, in run_file
    import_file_to_module("__main__", filename)
  File "/home/fox/.virtualenvs/hy/lib/python3.4/site-packages/hy-0.11.0-py3.4.egg/hy/importer.py", line 80, in import_file_to_module
    eval(ast_compile(_ast, fpath, "exec"), mod.__dict__)
  File "main.hy", line 1, in <module>
    (import something)
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1191, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1161, in _load_backward_compatible
  File "/home/fox/.virtualenvs/hy/lib/python3.4/site-packages/hy-0.11.0-py3.4.egg/hy/importer.py", line 184, in load_module
    self.path)
  File "/home/fox/.virtualenvs/hy/lib/python3.4/site-packages/hy-0.11.0-py3.4.egg/hy/importer.py", line 80, in import_file_to_module
    eval(ast_compile(_ast, fpath, "exec"), mod.__dict__)
  File "/home/fox/tmp/importtest/something/__init__.hy", line 2, in <module>
    (import .test2)
ValueError: Empty module name
```

Dir structure
```
λ fox@hackbook importtest » ls  
heyho.hy  main.hy  something

λ fox@hackbook importtest » cat main.hy 
(import something)

λ fox@hackbook importtest » cat heyho.hy 
(print "Nope")

λ fox@hackbook importtest » cat something/__init__.hy 
(import heyho)
(import .test2)

λ fox@hackbook importtest » cat something/test2.hy
(print "Wehey!")
```

Other ideas for getting around relative imports?
