### PR TITLE
Improve error messages related to _storeize

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1811,18 +1811,7 @@ class HyASTCompiler(object):
                               values=[value.force_expr for value in values])
         return ret
 
-    @builds("=")
-    @builds("!=")
-    @builds("<")
-    @builds("<=")
-    @builds(">")
-    @builds(">=")
-    @builds("is")
-    @builds("in")
-    @builds("is_not")
-    @builds("not_in")
-    @checkargs(min=2)
-    def compile_compare_op_expression(self, expression):
+    def _compile_compare_op_expression(self, expression):
         ops = {"=": ast.Eq, "!=": ast.NotEq,
                "<": ast.Lt, "<=": ast.LtE,
                ">": ast.Gt, ">=": ast.GtE,
@@ -1841,6 +1830,32 @@ class HyASTCompiler(object):
                                  comparators=exprs[1:],
                                  lineno=e.start_line,
                                  col_offset=e.start_column)
+
+    @builds("=")
+    @builds("!=")
+    @builds("<")
+    @builds("<=")
+    @builds(">")
+    @builds(">=")
+    @checkargs(min=1)
+    def compile_compare_op_expression(self, expression):
+        if len(expression) == 2:
+            rval = "True"
+            if expression[0] == "!=":
+                rval = "False"
+            return ast.Name(id=rval,
+                            ctx=ast.Load(),
+                            lineno=expression.start_line,
+                            col_offset=expression.start_column)
+        return self._compile_compare_op_expression(expression)
+
+    @builds("is")
+    @builds("in")
+    @builds("is_not")
+    @builds("not_in")
+    @checkargs(min=2)
+    def compile_compare_op_expression_coll(self, expression):
+        return self._compile_compare_op_expression(expression)
 
     @builds("%")
     @builds("**")

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -468,9 +468,9 @@ def test_ast_unicode_strings():
 def test_compile_error():
     """Ensure we get compile error in tricky cases"""
     try:
-        can_compile("(fn [] (= 1))")
+        can_compile("(fn [] (in [1 2 3]))")
     except HyTypeError as e:
-        assert(e.message == "`=' needs at least 2 arguments, got 1.")
+        assert(e.message == "`in' needs at least 2 arguments, got 1.")
     else:
         assert(False)
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -208,15 +208,26 @@
 
 (defn test-noteq []
   "NATIVE: not eq"
-  (assert (!= 2 3)))
+  (assert (!= 2 3))
+  (assert (not (!= 1))))
+
+
+(defn test-eq []
+  "NATIVE: eq"
+  (assert (= 1 1))
+  (assert (= 1)))
 
 
 (defn test-numops []
   "NATIVE: test numpos"
   (assert (> 5 4 3 2 1))
+  (assert (> 1))
   (assert (< 1 2 3 4 5))
+  (assert (< 1))
   (assert (<= 5 5 5 5 ))
-  (assert (>= 5 5 5 5 )))
+  (assert (<= 1))
+  (assert (>= 5 5 5 5 ))
+  (assert (>= 1)))
 
 
 (defn test-is []


### PR DESCRIPTION
`x.hy`:

```hy
(setv [1 2] 1)
```

Before:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "hy/cmdline.py", line 347, in hy_main
    sys.exit(cmdline_handler("hy", sys.argv))
  File "hy/cmdline.py", line 335, in cmdline_handler
    return run_file(options.args[0])
  File "hy/cmdline.py", line 210, in run_file
    import_file_to_module("__main__", filename)
  File "hy/importer.py", line 76, in import_file_to_module
    _ast = import_file_to_ast(fpath, module_name)
  File "hy/importer.py", line 68, in import_file_to_ast
    return hy_compile(import_file_to_hst(fpath), module_name)
  File "hy/compiler.py", line 2581, in hy_compile
    result = compiler.compile(tree)
  File "hy/compiler.py", line 433, in compile
    ret = self.compile_atom(_type, tree)
  File "hy/compiler.py", line 425, in compile_atom
    ret = _compile_table[atom_type](self, atom)
  File "hy/compiler.py", line 624, in compile_raw_list
    ret = self._compile_branch(entries)
  File "hy/compiler.py", line 489, in _compile_branch
    return _branch(self.compile(expr) for expr in exprs)
  File "hy/compiler.py", line 316, in _branch
    results = list(results)
  File "hy/compiler.py", line 489, in <genexpr>
    return _branch(self.compile(expr) for expr in exprs)
  File "hy/compiler.py", line 445, in compile
    raise_empty(HyCompileError, e, sys.exc_info()[2])
  File "hy/_compat.py", line 66, in raise_empty
    raise t(*args)
hy.errors.HyCompileError: Internal Compiler Bug 😱
⤷ TypeError: Can't assign / delete a <class '_ast.Num'> object
Compilation traceback:
File "hy/compiler.py", line 433, in compile
    ret = self.compile_atom(_type, tree)
  File "hy/compiler.py", line 425, in compile_atom
    ret = _compile_table[atom_type](self, atom)
  File "hy/compiler.py", line 2001, in compile_expression
    ret = self.compile_atom(fn, expression)
  File "hy/compiler.py", line 425, in compile_atom
    ret = _compile_table[atom_type](self, atom)
  File "hy/compiler.py", line 2062, in compile_def_expression
    expression.start_column)
  File "hy/compiler.py", line 2102, in _compile_assign
    st_name = self._storeize(ld_name)
  File "hy/compiler.py", line 607, in _storeize
    new_elts.append(self._storeize(x, func))
  File "hy/compiler.py", line 616, in _storeize
    raise TypeError("Can't assign / delete a %s object" % type(name))
```

Now:

```
  File "x.hy", line 1, column 7

  (setv [1 2] 1)
        ^---^
HyTypeError: Can't assign / delete a HyList
```
