### PR TITLE
Typos in the tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -505,9 +505,9 @@ In Hy:
 Macros
 ======
 
-One really powerful feature of Hy are macros. They are small functios that are
+One really powerful feature of Hy are macros. They are small functions that are
 used to generate code (or data). When program written in Hy is started, the
-macros are executed and their output is placed in program source. After this,
+macros are executed and their output is placed in the program source. After this,
 the program starts executing normally. Very simple example:
 
 .. code-block:: clj
@@ -519,8 +519,8 @@ the program starts executing normally. Very simple example:
 
 The thing to notice here is that hello macro doesn't output anything on
 screen. Instead it creates piece of code that is then executed and prints on
-screen. Macro writes a piece of program that looks like this (provided that
-we used "Tuukka" as parameter:
+screen. This macro writes a piece of program that looks like this (provided that
+we used "Tuukka" as parameter):
 
 .. code-block:: clj
 
@@ -536,14 +536,14 @@ We can also manipulate code with macros:
   => (rev (1 2 3 +))
   6
 
-The code that was generated with this macro just switched around some the
-elements, so by the time program started executing, it actually red:
+The code that was generated with this macro just switched around some of the
+elements, so by the time program started executing, it actually reads:
 
 .. code-block:: clj
 
   (+ 1 2 3)
 
-Sometimes it's nice to have a very short name for macro that doesn't take much
+Sometimes it's nice to have a very short name for a macro that doesn't take much
 space or use extra parentheses. Reader macros can be pretty useful in these
 situations (and since Hy operates well with unicode, we aren't running out of
 characters that soon):
@@ -556,7 +556,7 @@ characters that soon):
   => #↻(1 2 3 +)
   6
 
-Macros are useful when one wishes to extend the Hy or write their own
+Macros are useful when one wishes to extend Hy or write their own
 language on top of that. Many features of Hy are macros, like ``when``,
 ``cond`` and ``->``.
 


### PR DESCRIPTION
I was reading the tutorial and found typos.
I didn't think it needed a feature/fix branch (might be wrong).
