### PR TITLE
Give an error when &kwonly is used in a macro definition

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -503,6 +503,64 @@ In Hy:
      address (models.TextField)
      notes (models.TextField)])
 
+Macros
+======
+
+One really powerful feature of Hy are macros. They are small functios that are
+used to generate code (or data). When program written in Hy is started, the
+macros are executed and their output is placed in program source. After this,
+the program starts executing normally. Very simple example:
+
+.. code-block:: clj
+
+  => (defmacro hello [person]
+  ...  `(print "Hello there," ~person))
+  => (Hello "Tuukka")
+  Hello there, Tuukka
+
+The thing to notice here is that hello macro doesn't output anything on
+screen. Instead it creates piece of code that is then executed and prints on
+screen. Macro writes a piece of program that looks like this (provided that
+we used "Tuukka" as parameter:
+
+.. code-block:: clj
+
+  (print "Hello there," Tuukka)
+
+We can also manipulate code with macros:
+
+.. code-block:: clj
+
+  => (defmacro rev [code]
+  ...  (let [op (last code) params (list (butlast code))]
+  ...  `(~op ~@params)))
+  => (rev (1 2 3 +))
+  6
+
+The code that was generated with this macro just switched around some the
+elements, so by the time program started executing, it actually red:
+
+.. code-block:: clj
+
+  (+ 1 2 3)
+
+Sometimes it's nice to have a very short name for macro that doesn't take much
+space or use extra parentheses. Reader macros can be pretty useful in these
+situations (and since Hy operates well with unicode, we aren't running out of
+characters that soon):
+
+.. code-block:: clj
+
+  => (defreader ↻ [code]
+  ...  (let [op (last code) params (list (butlast code))]
+  ...  `(~op ~@params)))
+  => #↻(1 2 3 +)
+  6
+
+Macros are useful when one wished to extend the Hy or write their own
+language on top of that. Many features of Hy are macros, like ``when``,
+``cond`` and ``->``.
+
 Hy <-> Python interop
 =====================
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2371,6 +2371,9 @@ class HyASTCompiler(object):
             raise HyTypeError(name, ("received a `%s' instead of a symbol "
                                      "for macro name" % type(name).__name__))
         name = HyString(name).replace(name)
+        for kw in ("&kwonly", "&kwargs"):
+            if kw in expression[0]:
+                raise HyTypeError(name, "macros cannot use %s" % kw)
         new_expression = HyExpression([
             HySymbol("with_decorator"),
             HyExpression([HySymbol("hy.macros.macro"), name]),

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2428,7 +2428,7 @@ class HyASTCompiler(object):
             raise HyTypeError(name, ("received a `%s' instead of a symbol "
                                      "for macro name" % type(name).__name__))
         name = HyString(name).replace(name)
-        for kw in ("&kwonly", "&kwargs"):
+        for kw in ("&kwonly", "&kwargs", "&key"):
             if kw in expression[0]:
                 raise HyTypeError(name, "macros cannot use %s" % kw)
         new_expression = HyExpression([

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -51,7 +51,7 @@
   (foo x y))
 
 (defn test-macro-kw []
-  "NATIVE: test that an error is raised when &kwonly or &kwargs is used in a macro"
+  "NATIVE: test that an error is raised when &kwonly, &kwargs, or &key is used in a macro"
   (try
     (eval '(defmacro f [&kwonly a b]))
     (except [e HyTypeError]
@@ -62,6 +62,12 @@
     (eval '(defmacro f [&kwargs kw]))
     (except [e HyTypeError]
       (assert (= e.message "macros cannot use &kwargs")))
+    (else (assert false)))
+
+  (try
+    (eval '(defmacro f [&key {"kw" "xyz"}]))
+    (except [e HyTypeError]
+      (assert (= e.message "macros cannot use &key")))
     (else (assert false))))
 
 (defn test-fn-calling-macro []

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -1,3 +1,5 @@
+(import [hy.errors [HyTypeError]])
+
 (defmacro rev [&rest body]
   "Execute the `body` statements in reverse"
   (quasiquote (do (unquote-splice (list (reversed body))))))
@@ -47,6 +49,20 @@
 
 (defmacro bar [x y]
   (foo x y))
+
+(defn test-macro-kw []
+  "NATIVE: test that an error is raised when &kwonly or &kwargs is used in a macro"
+  (try
+    (eval '(defmacro f [&kwonly a b]))
+    (except [e HyTypeError]
+      (assert (= e.message "macros cannot use &kwonly")))
+    (else (assert false)))
+
+  (try
+    (eval '(defmacro f [&kwargs kw]))
+    (except [e HyTypeError]
+      (assert (= e.message "macros cannot use &kwargs")))
+    (else (assert false))))
 
 (defn test-fn-calling-macro []
   "NATIVE: test macro calling a plain function"


### PR DESCRIPTION
 (closes #959)