### PR TITLE
Allow --version as a synonym for -v

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -274,7 +274,7 @@ def cmdline_handler(scriptname, argv):
     parser.add_argument("--spy", action="store_true",
                         help="print equivalent Python code before executing")
 
-    parser.add_argument("-v", action="version", version=VERSION)
+    parser.add_argument("-v", "--version", action="version", version=VERSION)
 
     parser.add_argument("--show-tracebacks", action="store_true",
                         help="show complete tracebacks for Hy exceptions")


### PR DESCRIPTION
`--version` is [a GNU standard](https://www.gnu.org/prep/standards/html_node/_002d_002dversion.html#g_t_002d_002dversion) that is also common for non-GNU programs, such as Python.