### PR TITLE
ignore PyCharm .idea/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .coverage
 build/
 .noseids
+.idea/


### PR DESCRIPTION
This is a hidden folder that PyCharm (or IntelliJ with equivalent plugin) uses for bookkeeping. An IDE like PyCharm can make some aspects of managing bigger Python projects (like Hy) easier to deal with, but I don't think it belongs in the repository.