### PR TITLE
Backport fix Python 3.5.1 support by converting kwargs and stararg to str as late as possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 sudo: false
 language: python
 python:
-  - "pypy"
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-cache: pip
-# command to run tests
-script: make travis
+  - 3.5
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=pypy
+  - TOXENV=flake8
+install: pip install tox
+script: tox
+cache:
+  directories:
+    - .tox
+    - $HOME/.cache/pip
 after_success: make coveralls
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 sudo: false
 language: python
-python:
-  - 3.5
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
 env:
   - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34
-  - TOXENV=py35
   - TOXENV=pypy
   - TOXENV=flake8
 install: pip install tox

--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,6 @@ endif
 	$(pip) install coveralls
 	$(pip) install --allow-all-external -e .
 
-travis: python
-	$(nose) -s --with-coverage --cover-package hy
-ifeq (PyPy,$(findstring PyPy,$(shell python -V 2>&1 | tail -1)))
-	@echo "skipping flake8 on pypy"
-else
-	flake8 hy bin tests
-endif
-
 coveralls:
 	$(coveralls)
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1554,12 +1554,28 @@ class HyASTCompiler(object):
             stargs = expr.pop(0)
             if stargs is not None:
                 stargs = self.compile(stargs)
-                ret.expr.starargs = stargs.force_expr
+                if PY35:
+                    stargs_expr = stargs.force_expr
+                    ret.expr.args.append(
+                        ast.Starred(stargs_expr, ast.Load(),
+                                    lineno=stargs_expr.lineno,
+                                    col_offset=stargs_expr.col_offset)
+                    )
+                else:
+                    ret.expr.starargs = stargs.force_expr
                 ret = stargs + ret
 
         if expr:
             kwargs = self.compile(expr.pop(0))
-            ret.expr.kwargs = kwargs.force_expr
+            if PY35:
+                kwargs_expr = kwargs.force_expr
+                ret.expr.keywords.append(
+                    ast.keyword(None, kwargs_expr,
+                                lineno=kwargs_expr.lineno,
+                                col_offset=kwargs_expr.col_offset)
+                )
+            else:
+                ret.expr.kwargs = kwargs.force_expr
             ret = kwargs + ret
 
         return ret

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -522,7 +522,7 @@ class HyASTCompiler(object):
                     raise HyTypeError(expr,
                                       "There can only be one "
                                       "&rest argument")
-                varargs = str(expr)
+                varargs = expr
             elif lambda_keyword == "&key":
                 if type(expr) != HyDict:
                     raise HyTypeError(expr,
@@ -558,7 +558,7 @@ class HyASTCompiler(object):
                     raise HyTypeError(expr,
                                       "There can only be one "
                                       "&kwargs argument")
-                kwargs = str(expr)
+                kwargs = expr
 
         return ret, args, defaults, varargs, kwargs
 
@@ -1975,10 +1975,14 @@ class HyASTCompiler(object):
             # list because it's really just an internal parsing thing.
 
             if kwargs:
-                kwargs = ast.arg(arg=kwargs, annotation=None)
+                kwargs = ast.arg(arg=ast_str(kwargs), annotation=None,
+                                 lineno=kwargs.start_line,
+                                 col_offset=kwargs.start_column)
 
             if stararg:
-                stararg = ast.arg(arg=stararg, annotation=None)
+                stararg = ast.arg(arg=ast_str(stararg), annotation=None,
+                                  lineno=stararg.start_line,
+                                  col_offset=stararg.start_column)
 
             # Let's find a better home for these guys.
         else:
@@ -1986,6 +1990,12 @@ class HyASTCompiler(object):
                              ctx=ast.Param(),
                              lineno=x.start_line,
                              col_offset=x.start_column) for x in args]
+
+            if kwargs:
+                kwargs = ast_str(kwargs)
+
+            if stararg:
+                stararg = ast_str(stararg)
 
         args = ast.arguments(
             args=args,

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Topic :: Software Development :: Code Generators",
         "Topic :: Software Development :: Compilers",
         "Topic :: Software Development :: Libraries",

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -4,7 +4,7 @@
         [operator [or_]])
 (import sys)
 
-(import [hy._compat [PY33 PY34]])
+(import [hy._compat [PY33 PY34 PY35]])
 
 (defn test-sys-argv []
   "NATIVE: test sys.argv"
@@ -1047,8 +1047,11 @@
 
 (defn test-disassemble []
   "NATIVE: Test the disassemble function"
-  (assert (= (disassemble '(do (leaky) (leaky) (macros)))
-             "Module(\n    body=[\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[], starargs=None, kwargs=None))])"))
+  (if PY35
+    (assert (= (disassemble '(do (leaky) (leaky) (macros)))
+               "Module(\n    body=[Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[]))])"))
+    (assert (= (disassemble '(do (leaky) (leaky) (macros)))
+               "Module(\n    body=[\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[], starargs=None, kwargs=None))])")))
   (assert (= (disassemble '(do (leaky) (leaky) (macros)) true)
              "leaky()\nleaky()\nmacros()")))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py26,py27,pypy,py33,flake8
+envlist = py26,py27,pypy,py33,py34,py35,flake8
 skipsdist = True
 
 [testenv]
 commands =
  pip install --allow-all-external -e .
  nosetests
+passenv =
+ TERM
 deps =
  -rrequirements-dev.txt
 


### PR DESCRIPTION
(cherry picked from commit 9d8e4ddb8098dab39eb3d4f7ef89dc7ccd13a49f; PR #997)