### PR TITLE
Allow an empty (cond)

### DIFF
--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -67,26 +67,29 @@
      bar
      (if baz
        quux))"
-  (setv branches (iter branches))
-  (setv branch (next branches))
-  (defn check-branch [branch]
-    "check `cond` branch for validity, return the corresponding `if` expr"
-    (if (not (= (type branch) HyList))
-      (macro-error branch "cond branches need to be a list"))
-    (if (< (len branch) 2)
-      (macro-error branch "cond branches need at least two items: a test and one or more code branches"))
-    (setv test (car branch))
-    (setv thebranch (cdr branch))
-    `(if ~test (do ~@thebranch)))
+  (if (empty? branches)
+    nil
+    (do
+     (setv branches (iter branches))
+     (setv branch (next branches))
+     (defn check-branch [branch]
+       "check `cond` branch for validity, return the corresponding `if` expr"
+       (if (not (= (type branch) HyList))
+         (macro-error branch "cond branches need to be a list"))
+       (if (< (len branch) 2)
+         (macro-error branch "cond branches need at least two items: a test and one or more code branches"))
+       (setv test (car branch))
+       (setv thebranch (cdr branch))
+       `(if ~test (do ~@thebranch)))
 
-  (setv root (check-branch branch))
-  (setv latest-branch root)
+     (setv root (check-branch branch))
+     (setv latest-branch root)
 
-  (for* [branch branches]
-    (setv cur-branch (check-branch branch))
-    (.append latest-branch cur-branch)
-    (setv latest-branch cur-branch))
-  root)
+     (for* [branch branches]
+       (setv cur-branch (check-branch branch))
+       (.append latest-branch cur-branch)
+       (setv latest-branch cur-branch))
+     root)))
 
 
 (defmacro for [args &rest body]

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -231,7 +231,8 @@
   "NATIVE: test if cond sorta works."
   (cond
    [(= 1 2) (assert (is true false))]
-   [(is None None) (setv x true) (assert x)]))
+   [(is None None) (setv x true) (assert x)])
+  (assert (= (cond) nil)))
 
 
 (defn test-index []


### PR DESCRIPTION
For easier macro writing purposes, allow an empty (cond), that simply
returns nil. Closes #904.