### PR TITLE
Backport fix CI by moving exclude_lines

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,8 @@ omit =
     */site-packages/nose/*
     */pypy/*
 
+
+[report]
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover


### PR DESCRIPTION
Cherry picked from commit b1f497ae7224911cc4712a4b8939cd75845a2942; PR #943

This should fix CI for the 0.11 hotfix branch.