### PR TITLE
Allow (del) without arguments

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1298,9 +1298,15 @@ class HyASTCompiler(object):
         return ret
 
     @builds("del")
-    @checkargs(min=1)
     def compile_del_expression(self, expr):
-        expr.pop(0)
+        root = expr.pop(0)
+        if not expr:
+            result = Result()
+            result += ast.Name(id='None', ctx=ast.Load(),
+                               lineno=root.start_line,
+                               col_offset=root.start_column)
+            return result
+
         ld_targets, ret, _ = self._compile_collect(expr)
 
         del_targets = []

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1092,7 +1092,8 @@
   (del (get test 4))
   (assert (= test [0 1 2 3]))
   (del (get test 2))
-  (assert (= test [0 1 3])))
+  (assert (= test [0 1 3]))
+  (assert (= (del) nil)))
 
 
 (defn test-macroexpand []


### PR DESCRIPTION
To mirror the behaviour of (setv), allow an empty (del) too: one that
shall return nil. Closes #905.