### PR TITLE
Update style-guide.rst

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -61,8 +61,8 @@ Layout & Indentation
      ;; Good (and preferred)
      (defn fib [n]
        (if (<= n 2)
-         n
-         (+ (fib (- n 1)) (fib (- n 2)))))
+           n
+           (+ (fib (- n 1)) (fib (- n 2)))))
 
      ;; Still okay
      (defn fib [n]
@@ -89,8 +89,8 @@ Layout & Indentation
     ;; Good (and preferred)
     (defn fib [n]
       (if (<= n 2)
-        n
-        (+ (fib (- n 1)) (fib (- n 2)))))
+          n
+          (+ (fib (- n 1)) (fib (- n 2)))))
 
     ;; Hysterically ridiculous
     (defn fib [n]


### PR DESCRIPTION
Re-indent `fib` examples to match that in original blog post - "Indentation shall be two spaces, except where matching the indentation of the previous line"

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hylang/hy/944)
<!-- Reviewable:end -->
