### PR TITLE
Add link to stable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Project
 -------
 
 * Code: https://github.com/hylang/hy
-* Docs: http://hylang.org/
+* Docs (latest): http://hylang.org/
+* Docs (stable): http://docs.hylang.org/en/stable/
 * Quickstart: http://hylang.org/en/latest/quickstart.html
 * Bug reports: We have no bugs! Your bugs are your own! (https://github.com/hylang/hy/issues)
 * License: MIT (Expat)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Project
 -------
 
 * Code: https://github.com/hylang/hy
-* Docs (latest): http://hylang.org/
-* Docs (stable): http://docs.hylang.org/en/stable/
+* Docs (latest, for use with bleeding-edge github version): http://hylang.org/
+* Docs (stable, for use with the PyPI version): http://docs.hylang.org/en/stable/
 * Quickstart: http://hylang.org/en/latest/quickstart.html
 * Bug reports: We have no bugs! Your bugs are your own! (https://github.com/hylang/hy/issues)
 * License: MIT (Expat)


### PR DESCRIPTION
Ref #940, #942, #945.

The language cleanup is confusing the new people. This is at least the third time someone has complained that `defclass` is broken.