### PR TITLE
Fix anaphoric macro `ap-if`.

### DIFF
--- a/hy/contrib/anaphoric.hy
+++ b/hy/contrib/anaphoric.hy
@@ -25,8 +25,9 @@
 ;;; These macros make writing functional programs more concise
 
 
-(defmacro ap-if (test-form &rest args)
-  `(let [it ~test-form] (if it ~@args)))
+(defmacro ap-if [test-form then-form &optional else-form]
+  `(let [it ~test-form]
+     (if it ~then-form ~else-form)))
 
 
 (defmacro ap-each [lst &rest body]

--- a/tests/native_tests/contrib/anaphoric.hy
+++ b/tests/native_tests/contrib/anaphoric.hy
@@ -18,9 +18,10 @@
 ;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ;; DEALINGS IN THE SOFTWARE.
 
-;;;; some simple helpers
-
+(import [hy.errors [HyMacroExpansionError]])
 (require hy.contrib.anaphoric)
+
+;;;; some simple helpers
 
 (defn assert-true [x]
   (assert (= True x)))
@@ -35,7 +36,10 @@
 (defn test-ap-if []
   "NATIVE: testing anaphoric if"
   (ap-if true (assert-true it))
-  (ap-if false true (assert-false it)))
+  (ap-if false true (assert-false it))
+  (try (macroexpand '(ap-if true))
+       (except [HyMacroExpansionError] true)
+       (else (assert false))))
 
 (defn test-ap-each []
   "NATIVE: testing anaphoric each"


### PR DESCRIPTION
I have rebased pull request #816 onto master and added a test case (as requested).

_Edit:_ Force-pushed an amendment that replaces `(except [e Exception] (assert (instance? HyMacroExpansionError e)))` with `(except [HyMacroExpansionError] true)` (as suggested by @kirbyfan64).