### PR TITLE
docs/tutorial: Add a short (require) example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -557,9 +557,20 @@ characters that soon):
   => #↻(1 2 3 +)
   6
 
-Macros are useful when one wished to extend the Hy or write their own
+Macros are useful when one wishes to extend the Hy or write their own
 language on top of that. Many features of Hy are macros, like ``when``,
 ``cond`` and ``->``.
+
+To use macros defined in a different module, it is not enough to
+``import`` the module, because importing happens at run-time, while we
+would need macros at compile-time. Instead of importing the module
+with macros, it must be ``require``d:
+
+.. code-block:: clj
+
+   => (require tutorial.macros)
+   => (rev (1 2 3 +))
+   6
 
 Hy <-> Python interop
 =====================


### PR DESCRIPTION
Adds a short (require) example, along with a few words on why macros can't be imported.

Closes #966.

Signed-off-by: Csilla Nagyne Martinak <csilla@csillger.hu>