### PR TITLE
Revert #924

### DIFF
--- a/hy/macros.py
+++ b/hy/macros.py
@@ -18,7 +18,6 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-from inspect import getargspec, formatargspec
 from hy.models import replace_hy_obj, wrap_value
 from hy.models.expression import HyExpression
 from hy.models.string import HyString

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -125,16 +125,6 @@ def load_macros(module_name):
         _import(module)
 
 
-def make_empty_fn_copy(fn):
-    argspec = getargspec(fn)
-    formatted_args = formatargspec(*argspec)
-    fn_str = 'lambda {}: None'.format(
-        formatted_args.lstrip('(').rstrip(')'))
-
-    empty_fn = eval(fn_str)
-    return empty_fn
-
-
 def macroexpand(tree, compiler):
     """Expand the toplevel macros for the `tree`.
 
@@ -172,14 +162,6 @@ def macroexpand_1(tree, compiler):
             if m is not None:
                 if m._hy_macro_pass_compiler:
                     opts['compiler'] = compiler
-
-                try:
-                    m_copy = make_empty_fn_copy(m)
-                    m_copy(*ntree[1:], **opts)
-                except TypeError as e:
-                    msg = "expanding `" + str(tree[0]) + "': "
-                    msg += str(e).replace("<lambda>()", "", 1).strip()
-                    raise HyMacroExpansionError(tree, msg)
                 try:
                     obj = wrap_value(m(*ntree[1:], **opts))
                 except HyTypeError as e:

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -18,6 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+from inspect import getargspec
 from hy.models import replace_hy_obj, wrap_value
 from hy.models.expression import HyExpression
 from hy.models.string import HyString

--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -6,7 +6,6 @@ from hy.models.string import HyString
 from hy.models.list import HyList
 from hy.models.symbol import HySymbol
 from hy.models.expression import HyExpression
-from hy.errors import HyMacroExpansionError
 
 from hy.compiler import HyASTCompiler
 
@@ -40,13 +39,3 @@ def test_preprocessor_expression():
     obj = HyList([HyString("one"), HyString("two")])
     obj = tokenize('(shill ["one" "two"])')[0][1]
     assert obj == macroexpand(obj, HyASTCompiler(""))
-
-
-def test_preprocessor_exceptions():
-    """ Test that macro expansion raises appropriate exceptions"""
-    try:
-        macroexpand(tokenize('(defn)')[0], HyASTCompiler(__name__))
-        assert False
-    except HyMacroExpansionError as e:
-        assert "_hy_anon_fn_" not in str(e)
-        assert "TypeError" not in str(e)


### PR DESCRIPTION
reverts #924, which should never have been merged in the first place. Had we merged #903 first, #924 would not have passed our tests. (see discussion in #903).
