### PR TITLE
Allow 'for' and 'cond' to take a multi-expression body

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -267,11 +267,10 @@ is only called on every other value in the list.
     ;; collection is a list of numerical values
 
     (for [x collection]
-      (do
-        (side-effect1 x)
-        (if (% x 2)
-          (continue))
-        (side-effect2 x)))
+      (side-effect1 x)
+      (if (% x 2)
+        (continue))
+      (side-effect2 x))
 
 
 dict-comp

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -73,10 +73,11 @@
     "check `cond` branch for validity, return the corresponding `if` expr"
     (if (not (= (type branch) HyList))
       (macro-error branch "cond branches need to be a list"))
-    (if (!= (len branch) 2)
-      (macro-error branch "cond branches need two items: a test and a code branch"))
-    (setv (, test thebranch) branch)
-    `(if ~test ~thebranch))
+    (if (< (len branch) 2)
+      (macro-error branch "cond branches need at least two items: a test and one or more code branches"))
+    (setv test (car branch))
+    (setv thebranch (cdr branch))
+    `(if ~test (do ~@thebranch)))
 
   (setv root (check-branch branch))
   (setv latest-branch root)
@@ -96,14 +97,14 @@
   (for* [x foo]
     (for* [y bar]
       baz))"
-  (cond 
+  (cond
    [(odd? (len args))
     (macro-error args "`for' requires an even number of args.")]
    [(empty? body)
     (macro-error None "`for' requires a body to evaluate")]
    [(empty? args) `(do ~@body)]
-   [(= (len args) 2)  `(for* [~@args] ~@body)]
-   [true 
+   [(= (len args) 2)  `(for* [~@args] (do ~@body))]
+   [true
     (let [[alist (slice args 0 nil 2)]]
       `(for* [(, ~@alist) (genexpr (, ~@alist) [~@args])] ~@body))]))
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -97,16 +97,21 @@
   (for* [x foo]
     (for* [y bar]
       baz))"
+  (setv body (list body))
+  (setv lst (get body -1))
+  (setv belse (if (and (isinstance lst HyExpression) (= (get lst 0) "else"))
+                [(body.pop)]
+                []))
   (cond
    [(odd? (len args))
     (macro-error args "`for' requires an even number of args.")]
    [(empty? body)
     (macro-error None "`for' requires a body to evaluate")]
-   [(empty? args) `(do ~@body)]
-   [(= (len args) 2)  `(for* [~@args] (do ~@body))]
+   [(empty? args) `(do ~@body ~@belse)]
+   [(= (len args) 2) `(for* [~@args] (do ~@body) ~@belse)]
    [true
     (let [[alist (slice args 0 nil 2)]]
-      `(for* [(, ~@alist) (genexpr (, ~@alist) [~@args])] ~@body))]))
+      `(for* [(, ~@alist) (genexpr (, ~@alist) [~@args])] (do ~@body) ~@belse))]))
 
 
 (defmacro -> [head &rest rest]

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -32,7 +32,7 @@
 
 
 (defmacro with [args &rest body]
-  "shorthand for nested for* loops:
+  "shorthand for nested with* loops:
   (with [[x foo] [y bar]] baz) ->
   (with* [x foo]
     (with* [y bar]

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -32,4 +32,4 @@
 
 (defn test-macroexpand-all []
   (assert (= (macroexpand-all '(with [a b c] (for [d c] foo)))
-             '(with* [a] (with* [b] (with* [c] (do (for* [d c] foo))))))))
+             '(with* [a] (with* [b] (with* [c] (do (for* [d c] (do foo)))))))))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -86,10 +86,12 @@
 
 (defn test-for-loop []
   "NATIVE: test for loops"
-  (setv count 0)
+  (setv count1 0 count2 0)
   (for [x [1 2 3 4 5]]
-    (setv count (+ count x)))
-  (assert (= count 15))
+    (setv count1 (+ count1 x))
+    (setv count2 (+ count2 x)))
+  (assert (= count1 15))
+  (assert (= count2 15))
   (setv count 0)
   (for [x [1 2 3 4 5]
         y [1 2 3 4 5]]
@@ -224,7 +226,7 @@
   "NATIVE: test if cond sorta works."
   (cond
    [(= 1 2) (assert (is true false))]
-   [(is null null) (assert (is true true))]))
+   [(is null null) (setv x true) (assert x)]))
 
 
 (defn test-index []

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -95,8 +95,10 @@
   (setv count 0)
   (for [x [1 2 3 4 5]
         y [1 2 3 4 5]]
-    (setv count (+ count x y)))
-  (assert (= count 150))
+    (setv count (+ count x y))
+    (else
+      (+= count 1)))
+  (assert (= count 151))
   (assert (= (list ((fn [] (for [x [[1] [2 3]] y x] (yield y)))))
              (list-comp y [x [[1] [2 3]] y x])))
   (assert (= (list ((fn [] (for [x [[1] [2 3]] y x z (range 5)] (yield z)))))


### PR DESCRIPTION
I also fixed a slight docstring slip-up. Ref. #868.
