### PR TITLE
Partition

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,4 @@
 * Nicolas Pénet <z.nicolas@gmail.com>
 * Adrià Garriga Alonso <adria@monkingme.com>
 * Antony Woods <antony@teamwoods.org>
+* Matthew Egan Odendahl <github.gilch@xoxy.net>

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -674,6 +674,20 @@ Returns ``True`` if *x* is odd. Raises ``TypeError`` if
 
 .. _pos?-fn:
 
+partition
+---------
+
+Usage: ``(partition n coll)``
+
+Chunks coll into tuples of length n. The remainder, if any, is not included.
+
+.. code-block:: hy
+
+   => (list (partition 3 (range 10)))
+   [(0, 1, 2), (3, 4, 5), (6, 7, 8)]
+
+.. _partition-fn:
+
 pos?
 ----
 

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -314,6 +314,10 @@
   (_numeric-check n)
   (= (% n 2) 1))
 
+(defn partition [n coll]
+  "Chunks coll into tuples of length n. The remainder, if any, is not included."
+  (apply zip (* n (, (iter coll)))))
+
 (defn pos? [n]
   "Return true if n is > 0"
   (_numeric_check n)
@@ -423,12 +427,12 @@
         (hyify (. value __name__))
         (catch [] (string value))))))
 
-(def *exports* '[butlast calling-module-name coll? cons cons? cycle
-                 dec distinct disassemble drop drop-last drop-while empty? even?
-                 every? first filter filterfalse flatten float? fraction gensym
-                 identity inc input instance? integer integer? integer-char?
-                 interleave interpose iterable? iterate iterator? keyword
-                 keyword? last list* macroexpand macroexpand-1 map merge-with
-                 name neg? nil? none? nth numeric? odd? pos? range read read-str
-                 remove repeat repeatedly rest reduce second some string string?
-                 symbol? take take-nth take-while zero? zip zip_longest zipwith])
+(def *exports*
+  '[butlast calling-module-name coll? cons cons? cycle dec distinct disassemble
+    drop drop-last drop-while empty? even? every? first filter filterfalse
+    flatten float? fraction gensym identity inc input instance? integer integer?
+    integer-char? interleave interpose iterable? iterate iterator? keyword
+    keyword? last list* macroexpand macroexpand-1 map merge-with name neg? nil?
+    none? nth numeric? odd? partition pos? range read read-str remove repeat
+    repeatedly rest reduce second some string string? symbol? take take-nth
+    take-while zero? zip zip_longest zipwith])

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -470,6 +470,18 @@
   (try (do (odd? None) (assert False))
        (catch [e [TypeError]] (assert (in "not a number" (str e))))))
 
+(defn test-partition []
+  "NATIVE: testing the partition function"
+  (setv ten (range 10))
+  (assert-equal (list (partition 3 ten))
+                [(, 0 1 2) (, 3 4 5) (, 6 7 8)])
+  (assert-equal (list (partition 2 ten))
+                [(, 0 1) (, 2 3) (, 4 5) (, 6 7) (, 8 9)])
+  (assert-equal (list (partition 1 ten))
+                [(, 0) (, 1) (, 2) (, 3) (, 4) (, 5) (, 6) (, 7) (, 8) (, 9)])
+  (assert-equal (list (partition 0 ten)) [])
+  (assert-equal (list (partition -1 ten)) []))
+
 (defn test-pos []
   "NATIVE: testing the pos? function"
   (assert-true (pos? 2))


### PR DESCRIPTION
Ref #848. Clojure's `partition` is very useful when writing macros. This is only the 2-arg version of the Clojure multimethod, the most commonly used. Hy doesn't appear to support multiple dispatch, but the other versions could perhaps be added later using keyword arguments instead, if there is need.