### PR TITLE
Eval args typecheck

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -729,15 +729,11 @@ class HyASTCompiler(object):
 
         elist = [HySymbol("hy_eval")] + [expr[0]]
         if len(expr) >= 2:
-            if not isinstance(expr[1], (HyDict, HySymbol)):
-                raise HyTypeError(expr, "Globals must be a dictionary")
             elist.append(expr[1])
         else:
             elist.append(HyExpression([HySymbol("locals")]))
 
         if len(expr) == 3:
-            if not isinstance(expr[2], HyString):
-                raise HyTypeError(expr, "Module name must be a string")
             elist.append(expr[2])
         else:
             elist.append(HyString(self.module_name))

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -33,6 +33,7 @@ import os
 import __future__
 
 from hy._compat import PY3, PY33, MAGIC, builtins, long_type, wr_long
+from hy._compat import string_types
 
 
 def ast_compile(ast, filename, mode):
@@ -109,12 +110,7 @@ def hy_eval(hytree, namespace, module_name):
     foo.end_column = 0
     replace_hy_obj(hytree, foo)
 
-    try:
-        checktype = basestring
-    except NameError:
-        checktype = str
-
-    if not isinstance(module_name, checktype):
+    if not isinstance(module_name, string_types):
         raise HyTypeError(foo, "Module name must be a string")
 
     _ast, expr = hy_compile(hytree, module_name, get_expr=True)

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -108,6 +108,15 @@ def hy_eval(hytree, namespace, module_name):
     foo.start_column = 0
     foo.end_column = 0
     replace_hy_obj(hytree, foo)
+
+    try:
+        checktype = basestring
+    except NameError:
+        checktype = str
+
+    if not isinstance(module_name, checktype):
+        raise HyTypeError(foo, "Module name must be a string")
+
     _ast, expr = hy_compile(hytree, module_name, get_expr=True)
 
     # Spoof the positions in the generated ast...
@@ -118,6 +127,9 @@ def hy_eval(hytree, namespace, module_name):
     for node in ast.walk(expr):
         node.lineno = 1
         node.col_offset = 1
+
+    if not isinstance(namespace, dict):
+        raise HyTypeError(foo, "Globals must be a dictionary")
 
     # Two-step eval: eval() the body of the exec call
     eval(ast_compile(_ast, "<eval_body>", "exec"), namespace)

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -875,18 +875,6 @@
   (assert (= None (eval (quote (print ""))))))
 
 
-(defmacro assert-raise [exc-type &rest body]
-  `(try
-     (do
-       (eval ~@body)
-       (assert False "we shouldn't have arrived here"))
-     (except [e Exception]
-       (assert (instance? ~exc-type e)
-         (.format "Expected exception of type {}, got {}: {}"
-                  (. ~exc-type --name--)
-                  (. (type e) --name--)
-                  (str e))))))
-
 (defn test-eval-globals []
   "NATIVE: test eval with explicit global dict"
   (assert (= 'bar (eval (quote foo) {'foo 'bar})))
@@ -905,10 +893,11 @@
 (defn test-eval-failure []
   "NATIVE: test eval failure modes"
   (import [hy.errors [HyTypeError]])
-  (assert-raise HyTypeError '(eval))
-  (assert-raise HyTypeError '(eval "snafu"))
-  (assert-raise HyTypeError '(eval 'false []))
-  (assert-raise HyTypeError '(eval 'false {} 1)))
+  ; yo dawg
+  (try (eval '(eval)) (except [e HyTypeError]) (else (assert False)))
+  (try (eval '(eval "snafu")) (except [e HyTypeError]) (else (assert False)))
+  (try (eval 'false []) (except [e HyTypeError]) (else (assert False)))
+  (try (eval 'false {} 1) (except [e HyTypeError]) (else (assert False))))
 
 
 (defn test-import-syntax []


### PR DESCRIPTION
Typecheck `eval` arguments during execution instead of compilation

When checking types during compilation, things like

     (eval '(print 1) (. foo mod))

fail, even if `(. foo mod)` is a dictionary.
