### PR TITLE
Make (for [] ...) work like (for [_ []] ...) 

### DIFF
--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -112,7 +112,8 @@
     (macro-error args "`for' requires an even number of args.")]
    [(empty? body)
     (macro-error None "`for' requires a body to evaluate")]
-   [(empty? args) `(do ~@body ~@belse)]
+   [(empty? args)
+    (if belse `(do ~@(get belse 0 (slice 1 None))))]
    [(= (len args) 2) `(for* [~@args] (do ~@body) ~@belse)]
    [true
     (let [alist (cut args 0 nil 2)]

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -157,13 +157,13 @@
     (setv count2 (+ count2 x)))
   (assert (= count1 15))
   (assert (= count2 15))
-  (setv count 0)
+  (setv n 0)
   (for [x [1 2 3 4 5]
         y [1 2 3 4 5]]
-    (setv count (+ count x y))
+    (setv n (+ n x y))
     (else
-      (+= count 1)))
-  (assert (= count 151))
+      (+= n 1)))
+  (assert (= n 151))
   (assert (= (list ((fn [] (for [x [[1] [2 3]] y x] (yield y)))))
              (list-comp y [x [[1] [2 3]] y x])))
   (assert (= (list ((fn [] (for [x [[1] [2 3]] y x z (range 5)] (yield z)))))
@@ -212,12 +212,12 @@
 
 (defn test-while-loop []
   "NATIVE: test while loops?"
-  (setv count 5)
+  (setv n 5)
   (setv fact 1)
-  (while (> count 0)
-    (setv fact (* fact count))
-    (setv count (- count 1)))
-  (assert (= count 0))
+  (while (> n 0)
+    (setv fact (* fact n))
+    (setv n (- n 1)))
+  (assert (= n 0))
   (assert (= fact 120)))
 
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -174,11 +174,6 @@
   "NATIVE: test nesting for loops harder"
   ;; This test and feature is dedicated to @nedbat.
 
-  ;; let's ensure empty iterating is an implicit do
-  (setv t 0)
-  (for [] (setv t 1))
-  (assert (= t 1))
-
   ;; OK. This first test will ensure that the else is hooked up to the
   ;; for when we break out of it.
   (for [x (range 2)
@@ -210,8 +205,34 @@
   (assert (= flag 2)))
 
 
+(defn test-empty-for []
+  "NATIVE: test empty for loops"
+
+  (setv s "")
+  (for [x []]
+    (+= s "a"))
+  (assert (= s ""))
+
+  (setv s "")
+  (for [x []]
+    (+= s "a")
+    (else (+= s "b")))
+  (assert (= s "b"))
+
+  (setv s "")
+  (for []
+    (+= s "a"))
+  (assert (= s ""))
+
+  (setv s "")
+  (for []
+    (+= s "a")
+    (else (+= s "b")))
+  (assert (= s "b")))
+
+
 (defn test-while-loop []
-  "NATIVE: test while loops?"
+  "NATIVE: test while loops"
   (setv n 5)
   (setv fact 1)
   (while (> n 0)


### PR DESCRIPTION
Before, `(for [] ...)` would execute its body once, instead of zero times.
