### PR TITLE
Allow defclass to have properties/method with built-in names

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -370,6 +370,7 @@ def checkargs(exact=None, min=None, max=None, even=None, multiple=None):
 class HyASTCompiler(object):
 
     def __init__(self, module_name):
+        self.allow_builtins = False
         self.anon_fn_count = 0
         self.anon_var_count = 0
         self.imports = defaultdict(set)
@@ -2005,7 +2006,8 @@ class HyASTCompiler(object):
                         start_line, start_column):
 
         str_name = "%s" % name
-        if _is_hy_builtin(str_name, self.module_name):
+        if _is_hy_builtin(str_name, self.module_name) and \
+           not self.allow_builtins:
             raise HyTypeError(name,
                               "Can't assign to a builtin: `%s'" % str_name)
 
@@ -2275,6 +2277,8 @@ class HyASTCompiler(object):
                                          docstring.start_column)
             body += body.expr_as_stmt()
 
+        allow_builtins = self.allow_builtins
+        self.allow_builtins = True
         if expressions and isinstance(expressions[0], HyList) \
            and not isinstance(expressions[0], HyExpression):
             expr = expressions.pop(0)
@@ -2286,6 +2290,8 @@ class HyASTCompiler(object):
 
         for expression in expressions:
             body += self.compile(macroexpand(expression, self.module_name))
+
+        self.allow_builtins = allow_builtins
 
         if not body.stmts:
             body += ast.Pass(lineno=expressions.start_line,

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -554,6 +554,14 @@ def test_defn():
 
 
 def test_setv_builtins():
-    """Ensure that assigning to a builtin fails"""
+    """Ensure that assigning to a builtin fails, unless in a class"""
     cant_compile("(setv nil 42)")
     cant_compile("(defn get [&rest args] 42)")
+    can_compile("(defclass A [] (defn get [self] 42))")
+    can_compile("""
+    (defclass A []
+      (defn get [self] 42)
+      (defclass B []
+        (defn get [self] 42))
+      (defn if [self] 0))
+    """)

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -551,3 +551,9 @@ def test_defn():
     cant_compile("(defn \"hy\" [] 1)")
     cant_compile("(defn :hy [] 1)")
     can_compile("(defn &hy [] 1)")
+
+
+def test_setv_builtins():
+    """Ensure that assigning to a builtin fails"""
+    cant_compile("(setv nil 42)")
+    cant_compile("(defn get [&rest args] 42)")


### PR DESCRIPTION
To allow classes to have methods that match built-in names, yet, still
disallow them outside of defclass, keep an internal state whether
builtins are allowed in the current context.

By default, this is false. But defclass will set it to True when it
compiles its body, and set it back to the previous value when it's done
with that. We need to set back to the previous value to allow nested
defclasses to work properly.

This closes #783.