### PR TITLE
Trying to setv a callable should raise a nice error

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2004,6 +2004,10 @@ class HyASTCompiler(object):
         result = self.compile(result)
         ld_name = self.compile(name)
 
+        if isinstance(ld_name.expr, ast.Call):
+            raise HyTypeError(name,
+                              "Can't assign to a callable: `%s'" % str_name)
+
         if result.temp_variables \
            and isinstance(name, HyString) \
            and '.' not in name:

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -519,3 +519,9 @@ def test_attribute_access():
 def test_cons_correct():
     """Ensure cons gets compiled correctly"""
     can_compile("(cons a b)")
+
+
+def test_bad_setv():
+    """Ensure setv handles error cases"""
+    cant_compile("(setv if 1)")
+    cant_compile("(setv (a b) [1 2])")


### PR DESCRIPTION
When trying to setv a callable, raise an error instead of showing the
user an incredibly ugly backtrace. Closes #532.