### PR TITLE
Ignore a new Flake8 whitespace error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ tox: venv
 	tox
 
 flake:
-	flake8 hy tests --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E305
+	flake8 hy tests --ignore=E121,E123,E126,E226,E24,E704,W503,E305
 
 clear:
 	clear

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ tox: venv
 	tox
 
 flake:
-	flake8 hy tests
+	flake8 hy tests --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E305
 
 clear:
 	clear

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
  -rrequirements-dev.txt
 
 [testenv:flake8]
-commands = flake8 hy bin tests
+commands = flake8 hy bin tests --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E305

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
  -rrequirements-dev.txt
 
 [testenv:flake8]
-commands = flake8 hy bin tests --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E305
+commands = flake8 hy bin tests --ignore=E121,E123,E126,E226,E24,E704,W503,E305


### PR DESCRIPTION
Fixes #1157.

The new check is E305. Since we're now using the `--ignore` option, we have to list all the checks that are ignored by default, too.

I decided that ignoring E305 was better than changing the whitespace it was complaining about because, in at least some cases in our current codebase, single blank lines are used to indicate that several top-level definitions are associated with each other.