### PR TITLE
Mangle trailing bangs on symbols

### DIFF
--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -308,6 +308,9 @@ def t_identifier(p):
         if p.endswith("?") and p != "?":
             p = "is_%s" % (p[:-1])
 
+        if p.endswith("!") and p != "!":
+            p = "%s_bang" % (p[:-1])
+
         return p
 
     obj = ".".join([mangle(part) for part in obj.split(".")])

--- a/tests/lex/test_lex.py
+++ b/tests/lex/test_lex.py
@@ -326,6 +326,24 @@ def test_lex_mangling_qmark():
     assert entry == [HySymbol(".is_foo.bar.is_baz")]
 
 
+def test_lex_mangling_bang():
+    """Ensure that identifiers ending with a bang get mangled ok"""
+    entry = tokenize("foo!")
+    assert entry == [HySymbol("foo_bang")]
+    entry = tokenize("!")
+    assert entry == [HySymbol("!")]
+    entry = tokenize("im!foo")
+    assert entry == [HySymbol("im!foo")]
+    entry = tokenize(".foo!")
+    assert entry == [HySymbol(".foo_bang")]
+    entry = tokenize("foo.bar!")
+    assert entry == [HySymbol("foo.bar_bang")]
+    entry = tokenize("foo!.bar")
+    assert entry == [HySymbol("foo_bang.bar")]
+    entry = tokenize(".foo!.bar.baz!")
+    assert entry == [HySymbol(".foo_bang.bar.baz_bang")]
+
+
 def test_simple_cons():
     """Check that cons gets tokenized correctly"""
     entry = tokenize("(a . b)")[0]


### PR DESCRIPTION
Postfixing functions with a bang, like set!, get!, etc are relatively
common. However, those names are not valid in python, so in the name of
python interoperability, lets mangle them to set_bang and get_bang,
respectively.

Closes #536.