### PR TITLE
In python 3.3+, generator functions always return a value

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2309,7 +2309,10 @@ class HyASTCompiler(object):
             return ret
 
         if body.expr:
-            if body.contains_yield:
+            if body.contains_yield and not PY33:
+                # Prior to PEP 380 (introduced in Python 3.3)
+                # generators may not have a value in a return
+                # statement.
                 body += body.expr_as_stmt()
             else:
                 body += ast.Return(value=body.expr,


### PR DESCRIPTION
This fixes #1010 for Python 3.3+. Unit tests check that the behaviour is unchanged in earlier versions, and I've checked they pass on 2.7,3.4 and PyPy.