### PR TITLE
Implement meta-class support for defclass

### DIFF
--- a/tests/native_tests/defclass.hy
+++ b/tests/native_tests/defclass.hy
@@ -109,3 +109,16 @@
   (assert (= a.y 2))
   (assert foo 2)
   (assert (.greet a) "hello"))
+
+(defn test-defclass-meta []
+  "NATIVE: test defclass support for meta-classes"
+  (global foo)
+  (setv foo 1)
+  (defclass MyMeta [type]
+    (defn --init-- [self &rest args]
+      (global foo)
+      (setv foo "meta")
+      nil))
+
+  (defclass A [object :meta MyMeta])
+  (assert (= foo "meta")))


### PR DESCRIPTION
This works by picking out the first :meta X pair from the parent list,
and setting that up (in a python-version-specific manner) to be the meta
class.

Closes #855.