### PR TITLE
    Add PHONY targets; wrap call to recursive make; add path to find.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all:
 	@echo ""
 
 docs:
-	make -C docs html
+	$(MAKE) -C docs html
 
 upload: r
 	python setup.py sdist upload
@@ -72,10 +72,10 @@ coveralls:
 
 clean:
 	@find . -name "*.pyc" -exec rm {} \;
-	@find -name __pycache__ -delete
+	@find . -name __pycache__ -delete
 	@${RM} -r -f .tox
 	@${RM} -r -f dist
 	@${RM} -r -f *.egg-info
 	@${RM} -r -f docs/_build
 
-.PHONY: docs
+.PHONY: all docs upload full venv dev test tox flake clear d diff r python coveralls clean


### PR DESCRIPTION
Commit message:

    I've marked added the rest of the phony build targets; wrapped the
    recursive make call[0], and added the path specifier to the find
    command for compatibility with BSD find.

    [0]: https://www.gnu.org/software/make/manual/html_node/Recursion.html

Output of `make test`:
```
Name                      Stmts   Miss  Cover
---------------------------------------------
hy.py                        13      0   100%
hy/_compat.py                29      3    90%
hy/cmdline.py               213    162    24%
hy/compiler.py             1324     85    94%
hy/completer.py              95     75    21%
hy/contrib.py                 0      0   100%
hy/contrib/dispatch.py       20      1    95%
hy/core.py                    1      0   100%
hy/errors.py                 52     20    62%
hy/importer.py              141     22    84%
hy/lex.py                    14      2    86%
hy/lex/exceptions.py         27     14    48%
hy/lex/lexer.py              23      0   100%
hy/lex/parser.py            173      3    98%
hy/macros.py                107      7    93%
hy/models.py                 21      2    90%
hy/models/complex.py          6      0   100%
hy/models/cons.py            54      5    91%
hy/models/dict.py            12      0   100%
hy/models/expression.py       6      0   100%
hy/models/float.py            6      0   100%
hy/models/integer.py         17      1    94%
hy/models/keyword.py         10      0   100%
hy/models/list.py            20      1    95%
hy/models/set.py              6      1    83%
hy/models/string.py           5      0   100%
hy/models/symbol.py           7      0   100%
hy/version.py                 2      0   100%
---------------------------------------------
TOTAL                      2404    404    83%
----------------------------------------------------------------------
Ran 429 tests in 36.746s

OK
```