### PR TITLE
no-readline on OS X fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,3 +73,4 @@
 * Kodi Arfer <git@arfer.net>
 * Karan Sharma <karansharma1295@gmail.com>
 * Sergey Sobko <s.sobko@profitware.ru>
+# Erich Blume <blume.erich@gmail.com>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,7 +5,7 @@ In order to begin contributing code to the hylang project, ensure that you
 have completed the following steps to set up your development environment.
 
 - Clone the project to a local git repository. Let's assume you've got a
-   handle on that.
+  handle on that.
 
 - Create a virtual environment that will contain the python dependencies
   hylang uses. Starting with Python 3.3, the correct way to do this is::

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,42 @@
+Development Quickstart
+======================
+
+In order to begin contributing code to the hylang project, ensure that you
+have completed the following steps to set up your development environment.
+
+- Clone the project to a local git repository. Let's assume you've got a
+   handle on that.
+
+- Create a virtual environment that will contain the python dependencies
+  hylang uses. Starting with Python 3.3, the correct way to do this is::
+
+    $ python -m venv hylang_environment
+    $ source hylang_environment/bin/activate
+
+  In older versions of Python, and in many common distrobutions, this can
+  equivalently be done with::
+
+    $ virtualenv hylang_environment
+    $ source hylang_environment/bin/activate
+
+  How you name and use your virtual environment is up to you, you just need to
+  have one.
+
+- Install the core dependencies required for development as described in setup.py::
+
+    $ python setup.py develop
+
+- Install the additional tooling required for running unit tests, generating
+  docs, etc.::
+
+    $ pip install -r requirements-dev.txt
+
+- Verify that the unit tests run successfully (and documentation is generated, etc.)::
+
+    $ make d
+
+You should now have a working development environment.
+
 Contributor Guidelines
 ======================
 

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -47,7 +47,7 @@ except ImportError:
     except ImportError:
         docomplete = False
 
-if sys.platform == 'darwin' and 'libedit' in readline.__doc__:
+if docomplete and sys.platform == 'darwin' and 'libedit' in readline.__doc__:
     readline_bind = "bind ^I rl_complete"
 else:
     readline_bind = "tab: complete"


### PR DESCRIPTION
In the case that the user is running OS X / Darwin and does not have `readline` installed in their virtual environment, currently the completer barfs due to the failed import. **Without knowing any knock-on consequences**, I simply bypass the offending statement in the case that the `readline` import failed. This needs reviewing as there is a high risk of unintended consequences in other environments.

I also took the liberty of adding a quickstart to CONTRIBUTING. Let me know if you'd like me to pull that out. I added it as I could not find anything like it in the existing docs, and it seemed like a natural place for it.