### PR TITLE
Fix #1151

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1807,16 +1807,17 @@ class HyASTCompiler(object):
                                  ctx=ast.Load(),
                                  lineno=root_line,
                                  col_offset=root_column)
+            temp_variables = [name, expr_name]
 
             def make_assign(value, node=None):
                 if node is None:
                     line, column = root_line, root_column
                 else:
                     line, column = node.lineno, node.col_offset
-                return ast.Assign(targets=[ast.Name(id=var,
-                                                    ctx=ast.Store(),
-                                                    lineno=line,
-                                                    col_offset=column)],
+                positioned_name = ast.Name(id=var, ctx=ast.Store(),
+                                           lineno=line, col_offset=column)
+                temp_variables.append(positioned_name)
+                return ast.Assign(targets=[positioned_name],
                                   value=value,
                                   lineno=line,
                                   col_offset=column)
@@ -1846,7 +1847,7 @@ class HyASTCompiler(object):
                                       orelse=[]))
                 current = current[-1].body
             ret = sum(root, ret)
-            ret += Result(expr=expr_name, temp_variables=[expr_name, name])
+            ret += Result(expr=expr_name, temp_variables=temp_variables)
         else:
             ret += ast.BoolOp(op=opnode(),
                               lineno=root_line,

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -971,7 +971,12 @@
   ; short circuiting
   (setv a 1)
   (or 1 (setv a 2))
-  (assert (= a 1)))
+  (assert (= a 1))
+  ; issue #1151
+  (setv a (or 1 (do 2 2)))
+  (assert (= a 1))
+  (setv a (or 0 (do 2 2)))
+  (assert (= a 2)))
 
 
 (defn test-xor []

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -955,6 +955,28 @@
   (and 0 (setv a 2))
   (assert (= a 1)))
 
+(defn test-and-#1151-do []
+  (setv a (and 0 (do 2 3)))
+  (assert (= a 0))
+  (setv a (and 1 (do 2 3)))
+  (assert (= a 3)))
+
+(defn test-and-#1151-for []
+  (setv l [])
+  (setv x (and 0 (for [n [1 2]] (.append l n))))
+  (assert (= x 0))
+  (assert (= l []))
+  (setv x (and 15 (for [n [1 2]] (.append l n))))
+  (assert (= l [1 2])))
+
+(defn test-and-#1151-del []
+  (setv l ["a" "b"])
+  (setv x (and 0 (del (get l 1))))
+  (assert (= x 0))
+  (assert (= l ["a" "b"]))
+  (setv x (and 15 (del (get l 1))))
+  (assert (= l ["a"])))
+
 
 (defn test-or []
   "NATIVE: test the or function"
@@ -971,13 +993,29 @@
   ; short circuiting
   (setv a 1)
   (or 1 (setv a 2))
-  (assert (= a 1))
-  ; issue #1151
-  (setv a (or 1 (do 2 2)))
-  (assert (= a 1))
-  (setv a (or 0 (do 2 2)))
-  (assert (= a 2)))
+  (assert (= a 1)))
 
+(defn test-or-#1151-do []
+  (setv a (or 1 (do 2 3)))
+  (assert (= a 1))
+  (setv a (or 0 (do 2 3)))
+  (assert (= a 3)))
+
+(defn test-or-#1151-for []
+  (setv l [])
+  (setv x (or 15 (for [n [1 2]] (.append l n))))
+  (assert (= x 15))
+  (assert (= l []))
+  (setv x (or 0 (for [n [1 2]] (.append l n))))
+  (assert (= l [1 2])))
+
+(defn test-or-#1151-del []
+  (setv l ["a" "b"])
+  (setv x (or 15 (del (get l 1))))
+  (assert (= x 15))
+  (assert (= l ["a" "b"]))
+  (setv x (or 0 (del (get l 1))))
+  (assert (= l ["a"])))
 
 (defn test-xor []
   "NATIVE: test the xor macro"


### PR DESCRIPTION
It was caused by improper management of temp_variables when compiling and/or statements.

See, that wasn't so hard. :)