### PR TITLE
Replace `true` with `T` and `false` with `F`

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -34,6 +34,13 @@ languages.
 Notes on Syntax
 ===============
 
+logical values
+--------------
+
+``True``, ``False``, and ``None`` have the same meaning as in Python.
+In addition, ``True`` may be written as ``T``, ``False`` as ``F``, and
+``None`` as ``nil``.
+
 integers
 --------
 
@@ -392,7 +399,7 @@ Some example usage:
 
 .. code-block:: clj
 
-    => (if true
+    => (if T
     ...  (do (print "Side effects rock!")
     ...      (print "Yeah, really!")))
     Side effects rock!
@@ -589,7 +596,7 @@ Parameters may have the following keywords in front of them:
         => (apply compare ["lisp" "python"]
         ...        {"keyfn" (fn [x y]
         ...                   (reduce - (map (fn [s] (ord (first s))) [x y])))
-        ...         "reverse" true})
+        ...         "reverse" T})
         4
 
     .. code-block:: python

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -137,7 +137,7 @@ is ``True``, the function prints Python code instead.
     body=[
         Expr(value=Call(func=Name(id='print'), args=[Str(s='Hello World!')], keywords=[], starargs=None, kwargs=None))])
 
-   => (disassemble '(print "Hello World!") true)
+   => (disassemble '(print "Hello World!") T)
    print('Hello World!')
 
 
@@ -898,12 +898,12 @@ as an example of how to use some of these functions.
    (defn fib []
      (setv a 0)
      (setv b 1)
-     (while true
+     (while T
        (yield a)
        (setv (, a b) (, b (+ a b)))))
 
 
-Note the ``(while true ...)`` loop. If we run this in the REPL,
+Note the ``(while T ...)`` loop. If we run this in the REPL,
 
 .. code-block:: hy
 
@@ -1140,7 +1140,7 @@ if *from-file* ends before a complete expression can be parsed.
    => ;   (print "hyfriends!")
    => (with [f (open "example.hy")]
    ...   (try
-   ...     (while true
+   ...     (while T
    ...            (let [exp (read f)]
    ...              (do
    ...                (print "OHY" exp)

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -288,7 +288,7 @@ Second Stage Expression-Dispatch
 
 The only special case is the ``HyExpression``, since we need to create different
 AST depending on the special form in question. For instance, when we hit an
-``(if true true false)``, we need to generate a ``ast.If``, and properly
+``(if T T F)``, we need to generate a ``ast.If``, and properly
 compile the sub-nodes. This is where the ``@builds()`` with a String as an
 argument comes in.
 
@@ -321,7 +321,7 @@ In Python, doing something like:
 features, such as ``if``, ``for``, or ``while`` are statements.
 
 Since they have no "value" to Python, this makes working in Hy hard, since
-doing something like ``(print (if true true false))`` is not just common, it's
+doing something like ``(print (if T T F))`` is not just common, it's
 expected.
 
 As a result, we auto-mangle things using a ``Result`` object, where we offer
@@ -331,7 +331,7 @@ assignment to things while running.
 
 As example, the Hy::
 
-    (print (if true true false))
+    (print (if T T F))
 
 Will turn into::
 

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -138,13 +138,13 @@ Coding Style
      (def *limit* 400000)
 
      (defn fibs [a b]
-       (while true
+       (while T
          (yield a)
          (setv (, a b) (, b (+ a b)))))
 
      ;; Bad (and not preferred)
      (defn fibs [a b]
-       (while true
+       (while T
          (yield a)
          (def (, a b) (, b (+ a b)))))
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -264,15 +264,16 @@ In Hy, you would do:
      (print "That variable is too big!")]
     [(< somevar 10)
      (print "That variable is too small!")]
-    [true
+    [T
      (print "That variable is jussssst right!")])
 
 What you'll notice is that ``cond`` switches off between a statement
 that is executed and checked conditionally for true or falseness, and
 then a bit of code to execute if it turns out to be true.  You'll also
 notice that the ``else`` is implemented at the end simply by checking
-for ``true`` -- that's because ``true`` will always be true, so if we get
-this far, we'll always run that one!
+for ``T`` -- that's because ``T`` will always be true, so if we get
+this far, we'll always run that one! (``T`` is a synonym for ``True``,
+``F`` for ``False``, and ``nil`` for ``None``.)
 
 You might notice above that if you have code like:
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -83,7 +83,7 @@ def load_stdlib():
 # keywords in Python 3.*
 def _is_hy_builtin(name, module_name):
     extras = ['True', 'False', 'None',
-              'true', 'false', 'nil']
+              'T', 'F', 'nil']
     if name in extras or keyword.iskeyword(name):
         return True
     # for non-Hy modules, check for pre-existing name in

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -39,7 +39,7 @@
     ((type form) (outer (HyExpression (map inner form))))]
    [(coll? form)
     (walk inner outer (list form))]
-   [true (outer form)]))
+   [T (outer form)]))
 
 (defn postwalk [f form]
   "Performs depth-first, post-order traversal of form. Calls f on each

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -64,7 +64,7 @@
   "Decrement n by 1"
   (- n 1))
 
-(defn disassemble [tree &optional [codegen false]]
+(defn disassemble [tree &optional [codegen F]]
   "Return the python AST for a quoted Hy tree as a string.
    If the second argument is true, generate python code instead."
   (import astor)
@@ -250,8 +250,8 @@
   "Return True if char `x` parses as an integer"
   (try
     (integer? (int x))
-    (except [e ValueError] False)
-    (except [e TypeError] False)))
+    (except [ValueError] F)
+    (except [TypeError] F)))
 
 (defn interleave [&rest seqs]
   "Return an iterable of the first item in each of seqs, then the second etc."
@@ -267,7 +267,7 @@
 
 (defn iterate [f x]
   (setv val x)
-  (while true
+  (while T
     (yield val)
     (setv val (f val))))
 
@@ -363,7 +363,7 @@
 
 (defn repeatedly [func]
   "Yield result of running func repeatedly"
-  (while true
+  (while T
     (yield (func))))
 
 (defn second [coll]
@@ -412,7 +412,7 @@
   "Read from input and returns a tokenized string.
    Can take a given input buffer to read from"
   (def buff "")
-  (while true
+  (while T
     (def inn (str (.readline from-file)))
     (if (= inn eof)
       (raise (EOFError "Reached end of file" )))

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -124,7 +124,7 @@
     (macro-error None "`for' requires a body to evaluate")]
    [(empty? args) `(do ~@body ~@belse)]
    [(= (len args) 2) `(for* [~@args] (do ~@body) ~@belse)]
-   [true
+   [T
     (let [alist (cut args 0 nil 2)]
       `(for* [(, ~@alist) (genexpr (, ~@alist) [~@args])] (do ~@body) ~@belse))]))
 
@@ -228,7 +228,7 @@
          (setv ~g!iter (iter ~expr))
          (setv ~g!return nil)
          (setv ~g!message nil)
-         (while true
+         (while T
            (try (if (isinstance ~g!iter types.GeneratorType)
                   (setv ~g!message (yield (.send ~g!iter ~g!message)))
                   (setv ~g!message (yield (next ~g!iter))))

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -302,8 +302,8 @@ def t_identifier(p):
             pass
 
     table = {
-        "true": "True",
-        "false": "False",
+        "T": "True",
+        "F": "False",
         "nil": "None",
     }
 

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -102,7 +102,7 @@ def test_ast_invalid_unary_op():
 def test_ast_bad_while():
     "Make sure AST can't compile invalid while"
     cant_compile("(while)")
-    cant_compile("(while (true))")
+    cant_compile("(while (T))")
 
 
 def test_ast_good_do():

--- a/tests/native_tests/contrib/anaphoric.hy
+++ b/tests/native_tests/contrib/anaphoric.hy
@@ -35,11 +35,11 @@
 
 (defn test-ap-if []
   "NATIVE: testing anaphoric if"
-  (ap-if true (assert-true it))
-  (ap-if false true (assert-false it))
-  (try (macroexpand '(ap-if true))
-       (except [HyMacroExpansionError] true)
-       (else (assert false))))
+  (ap-if T (assert-true it))
+  (ap-if F T (assert-false it))
+  (try (macroexpand '(ap-if T))
+       (except [HyMacroExpansionError] T)
+       (else (assert F))))
 
 (defn test-ap-each []
   "NATIVE: testing anaphoric each"

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -19,15 +19,15 @@
   (try
    (setv n (non-tco-sum 100 10000))
    (except [e RuntimeError]
-     (assert true))
+     (assert T))
    (else
-    (assert false)))
+    (assert F)))
 
   ;; tco-sum should not fail
   (try
    (setv n (tco-sum 100 10000))
    (except [e RuntimeError]
-     (assert false))
+     (assert F))
    (else
     (assert (= n 10100)))))
 
@@ -41,6 +41,6 @@
   (try
    (bad-recur 3)
    (except [e TypeError]
-     (assert true))
+     (assert T))
    (else
-    (assert false))))
+    (assert F))))

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -570,10 +570,10 @@
   (setv res (list (take-nth 3 [1 2 3 None 5 6])))
   (assert-equal res [1 None])
   ;; using 0 should raise ValueError
-  (let [passed false]
+  (let [passed F]
     (try
      (setv res (list (take-nth 0 [1 2 3 4 5 6 7])))
-     (except [ValueError] (setv passed true)))
+     (except [ValueError] (setv passed T)))
     (assert passed)))
 
 (defn test-take-while []

--- a/tests/native_tests/defclass.hy
+++ b/tests/native_tests/defclass.hy
@@ -43,10 +43,10 @@
 
 (defn test-defclass-dynamic-inheritance []
   "NATIVE: test defclass with dynamic inheritance"
-  (defclass A [((fn [] (if true list dict)))]
+  (defclass A [((fn [] (if T list dict)))]
     [x 42])
   (assert (isinstance (A) list))
-  (defclass A [((fn [] (if false list dict)))]
+  (defclass A [((fn [] (if F list dict)))]
     [x 42])
   (assert (isinstance (A) dict)))
 
@@ -58,7 +58,7 @@
   (try
    (do
     (x)
-    (assert false))
+    (assert F))
    (except [NameError])))
 
 (defn test-defclass-docstring []

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -71,9 +71,9 @@
        (except [e [TypeError]] (assert (in "Can't assign to a builtin" (str e)))))
   (try (eval '(setv None 1))
        (except [e [TypeError]] (assert (in "Can't assign to a builtin" (str e)))))
-  (try (eval '(setv false 1))
+  (try (eval '(setv F 1))
        (except [e [TypeError]] (assert (in "Can't assign to a builtin" (str e)))))
-  (try (eval '(setv true 0))
+  (try (eval '(setv T 0))
        (except [e [TypeError]] (assert (in "Can't assign to a builtin" (str e)))))
   (try (eval '(setv nil 1))
        (except [e [TypeError]] (assert (in "Can't assign to a builtin" (str e)))))
@@ -101,28 +101,28 @@
   (try
     (do
       (eval '(setv (do 1 2) 1))
-      (assert false))
+      (assert F))
     (except [e HyTypeError]
       (assert (= e.message "Can't assign or delete a non-expression"))))
 
   (try
     (do
       (eval '(setv 1 1))
-      (assert false))
+      (assert F))
     (except [e HyTypeError]
       (assert (= e.message "Can't assign or delete a HyInteger"))))
 
   (try
     (do
       (eval '(setv {1 2} 1))
-      (assert false))
+      (assert F))
     (except [e HyTypeError]
       (assert (= e.message "Can't assign or delete a HyDict"))))
 
   (try
     (do
       (eval '(del 1 1))
-      (assert false))
+      (assert F))
     (except [e HyTypeError]
       (assert (= e.message "Can't assign or delete a HyInteger")))))
 
@@ -224,8 +224,8 @@
 (defn test-not []
   "NATIVE: test not"
   (assert (not (= 1 2)))
-  (assert (= true (not false)))
-  (assert (= false (not 42))) )
+  (assert (= T (not F)))
+  (assert (= F (not 42))) )
 
 
 (defn test-inv []
@@ -274,14 +274,14 @@
 
 (defn test-branching []
   "NATIVE: test if branching"
-  (if true
+  (if T
     (assert (= 1 1))
     (assert (= 2 1))))
 
 
 (defn test-branching-with-do []
   "NATIVE: test if branching (multiline)"
-  (if false
+  (if F
     (assert (= 2 1))
     (do
      (assert (= 1 1))
@@ -291,7 +291,7 @@
 (defn test-branching-expr-count-with-do []
   "NATIVE: make sure we execute the right number of expressions in the branch"
   (setv counter 0)
-  (if false
+  (if F
     (assert (= 2 1))
     (do
      (setv counter (+ counter 1))
@@ -303,8 +303,8 @@
 (defn test-cond []
   "NATIVE: test if cond sorta works."
   (cond
-   [(= 1 2) (assert (is true false))]
-   [(is None None) (setv x true) (assert x)])
+   [(= 1 2) (assert (is T F))]
+   [(is None None) (setv x T) (assert x)])
   (assert (= (cond) nil)))
 
 
@@ -359,9 +359,9 @@
 
 (defn test-imported-bits []
   "NATIVE: test the imports work"
-  (assert (is (exists ".") true))
-  (assert (is (isdir ".") true))
-  (assert (is (isfile ".") false)))
+  (assert (is (exists ".") T))
+  (assert (is (isdir ".") T))
+  (assert (is (isfile ".") F)))
 
 
 (defn test-kwargs []
@@ -409,7 +409,7 @@
 (defn test-bare-try [] (try
     (try (raise ValueError))
   (except [ValueError])
-  (else (assert false))))
+  (else (assert F))))
 
 
 (defn test-exceptions []
@@ -426,70 +426,70 @@
   (try (do) (except [IOError]) (except))
 
   ;; Test correct (raise)
-  (let [passed false]
+  (let [passed F]
     (try
      (try
       (raise IndexError)
       (except [IndexError] (raise)))
      (except [IndexError]
-       (setv passed true)))
+       (setv passed T)))
     (assert passed))
 
   ;; Test incorrect (raise)
-  (let [passed false]
+  (let [passed F]
     (try
      (raise)
      ;; Python 2 raises TypeError
      ;; Python 3 raises RuntimeError
      (except [[TypeError RuntimeError]]
-       (setv passed true)))
+       (setv passed T)))
     (assert passed))
 
   ;; Test (finally)
-  (let [passed false]
+  (let [passed F]
     (try
      (do)
-     (finally (setv passed true)))
+     (finally (setv passed T)))
     (assert passed))
 
   ;; Test (finally) + (raise)
-  (let [passed false]
+  (let [passed F]
     (try
      (raise Exception)
      (except)
-     (finally (setv passed true)))
+     (finally (setv passed T)))
     (assert passed))
 
 
   ;; Test (finally) + (raise) + (else)
-  (let [passed false
-        not-elsed true]
+  (let [passed F
+        not-elsed T]
     (try
      (raise Exception)
      (except)
-     (else (setv not-elsed false))
-     (finally (setv passed true)))
+     (else (setv not-elsed F))
+     (finally (setv passed T)))
     (assert passed)
     (assert not-elsed))
 
   (try
    (raise (KeyError))
-   (except [[IOError]] (assert false))
+   (except [[IOError]] (assert F))
    (except [e [KeyError]] (assert e)))
 
   (try
    (raise (KeyError))
-   (except [[IOError]] (assert false))
+   (except [[IOError]] (assert F))
    (except [e [KeyError]] (assert e)))
 
   (try
    (get [1] 3)
-   (except [IndexError] (assert true))
+   (except [IndexError] (assert T))
    (except [IndexError] (do)))
 
   (try
    (print foobar42ofthebaz)
-   (except [IndexError] (assert false))
+   (except [IndexError] (assert F))
    (except [NameError] (do)))
 
   (try
@@ -530,10 +530,10 @@
      (setv foobar42ofthebaz 42)
      (assert (= foobar42ofthebaz 42))))
 
-  (let [passed false]
+  (let [passed F]
     (try
      (try (do) (except) (else (bla)))
-     (except [NameError] (setv passed true)))
+     (except [NameError] (setv passed T)))
     (assert passed))
 
   (let [x 0]
@@ -625,7 +625,7 @@
 
 (defn test-pass []
   "NATIVE: Test pass worksish"
-  (if true (do) (do))
+  (if T (do) (do))
   (assert (= 1 1)))
 
 
@@ -874,7 +874,7 @@
 
 (defn test-if-mangler []
   "NATIVE: test that we return ifs"
-  (assert (= true (if true true true))))
+  (assert (= T (if T T T))))
 
 
 (defn test-nested-mangles []
@@ -953,19 +953,19 @@
 
 (defn test-xor []
   "NATIVE: test the xor macro"
-  (let [xor-both-true (xor true true)
-        xor-both-false (xor false false)
-        xor-true-false (xor true false)]
-    (assert (= xor-both-true false))
-    (assert (= xor-both-false false))
-    (assert (= xor-true-false true))))
+  (let [xor-both-true (xor T T)
+        xor-both-false (xor F F)
+        xor-true-false (xor T F)]
+    (assert (= xor-both-true F))
+    (assert (= xor-both-false F))
+    (assert (= xor-true-false T))))
 
 (defn test-if-return-branching []
   "NATIVE: test the if return branching"
                                 ; thanks, algernon
   (assert (= 1 (let [x 1
                      y 2]
-                 (if true
+                 (if T
                    2)
                  1)))
   (assert (= 1 (let [x 1 y 2]
@@ -992,9 +992,9 @@
   (for [x (range 10)]
     (if (in "foo" "foobar")
       (do
-       (if true true true))
+       (if T T T))
       (do
-       (if false false false)))))
+       (if F F F)))))
 
 
 (defn test-eval []
@@ -1034,8 +1034,8 @@
   ; yo dawg
   (try (eval '(eval)) (except [e HyTypeError]) (else (assert False)))
   (try (eval '(eval "snafu")) (except [e HyTypeError]) (else (assert False)))
-  (try (eval 'false []) (except [e HyTypeError]) (else (assert False)))
-  (try (eval 'false {} 1) (except [e HyTypeError]) (else (assert False))))
+  (try (eval 'F []) (except [e HyTypeError]) (else (assert False)))
+  (try (eval 'F {} 1) (except [e HyTypeError]) (else (assert False))))
 
 
 (defn test-import-syntax []
@@ -1099,7 +1099,7 @@
 
 (defn test-if-let-mixing []
   "NATIVE: test that we can now mix if and let"
-  (assert (= 0 (if true (let [x 0] x) 42))))
+  (assert (= 0 (if T (let [x 0] x) 42))))
 
 (defn test-if-in-if []
   "NATIVE: test that we can use if in if"
@@ -1140,8 +1140,8 @@
   (try (parald 1 2 3 4)
        (except [NameError] True)
        (else (assert False)))
-  (require [tests.resources.tlib :as T])
-  (assert (= (T.parald 1 2 3) [9 1 2 3]))
+  (require [tests.resources.tlib :as TL])
+  (assert (= (TL.parald 1 2 3) [9 1 2 3]))
   (try (parald 1 2 3 4)
        (except [NameError] True)
        (else (assert False)))
@@ -1286,7 +1286,7 @@
                "Module(\n    body=[Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[]))])"))
     (assert (= (disassemble '(do (leaky) (leaky) (macros)))
                "Module(\n    body=[\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[], starargs=None, kwargs=None))])")))
-  (assert (= (disassemble '(do (leaky) (leaky) (macros)) true)
+  (assert (= (disassemble '(do (leaky) (leaky) (macros)) T)
              "leaky()\nleaky()\nmacros()")))
 
 

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -59,19 +59,19 @@
     (eval '(defmacro f [&kwonly a b]))
     (except [e HyTypeError]
       (assert (= e.message "macros cannot use &kwonly")))
-    (else (assert false)))
+    (else (assert F)))
 
   (try
     (eval '(defmacro f [&kwargs kw]))
     (except [e HyTypeError]
       (assert (= e.message "macros cannot use &kwargs")))
-    (else (assert false)))
+    (else (assert F)))
 
   (try
     (eval '(defmacro f [&key {"kw" "xyz"}]))
     (except [e HyTypeError]
       (assert (= e.message "macros cannot use &key")))
-    (else (assert false))))
+    (else (assert F))))
 
 (defn test-fn-calling-macro []
   "NATIVE: test macro calling a plain function"

--- a/tests/native_tests/py3_only_tests.hy
+++ b/tests/native_tests/py3_only_tests.hy
@@ -15,9 +15,9 @@
 (defn test-kwonly []
   "NATIVE: test keyword-only arguments"
   ;; keyword-only with default works
-  (let [kwonly-foo-default-false (fn [&kwonly [foo false]] foo)]
-    (assert (= (apply kwonly-foo-default-false) false))
-    (assert (= (apply kwonly-foo-default-false [] {"foo" true}) true)))
+  (let [kwonly-foo-default-false (fn [&kwonly [foo F]] foo)]
+    (assert (= (apply kwonly-foo-default-false) F))
+    (assert (= (apply kwonly-foo-default-false [] {"foo" T}) T)))
   ;; keyword-only without default ...
   (let [kwonly-foo-no-default (fn [&kwonly foo] foo)
         attempt-to-omit-default (try

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -10,9 +10,9 @@
 
 (defn test-quoted-hoistable []
   "NATIVE: check whether quote works on hoisted things"
-  (setv f (quote (if true true true)))
+  (setv f (quote (if T T T)))
   (assert (= (car f) (quote if)))
-  (assert (= (cdr f) (quote (true true true)))))
+  (assert (= (cdr f) (quote (T T T)))))
 
 
 (defn test-quoted-macroexpand []

--- a/tests/native_tests/unless.hy
+++ b/tests/native_tests/unless.hy
@@ -1,10 +1,10 @@
 (defn test-unless []
   "NATIVE: test unless"
-  (assert (= (unless false 1) 1))
-  (assert (= (unless false 1 2) 2))
-  (assert (= (unless false 1 3) 3))
-  (assert (= (unless true 2) None))
-  (assert (= (unless true 2) nil))
+  (assert (= (unless F 1) 1))
+  (assert (= (unless F 1 2) 2))
+  (assert (= (unless F 1 3) 3))
+  (assert (= (unless T 2) None))
+  (assert (= (unless T 2) nil))
   (assert (= (unless (!= 1 2) 42) None))
   (assert (= (unless (!= 1 2) 42) nil))
   (assert (= (unless (!= 2 2) 42) 42)))

--- a/tests/native_tests/when.hy
+++ b/tests/native_tests/when.hy
@@ -1,10 +1,10 @@
 (defn test-when []
   "NATIVE: test when"
-  (assert (= (when true 1) 1))
-  (assert (= (when true 1 2) 2))
-  (assert (= (when true 1 3) 3))
-  (assert (= (when false 2) None))
+  (assert (= (when T 1) 1))
+  (assert (= (when T 1 2) 2))
+  (assert (= (when T 1 3) 3))
+  (assert (= (when F 2) None))
   (assert (= (when (= 1 2) 42) None))
-  (assert (= (when false 2) nil))
+  (assert (= (when F 2) nil))
   (assert (= (when (= 1 2) 42) nil))
   (assert (= (when (= 2 2) 42) 42)))


### PR DESCRIPTION
Per discussion in #908.

`True` and `False` are still allowed. Allowing users to use these as variable names is probably more trouble than it's worth, and I figure this helps to smooth over human translation from Python code to Hy. It might be a good idea to use `T` and `F` consistently in Hy's own code, not to mention the documentation. (This preference could be stated in the style guide.)

I added a bit to the documentation about the correspondences between `True`, `False`, `None`, and their synonyms because this didn't seem to be documented at all.