### PR TITLE
Typecheck `eval` arguments during execution instead of compilation

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -729,15 +729,11 @@ class HyASTCompiler(object):
 
         elist = [HySymbol("hy_eval")] + [expr[0]]
         if len(expr) >= 2:
-            if not isinstance(expr[1], (HyDict, HySymbol)):
-                raise HyTypeError(expr, "Globals must be a dictionary")
             elist.append(expr[1])
         else:
             elist.append(HyExpression([HySymbol("locals")]))
 
         if len(expr) == 3:
-            if not isinstance(expr[2], HyString):
-                raise HyTypeError(expr, "Module name must be a string")
             elist.append(expr[2])
         else:
             elist.append(HyString(self.module_name))

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -119,6 +119,12 @@ def hy_eval(hytree, namespace, module_name):
         node.lineno = 1
         node.col_offset = 1
 
+    if not isinstance(namespace, dict):
+        raise HyTypeError(expr, "Globals must be a dictionary, is {}".format(type(namespace)))
+
+    if not isinstance(module_name, str):
+        raise HyTypeError(expr, "Module name must be a string")
+
     # Two-step eval: eval() the body of the exec call
     eval(ast_compile(_ast, "<eval_body>", "exec"), namespace)
 


### PR DESCRIPTION
When checking types during compilation, things like

    (eval '(print 1) (. foo mod))

fail, even if `(. foo mod)` is a dictionary.