### PR TITLE
Explicitly set missing source on LexExceptions

### DIFF
--- a/hy/lex/__init__.py
+++ b/hy/lex/__init__.py
@@ -35,3 +35,7 @@ def tokenize(buf):
         pos = e.getsourcepos()
         raise LexException("Could not identify the next token.",
                            pos.lineno, pos.colno)
+    except LexException as e:
+        if e.source is None:
+            e.source = buf
+        raise


### PR DESCRIPTION
This repairs things like the following:

    (import [hy.lex [tokenize]])
    (tokenize "(foo))")

Without this patch, the lexer exception thrown by `tokenize` is unprintable because of the missing source reference.