### PR TITLE
fix CI by downgrading Coverage?

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,8 @@ omit =
     */site-packages/nose/*
     */pypy/*
 
+
+[report]
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover


### PR DESCRIPTION
On 21 September, all the continuous integration checks on a revision of
pull-request #920 were observed to fail with a "CoverageException:
Unrecognized option '[run] exclude_lines=' in config file
.coveragerc". One can only imagine that this was due to it trying to use
the new version 4.0 of Ned Batchelder's ever-popular coverage.py (just
released on 20 September), with which our existing .coveragerc may not
be compatible. Unfortunately, a quick glance at the documentation was
not sufficient for the present author to deduce how we should edit our
configuration to be in compliance with the new version of the tool; as a
temporary workaround to get the CI Hy infrastructure up and running,
this pull request proposes an attempt to pin us to the just-prior version of coverage.