### PR TITLE
defreader: Allow strings as macro names

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2456,7 +2456,7 @@ class HyASTCompiler(object):
         NOT_READERS = [":", "&"]
         if name in NOT_READERS or len(name) > 1:
             raise NameError("%s can't be used as a macro reader symbol" % name)
-        if not isinstance(name, HySymbol):
+        if not isinstance(name, HySymbol) and not isinstance(name, HyString):
             raise HyTypeError(name,
                               ("received a `%s' instead of a symbol "
                                "for reader macro name" % type(name).__name__))

--- a/tests/native_tests/reader_macros.hy
+++ b/tests/native_tests/reader_macros.hy
@@ -37,6 +37,15 @@
   (assert (= (, 1 2 3) a)))
 
 
+(defn test-reader-macro-string-name []
+  "Test if defreader accepts a string as a macro name."
+
+  (defreader "." [expr]
+    expr)
+
+  (assert (= #."works" "works")))
+
+
 (defn test-builtin-decorator-reader []
   (defn increment-arguments [func]
     "Increments each argument passed to the decorated function."


### PR DESCRIPTION
This makes it possible to use strings as the macro name argument to `defreader`, which in turn makes it possible to define reader macros with names that would otherwise result in parse errors.

Such as `#.`.

This fixes #918.
