### PR TITLE
Make `read` read line-wise and don't ignore lexer errors

### DIFF
--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -371,13 +371,13 @@
    Can take a given input buffer to read from"
   (def buff "")
   (while true
-    (def inn (str (.read from-file 1)))
+    (def inn (str (.readline from-file)))
     (if (= inn eof)
       (throw (EOFError "Reached end of file" )))
     (setv buff (+ buff inn))
     (try
       (def parsed (first (tokenize buff)))
-      (except [e [LexException PrematureEndOfInput IndexError]])
+      (except [e [PrematureEndOfInput IndexError]])
       (else (if parsed (break)))))
     parsed)
 


### PR DESCRIPTION
This allows us to react to things like "(foo))" being passed in instead of
looping until kingdom come. Also makes tokenizing things that are not
expressions easier:

    => (read)
    "foo"
    u'foo'
    =>