### PR TITLE
Teach apply about symbol mangling

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -115,8 +115,10 @@ it appends it as the last argument. The following code demonstrates this:
 apply
 -----
 
-``apply`` is used to apply an optional list of arguments and an optional
-dictionary of kwargs to a function.
+``apply`` is used to apply an optional list of arguments and an
+optional dictionary of kwargs to a function. The symbol mangling
+transformations will be applied to all keys in the dictionary of
+kwargs, provided the dictionary and its keys are defined in-place.
 
 Usage: ``(apply fn-name [args] [kwargs])``
 
@@ -142,6 +144,8 @@ Examples:
     (apply total-purchase [] {"price" 10 "amount" 15 "vat" 1.05})
     ;=> 165.375
 
+    (apply total-purchase [] {:price 10 :amount 15 :vat 1.05})
+    ;=> 165.375
 
 and
 ---

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -45,6 +45,22 @@ pg = ParserGenerator(
 )
 
 
+def hy_symbol_mangle(p):
+    if p.startswith("*") and p.endswith("*") and p not in ("*", "**"):
+        p = p[1:-1].upper()
+
+    if "-" in p and p != "-":
+        p = p.replace("-", "_")
+
+    if p.endswith("?") and p != "?":
+        p = "is_%s" % (p[:-1])
+
+    if p.endswith("!") and p != "!":
+        p = "%s_bang" % (p[:-1])
+
+    return p
+
+
 def set_boundaries(fun):
     @wraps(fun)
     def wrapped(p):
@@ -297,22 +313,7 @@ def t_identifier(p):
     if obj.startswith(":"):
         return HyKeyword(obj)
 
-    def mangle(p):
-        if p.startswith("*") and p.endswith("*") and p not in ("*", "**"):
-            p = p[1:-1].upper()
-
-        if "-" in p and p != "-":
-            p = p.replace("-", "_")
-
-        if p.endswith("?") and p != "?":
-            p = "is_%s" % (p[:-1])
-
-        if p.endswith("!") and p != "!":
-            p = "%s_bang" % (p[:-1])
-
-        return p
-
-    obj = ".".join([mangle(part) for part in obj.split(".")])
+    obj = ".".join([hy_symbol_mangle(part) for part in obj.split(".")])
 
     return HySymbol(obj)
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -309,7 +309,10 @@
   (assert (= (apply sumit [] {"a" 1 "b" 1 "c" 2}) 4))
   (assert (= (apply sumit ((fn [] [1 1])) {"c" 1}) 3))
   (defn noargs [] [1 2 3])
-  (assert (= (apply noargs) [1 2 3])))
+  (assert (= (apply noargs) [1 2 3]))
+  (defn sumit-mangle [an-a a-b a-c a-d] (+ an-a a-b a-c a-d))
+  (def Z "a_d")
+  (assert (= (apply sumit-mangle [] {"an-a" 1 :a-b 2 'a-c 3 Z 4}) 10)))
 
 
 (defn test-apply-with-methods []


### PR DESCRIPTION
apply now mangles strings and keywords according to the Hy mangling
rules (by using the same function, now imported from
hy.lex.parser). With this change, if the dict passed to apply has
keywords, strings or quoted symbols, they'll get mangled, to turn them
into proper keys.

This only works for the cases where the keys are directly in the apply
params. A previously deffed dict, or key through a variable will not be
mangled.

This closes #219.