### PR TITLE
Include original XKCD title text in comic image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Hy
 [![Version](https://img.shields.io/pypi/v/hy.svg)](https://pypi.python.org/pypi/hy)
 [![Coverage Status](https://img.shields.io/coveralls/hylang/hy/master.svg)](https://coveralls.io/r/hylang/hy)
 
-[![XKCD #224](https://raw.github.com/hylang/shyte/18f6925e08684b0e1f52b2cc2c803989cd62cd91/imgs/xkcd.png)](https://xkcd.com/224/)
+<a href="https://xkcd.com/224/"><img title="We lost the documentation on quantum mechanics. You'll have to decode the regexes yourself." alt="XKCD #224" src="https://raw.github.com/hylang/shyte/18f6925e08684b0e1f52b2cc2c803989cd62cd91/imgs/xkcd.png"></a>
 
 Lisp and Python should love each other. Let's make it happen. [Try it](http://try-hy.appspot.com/).
 


### PR DESCRIPTION
When I see an XKCD comic, or an adaptation thereof, my first instinct is to look for title text. Not finding any, this proposes adding the original title text back in; if a good Hy-specific adaptation is proposed that'd be even better.

And no, this isn't important :)