### PR TITLE
defclass should add an implicit nil return to --init--

### DIFF
--- a/tests/native_tests/defclass.hy
+++ b/tests/native_tests/defclass.hy
@@ -109,3 +109,17 @@
   (assert (= a.y 2))
   (assert foo 2)
   (assert (.greet a) "hello"))
+
+(defn test-defclass-implicit-nil-for-init []
+  "NATIVE: test that defclass adds an implicit nil to --init--"
+  (defclass A []
+    [--init-- (fn [self] (setv self.x 1) 42)])
+  (defclass B []
+    (defn --init-- [self]
+      (setv self.x 2)
+      42))
+
+  (setv a (A))
+  (setv b (B))
+  (assert (= a.x 1))
+  (assert (= b.x 2)))


### PR DESCRIPTION
When using `defclass`, having to remember to explicitly return `nil` from `--init--` is painful. Ideally, `--init--` should do that automatically.

There are, unfortunately, a number of ways to define an `--init--` function:

```hy
(defclass Something []
  [--init-- (fn [self] ...)])
```

```hy
(defclass Something []
  (defn --init-- [self] ....))
```

```hy
(defmacro blah []
  `(defn --init-- [self] ...))
(defclass Something []
  (blah))
```

Catching all of these may be problematic, so implementing this may not be entirely trivial. Mind you, if we catch the two most common cases (the first two), that would be useful too.