### PR TITLE
Hyghlight (Hy support for highlight.js library)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,3 +72,4 @@
 * Jakub Wilk <jwilk@jwilk.net>
 * Kodi Arfer <git@arfer.net>
 * Karan Sharma <karansharma1295@gmail.com>
+* Sergey Sobko <s.sobko@profitware.ru>

--- a/eg/hyghlight/README.md
+++ b/eg/hyghlight/README.md
@@ -1,0 +1,11 @@
+# Hyghlight
+
+Hy builtin keywords generator for highlight.js and may be other highlighting libraries.
+
+## Usage
+
+Generate actual hy.js for highlight.js project:
+
+```bash
+hy hyghlight.hy > ~/projects/highlight.js/src/languages/hy.js
+```

--- a/eg/hyghlight/hyghlight.hy
+++ b/eg/hyghlight/hyghlight.hy
@@ -1,0 +1,116 @@
+#!/usr/bin/env hy
+
+(import os.path)
+
+(import hy.compiler)
+(import hy.core)
+
+
+;; absolute path for Hy core
+(setv *core-path* (os.path.dirname hy.core.--file--))
+
+
+(defn collect-macros [collected-names opened-file]
+  (while True
+    (try
+     (let [data (read opened-file)]
+       (if (and (in (first data)
+                    '(defmacro defmacro/g! defn))
+                (not (.startswith (second data) "_")))
+         (.add collected-names (second data))))
+     (except [e EOFError] (break)))))
+
+
+(defmacro core-file [filename]
+  `(open (os.path.join *core-path* ~filename)))
+
+
+(defmacro contrib-file [filename]
+  `(open (os.path.join *core-path* ".." "contrib" ~filename)))
+
+
+(defn collect-core-names []
+  (doto (set)
+        (.update hy.core.language.*exports*)
+        (.update hy.core.shadow.*exports*)
+        (collect-macros (core-file "macros.hy"))
+        (collect-macros (core-file "bootstrap.hy"))))
+
+
+(defn collect-contrib-names []
+  (doto (set)
+        (collect-macros (contrib-file "alias.hy"))
+        (collect-macros (contrib-file "anaphoric.hy"))
+        (collect-macros (contrib-file "curry.hy"))
+        (collect-macros (contrib-file "flow.hy"))
+        (collect-macros (contrib-file "loop.hy"))
+        (collect-macros (contrib-file "meth.hy"))
+        (collect-macros (contrib-file "multi.hy"))
+        (collect-macros (contrib-file "profile.hy"))
+        (collect-macros (contrib-file "sequences.hy"))
+        (collect-macros (contrib-file "walk.hy"))))
+
+
+(defn collect-compiler-names []
+  (set-comp (str name)
+            [name (hy.compiler.-compile-table.keys)]
+            (not (in "<class" (str name)))))
+
+
+(defn collect-python-builtins []
+  (set-comp function.--name--
+            [function (.values --builtins--)]
+            (in "built-in function" (repr function))))
+
+
+(defn to-lisp-names [collected-names]
+  (let [to-add (set) to-discard (set)]
+    (for [name collected-names]
+      (let [lisp-name (.replace (str name) "_" "-")]
+        (if (in "-bang" lisp-name)
+          (do (.add to-discard name)
+              (.add to-discard lisp-name)
+              (.add to-add (.replace lisp-name "-bang" "!"))))
+
+        (if (in "is-" lisp-name)
+          (.add to-add (.join "" (-> (drop 3 lisp-name)
+                                     (list)
+                                     (+ ["?"])))))
+
+        (if (in "-" lisp-name)
+          (do
+           (.add to-add lisp-name)
+           (.add to-discard name)))))
+
+    (-> (doto collected-names (.update to-add))
+        (.difference to-discard))))
+
+
+(defn hyghlight-names []
+  (-> (.union (collect-core-names)
+              (collect-contrib-names)
+              (collect-compiler-names)
+              (collect-python-builtins))
+      (to-lisp-names)
+      (sorted)))
+
+
+(defn generate-highlight-js-file []
+  (defn replace-highlight-js-keywords [line]
+    (if (in "// keywords" line)
+      (+ line
+         (.join " +\n"
+                (list-comp (.format "{space}'{line} '"
+                                    :space (* " " 6)
+                                    :line (.join " " keyword-line))
+                           [keyword-line (partition (hyghlight-names) 10)])))
+      line))
+
+  (with [f (open "templates/hy.js")]
+        (.join ""
+               (list-comp (replace-highlight-js-keywords line)
+                          [line (.readlines f)]))))
+
+
+(defmain [&rest args]
+  (print (generate-highlight-js-file)))

--- a/eg/hyghlight/templates/hy.js
+++ b/eg/hyghlight/templates/hy.js
@@ -1,0 +1,80 @@
+/*
+Language: Hy
+Description: Hy syntax (based on clojure.js)
+Author: Sergey Sobko <s.sobko@profitware.ru>
+Category: lisp
+*/
+
+function(hljs) {
+  var keywords = {
+    'builtin-name':
+      // keywords
+
+   };
+
+  var SYMBOLSTART = 'a-zA-Z_\\-!.?+*=<>&#\'';
+  var SYMBOL_RE = '[' + SYMBOLSTART + '][' + SYMBOLSTART + '0-9/;:]*';
+  var SIMPLE_NUMBER_RE = '[-+]?\\d+(\\.\\d+)?';
+
+  var SHEBANG = {
+    className: 'meta',
+    begin: '^#!', end: '$'
+  };
+
+  var SYMBOL = {
+    begin: SYMBOL_RE,
+    relevance: 0
+  };
+  var NUMBER = {
+    className: 'number', begin: SIMPLE_NUMBER_RE,
+    relevance: 0
+  };
+  var STRING = hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null});
+  var COMMENT = hljs.COMMENT(
+    ';',
+    '$',
+    {
+      relevance: 0
+    }
+  );
+  var LITERAL = {
+    className: 'literal',
+    begin: /\b([Tt]rue|[Ff]alse|nil|None)\b/
+  };
+  var COLLECTION = {
+    begin: '[\\[\\{]', end: '[\\]\\}]'
+  };
+  var HINT = {
+    className: 'comment',
+    begin: '\\^' + SYMBOL_RE
+  };
+  var HINT_COL = hljs.COMMENT('\\^\\{', '\\}');
+  var KEY = {
+    className: 'symbol',
+    begin: '[:]{1,2}' + SYMBOL_RE
+  };
+  var LIST = {
+    begin: '\\(', end: '\\)'
+  };
+  var BODY = {
+    endsWithParent: true,
+    relevance: 0
+  };
+  var NAME = {
+    keywords: keywords,
+    lexemes: SYMBOL_RE,
+    className: 'name', begin: SYMBOL_RE,
+    starts: BODY
+  };
+  var DEFAULT_CONTAINS = [LIST, STRING, HINT, HINT_COL, COMMENT, KEY, COLLECTION, NUMBER, LITERAL, SYMBOL];
+
+  LIST.contains = [hljs.COMMENT('comment', ''), NAME, BODY];
+  BODY.contains = DEFAULT_CONTAINS;
+  COLLECTION.contains = DEFAULT_CONTAINS;
+
+  return {
+    aliases: ['hylang'],
+    illegal: /\S/,
+    contains: [SHEBANG, LIST, STRING, HINT, HINT_COL, COMMENT, KEY, COLLECTION, NUMBER, LITERAL]
+  }
+}


### PR DESCRIPTION
The following code generates a list for all built-in keywords in Hy (including Python keywords, core & contrib macros). It is used to generate hy.js - code for Hy support in highlight.js library. MR for providing the support may be found here: https://github.com/isagalaev/highlight.js/pull/1382

To make the story simple this may help implementing Hy highlighting in Gitlab CE.
