### PR TITLE
Add the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include AUTHORS
+include LICENSE
+include NEWS
+include README.md


### PR DESCRIPTION
Add a `MANIFEST.in` file to ensure that some other files get included in packages (e.g. `sdist`s on PyPI). In particular, include the author listing, the license file (as required by the MIT), the news/changelog, and the readme.