### PR TITLE
Remove hard-coded references to 'fn' and 'setv' in errors

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1994,7 +1994,8 @@ class HyASTCompiler(object):
                                         expression.start_column)
         elif len(expression) % 2 != 0:
             raise HyTypeError(expression,
-                              "setv needs an even number of arguments")
+                              "`{}' needs an even number of arguments".format(
+                                  root))
         else:
             result = Result()
             exprs = []
@@ -2152,7 +2153,8 @@ class HyASTCompiler(object):
         arglist = expression.pop(0)
         if not isinstance(arglist, HyList):
             raise HyTypeError(expression,
-                              "First argument to (fn) must be a list")
+                              "First argument to `{}' must be a list".format(
+                                  called_as))
 
         (ret, args, defaults, stararg,
          kwonlyargs, kwonlydefaults, kwargs) = self._parse_lambda_list(arglist)

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -75,17 +75,30 @@
   (setv y 0 x 1 y x)
   (assert y)
   (try (eval '(setv a 1 b))
-       (except [e [TypeError]] (assert (in "setv needs an even number of arguments" (str e))))))
+       (except [e [TypeError]] (assert (in "`setv' needs an even number of arguments" (str e))))))
 
 
 (defn test-fn-corner-cases []
   "NATIVE: tests that fn/defn handles corner cases gracefully"
   (try (eval '(fn "foo"))
-       (except [e [Exception]] (assert (in "to (fn) must be a list"
+       (except [e [Exception]] (assert (in "to `fn' must be a list"
                                           (str e)))))
   (try (eval '(defn foo "foo"))
        (except [e [Exception]]
          (assert (in "takes a parameter list as second" (str e))))))
+
+
+(defn test-alias-names-in-errors []
+  "NATIVE: tests that native aliases show the correct names in errors"
+  (try (eval '(lambda))
+       (except [e [Exception]] (assert (in "lambda" (str e)))))
+  (try (eval '(fn))
+       (except [e [Exception]] (assert (in "fn" (str e)))))
+  (try (eval '(setv 1 2 3))
+       (except [e [Exception]] (assert (in "setv" (str e)))))
+  (try (eval '(def 1 2 3))
+       (except [e [Exception]] (assert (in "def" (str e))))))
+
 
 (defn test-for-loop []
   "NATIVE: test for loops"


### PR DESCRIPTION
Currently some of errors for built-in forms make references to a particular one of the multiple they handle. This can be confusing, for example, attempting to compile `(def foo bar baz)` produces:

    HyTypeError: setv needs an even number of arguments

This one and `fn/lambda` are the two I see. Please let me know if anyone can find any others and I'll add them to this pr.