### PR TITLE
added defmacro!

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -619,21 +619,21 @@ For example,
 
 .. code-block:: clj
 
-=> (defn expensive-get-number [] (print "spam") 14)
-=> (defmacro triple-1 [n] `(+ n n n))
-=> (triple-1 (expensive-get-number))  ; evals n three times!
-spam
-spam
-spam
-42
-=> (defmacro/g! triple-2 [n] `(do (setv ~g!n ~n) (+ ~g!n ~g!n ~g!n)))
-=> (triple-2 (expensive-get-number))  ; avoid repeats with a gensym
-spam
-42
-=> (defmacro! triple-3 [o!n] `(+ ~g!n ~g!n ~g!n))
-=> (triple-3 (expensive-get-number))  ; easier with defmacro!
-spam
-42
+    => (defn expensive-get-number [] (print "spam") 14)
+    => (defmacro triple-1 [n] `(+ n n n))
+    => (triple-1 (expensive-get-number))  ; evals n three times!
+    spam
+    spam
+    spam
+    42
+    => (defmacro/g! triple-2 [n] `(do (setv ~g!n ~n) (+ ~g!n ~g!n ~g!n)))
+    => (triple-2 (expensive-get-number))  ; avoid repeats with a gensym
+    spam
+    42
+    => (defmacro! triple-3 [o!n] `(+ ~g!n ~g!n ~g!n))
+    => (triple-3 (expensive-get-number))  ; easier with defmacro!
+    spam
+    42
 
 
 defreader

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -607,6 +607,35 @@ For example, ``g!a`` would become ``(gensym "a")``.
 
    Section :ref:`using-gensym`
 
+.. _defmacro!:
+
+defmacro!
+---------
+
+``defmacro!`` is like ``defmacro/g!``, plus automatic once-only evaluation for
+``o!`` parameters, which are available as the equivalent ``g!`` symbol.
+
+For example,
+
+.. code-block:: clj
+
+=> (defn expensive-get-number [] (print "spam") 14)
+=> (defmacro triple-1 [n] `(+ n n n))
+=> (triple-1 (expensive-get-number))  ; evals n three times!
+spam
+spam
+spam
+42
+=> (defmacro/g! triple-2 [n] `(do (setv ~g!n ~n) (+ ~g!n ~g!n ~g!n)))
+=> (triple-2 (expensive-get-number))  ; avoid repeats with a gensym
+spam
+42
+=> (defmacro! triple-3 [o!n] `(+ ~g!n ~g!n ~g!n))
+=> (triple-3 (expensive-get-number))  ; easier with defmacro!
+spam
+42
+
+
 defreader
 ---------
 

--- a/docs/language/cli.rst
+++ b/docs/language/cli.rst
@@ -35,7 +35,7 @@ Command Line Options
 
 .. cmdoption:: --spy
 
-   Print equivalent Python code before executing. For example::
+   Print equivalent Python code before executing in REPL. For example::
 
     => (defn salutationsnm [name] (print (+ "Hy " name "!")))
     def salutationsnm(name):
@@ -45,6 +45,7 @@ Command Line Options
     Hy YourName!
     =>
 
+   `--spy` only works on REPL mode.
    .. versionadded:: 0.9.11
 
 .. cmdoption:: --show-tracebacks

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -211,6 +211,14 @@
        (let ~gensyms
          ~@body))))
 
+(defmacro defmacro! [name args &rest body]
+  "like defmacro/g! plus args that start with o! will automatically evaluate
+   once only and be bound to the equivalent g!"
+  (setv os (list-comp s [s args] (.startswith s "o!"))
+        gs (list-comp (HySymbol (+ "g!" (cut s 2))) [s os]))
+  `(defmacro/g! ~name ~args
+     `(do (setv ~@(interleave ~gs ~os))
+          ~@~body)))
 
 (if-python2
   (defmacro/g! yield-from [expr]

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -18,7 +18,6 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-from inspect import getargspec, formatargspec
 from hy.models import replace_hy_obj, wrap_value
 from hy.models.expression import HyExpression
 from hy.models.string import HyString

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -125,16 +125,6 @@ def load_macros(module_name):
         _import(module)
 
 
-def make_empty_fn_copy(fn):
-    argspec = getargspec(fn)
-    formatted_args = formatargspec(*argspec)
-    fn_str = 'lambda {}: None'.format(
-        formatted_args.lstrip('(').rstrip(')'))
-
-    empty_fn = eval(fn_str)
-    return empty_fn
-
-
 def macroexpand(tree, compiler):
     """Expand the toplevel macros for the `tree`.
 
@@ -172,14 +162,6 @@ def macroexpand_1(tree, compiler):
             if m is not None:
                 if m._hy_macro_pass_compiler:
                     opts['compiler'] = compiler
-
-                try:
-                    m_copy = make_empty_fn_copy(m)
-                    m_copy(*ntree[1:], **opts)
-                except TypeError as e:
-                    msg = "expanding `" + str(tree[0]) + "': "
-                    msg += str(e).replace("<lambda>()", "", 1).strip()
-                    raise HyMacroExpansionError(tree, msg)
                 try:
                     obj = wrap_value(m(*ntree[1:], **opts))
                 except HyTypeError as e:

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -18,6 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+from inspect import getargspec
 from hy.models import replace_hy_obj, wrap_value
 from hy.models.expression import HyExpression
 from hy.models.string import HyString

--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -6,7 +6,6 @@ from hy.models.string import HyString
 from hy.models.list import HyList
 from hy.models.symbol import HySymbol
 from hy.models.expression import HyExpression
-from hy.errors import HyMacroExpansionError
 
 from hy.compiler import HyASTCompiler
 
@@ -40,13 +39,3 @@ def test_preprocessor_expression():
     obj = HyList([HyString("one"), HyString("two")])
     obj = tokenize('(shill ["one" "two"])')[0][1]
     assert obj == macroexpand(obj, HyASTCompiler(""))
-
-
-def test_preprocessor_exceptions():
-    """ Test that macro expansion raises appropriate exceptions"""
-    try:
-        macroexpand(tokenize('(defn)')[0], HyASTCompiler(__name__))
-        assert False
-    except HyMacroExpansionError as e:
-        assert "_hy_anon_fn_" not in str(e)
-        assert "TypeError" not in str(e)

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -199,6 +199,42 @@
   (setv macro2 "(defmacro/g! two-point-zero [] `(+ (float 1) 1.0))")
   (assert (import_buffer_to_ast macro2 "foo")))
 
+(defn test-defmacro! []
+  ;; defmacro! must do everything defmacro/g! can
+  (import ast)
+  (import [astor.codegen [to_source]])
+  (import [hy.importer [import_buffer_to_ast]])
+  (setv macro1 "(defmacro! nif [expr pos zero neg]
+        `(let [[~g!res ~expr]]
+           (cond [(pos? ~g!res) ~pos]
+                 [(zero? ~g!res) ~zero]
+                 [(neg? ~g!res) ~neg])))
+
+    (print (nif (inc -1) 1 0 -1))
+    ")
+  ;; expand the macro twice, should use a different
+  ;; gensym each time
+  (setv _ast1 (import_buffer_to_ast macro1 "foo"))
+  (setv _ast2 (import_buffer_to_ast macro1 "foo"))
+  (setv s1 (to_source _ast1))
+  (setv s2 (to_source _ast2))
+  (assert (in ":res_" s1))
+  (assert (in ":res_" s2))
+  (assert (not (= s1 s2)))
+
+  ;; defmacro/g! didn't like numbers initially because they
+  ;; don't have a startswith method and blew up during expansion
+  (setv macro2 "(defmacro! two-point-zero [] `(+ (float 1) 1.0))")
+  (assert (import_buffer_to_ast macro2 "foo"))
+
+  (defmacro! foo! [o!foo] `(do ~g!foo ~g!foo))
+  ;; test that o! becomes g!
+  (assert (= "Hy" (foo! "Hy")))
+  ;; test that o! is evaluated once only
+  (setv foo 40)
+  (foo! (+= foo 1))
+  (assert (= 41 foo)))
+
 
 (defn test-if-not []
   (assert (= (if-not True :yes :no)


### PR DESCRIPTION
I saw `defmacro/g!` in _Let Over Lambda_ before I saw it in Hy, but it's just a helper macro for the real utility: `defmacro!`, which is like `defmacro/g!`, plus automatic once-only evaluation for
`o!` parameters, which are available as the equivalent `g!` symbol. This pull translates `defmacro!` to Hy.

For those who haven't read the book, a common problem with macros is multiple-evaluation.

``` Hy
=> (defn expensive-get-number [] (print "spam") 14)
=> (defmacro triple-1 [n] `(+ n n n))
=> (triple-1 (expensive-get-number))  ; evals n three times!
spam
spam
spam
42
```

You can avoid this with a gensym:

``` Hy
=> (defmacro/g! triple-2 [n] `(do (setv ~g!n ~n) (+ ~g!n ~g!n ~g!n)))
=> (triple-2 (expensive-get-number))  ; avoid repeats with a gensym
spam
42
```

But this is more concise and clear with `defmacro!`, which does that for you:

``` Hy
=> (defmacro! triple-3 [o!n] `(+ ~g!n ~g!n ~g!n))
=> (triple-3 (expensive-get-number))  ; easier with defmacro!
spam
42
```
