### PR TITLE
docs: contrib/loop: fix rst markup.

### DIFF
--- a/docs/contrib/loop.rst
+++ b/docs/contrib/loop.rst
@@ -39,7 +39,7 @@ rebinds the variables set in the recursion point and sends code
 execution back to that recursion point. If ``recur`` is used in a
 non-tail position, an exception is raised.
 
-Usage: `(loop bindings &rest body)`
+Usage: ``(loop bindings &rest body)``
 
 Example:
 


### PR DESCRIPTION
In RestrutruedText, double backtick quotes (instead of single
backtick quotes in markdown) are used for code span.

---
 docs/contrib/loop.rst | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)