### PR TITLE
fix Hy on recent Pythons

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1516,7 +1516,8 @@ class HyASTCompiler(object):
             gen.append(ast.comprehension(
                 target=target,
                 iter=gen_res.force_expr,
-                ifs=[]))
+                ifs=[],
+                is_async=False))
 
         if cond.expr:
             gen[-1].ifs.append(cond.expr)


### PR DESCRIPTION
In issue #1111, @tianon reported that Hy didn't work with Python
3.6.0b1: trying to evaluate a simple expression at the REPL blew up with
`TypeError: required field "is_async" missing from comprehension`. This
was due to a grammar
change (https://www.python.org/dev/peps/pep-0530/#grammar-updates) in
the implementation (https://hg.python.org/cpython/rev/cf91a929b81a) of
PEP 530, which we can easily accomodate.