### PR TITLE
docs/tutorial: Simplify two examples

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -479,8 +479,7 @@ In Hy:
     "Yet Another Example Class"
 
     (defn --init-- [self x]
-      (setv self.x x)
-      None)
+      (setv self.x x))
 
     (defn get-x [self]
       "Return our copy of x"
@@ -604,7 +603,7 @@ To use keyword arguments, you can use in ``greetings.py``::
     (import greetings)
     (.greet greetings "Foo")
     (.greet greetings "Foo" "Darth")
-    (apply (. greetings greet) ["Foo"] {"title" "Lord"})
+    (apply (. greetings greet) ["Foo"] {:title "Lord"})
 
 Which would output::
 


### PR DESCRIPTION
As part of the Grand Language Cleanup, a few examples in the tutorial could be simplified:

* The --init-- function of the defclass example does not need an explicit None anymore.
* The apply example in the Hy<->Python interop section can use a keyword instead of a string in the last part.

This perhaps closes #971.

Signed-off-by: Csilla Nagyne Martinak <csilla@csillger.hu>