### PR TITLE
Allow &rest after &optional, like Python

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -503,19 +503,13 @@ class HyASTCompiler(object):
         for expr in exprs:
 
             if expr in ll_keywords:
-                if expr == "&rest" and lambda_keyword is None:
-                    lambda_keyword = expr
-                elif expr == "&optional":
+                if expr == "&optional":
                     if len(defaults) > 0:
                         raise HyTypeError(expr,
                                           "There can only be &optional "
                                           "arguments or one &key argument")
                     lambda_keyword = expr
-                elif expr == "&key":
-                    lambda_keyword = expr
-                elif expr == "&kwonly":
-                    lambda_keyword = expr
-                elif expr == "&kwargs":
+                elif expr in ("&rest", "&key", "&kwonly", "&kwargs"):
                     lambda_keyword = expr
                 else:
                     raise HyTypeError(expr,

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -397,6 +397,7 @@ def test_lambda_list_keywords_rest():
     """ Ensure we can compile functions with lambda list keywords."""
     can_compile("(fn (x &rest xs) (print xs))")
     cant_compile("(fn (x &rest xs &rest ys) (print xs))")
+    can_compile("(fn (&optional a &rest xs) (print xs))")
 
 
 def test_lambda_list_keywords_key():
@@ -410,6 +411,7 @@ def test_lambda_list_keywords_kwargs():
     """ Ensure we can compile functions with &kwargs."""
     can_compile("(fn (x &kwargs kw) (list x kw))")
     cant_compile("(fn (x &kwargs xs &kwargs ys) (list x xs ys))")
+    can_compile("(fn (&optional x &kwargs kw) (list x kw))")
 
 
 def test_lambda_list_keywords_kwonly():


### PR DESCRIPTION
I consider this a bug-fix, since `lambda a=None, *xs: 1` is valid Python, but in Hy, you'd have to write that as `(fn [&rest xs &optional a] 1)` without this patch.