### PR TITLE
xi parameter may appear in function position

### DIFF
--- a/docs/contrib/anaphoric.rst
+++ b/docs/contrib/anaphoric.rst
@@ -231,7 +231,7 @@ Returns a function which applies several forms in series from left to right. The
 xi
 ==
 
-Usage ``(xi function body ...)``
+Usage ``(xi body ...)``
 
 Returns a function with parameters implicitly determined by the presence in the body of xi parameters. An xi symbol designates the ith parameter (1-based, e.g. x1, x2, x3, etc.), or all remaining parameters for xi itself. This is not a replacement for lambda. The xi forms cannot be nested. 
 

--- a/hy/contrib/anaphoric.hy
+++ b/hy/contrib/anaphoric.hy
@@ -122,7 +122,7 @@
   "Returns a function which is the composition of several forms."
   `(fn [var] (ap-pipe var ~@forms)))
 
-(defmacro xi [function &rest body]
+(defmacro xi [&rest body]
   "Returns a function with parameters implicitly determined by the presence in
    the body of xi parameters. An xi symbol designates the ith parameter
    (1-based, e.g. x1, x2, x3, etc.), or all remaining parameters for xi itself.
@@ -143,5 +143,5 @@
             ~@(if (in 'xi flatbody)
                 '(&rest xi)
                 '())]
-     (~function ~@body)))
+     (~@body)))
 

--- a/tests/native_tests/contrib/anaphoric.hy
+++ b/tests/native_tests/contrib/anaphoric.hy
@@ -134,4 +134,8 @@
   (assert-equal ((xi identity [x3 x1]) 1 2 3) [3 1])
   ;; test nesting
   (assert-equal ((xi identity [x1 (, x2 [x3] "Hy" [xi])]) 1 2 3 4 5)
-                [1 (, 2 [3] "Hy" [(, 4 5)])]))
+                [1 (, 2 [3] "Hy" [(, 4 5)])])
+  ;; test arg as function
+  (assert-equal ((xi x1 2 4) +) 6)
+  (assert-equal ((xi x1 2 4) -) -2)
+  (assert-equal ((xi x1 2 4) /) 0.5))


### PR DESCRIPTION
I just realized something.
```Clojure
user=> (def foo #(% 2 3))
#'user/foo
user=> (foo +)
5
user=> (foo -)
-1
user=> (foo /)
2/3
```
The parameter can appear in the function position.
This won't currently work in Hy's xi forms because the first element isn't checked for xi symbols, but I just fixed that with this slight adjustment.