### PR TITLE
Keyword arguments to functions are required to be strings

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -547,6 +547,10 @@ class HyASTCompiler(object):
                     # defining keyword arguments.
                     it = iter(expr)
                     for k, v in zip(it, it):
+                        if not isinstance(k, HyString):
+                            raise HyTypeError(expr,
+                                              "Only strings can be used "
+                                              "as parameter names")
                         args.append(k)
                         ret += self.compile(v)
                         defaults.append(ret.force_expr)
@@ -560,6 +564,10 @@ class HyASTCompiler(object):
                 else:
                     k = expr
                     v = HySymbol("None").replace(k)
+                if not isinstance(k, HyString):
+                    raise HyTypeError(expr,
+                                      "Only strings can be used as "
+                                      "parameter names")
                 args.append(k)
                 ret += self.compile(v)
                 defaults.append(ret.force_expr)

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -372,6 +372,7 @@ def test_ast_lambda_lists():
     cant_compile('(fn [&key {"a" b} &key {"foo" bar}] [a foo])')
     cant_compile('(fn [&optional a &key {"foo" bar}] [a foo])')
     cant_compile('(fn [&optional [a b c]] a)')
+    cant_compile('(fn [&optional [1 2]] (list 1 2))')
 
 
 def test_ast_print():
@@ -402,6 +403,7 @@ def test_lambda_list_keywords_key():
     """ Ensure we can compile functions with &key."""
     can_compile("(fn (x &key {foo True}) (list x foo))")
     cant_compile("(fn (x &key {bar \"baz\"} &key {foo 42}) (list x bar foo))")
+    cant_compile("(fn (x &key {1 2 3 4}) (list x))")
 
 
 def test_lambda_list_keywords_kwargs():


### PR DESCRIPTION
See discussion in #961. Currently you can specify any type you like as the parameter "name" for a function when you use `&key` or `&optional`. This patch restricts it to be a `HyString`.