### PR TITLE
Use `and` in hy.core.shadow.comp_op

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ Changes from 0.12.1
    [ Language Changes ]
    * xor: If exactly one argument is true, return it
 
+   [ Bug Fixes ]
+   * Shadowed comparison operators now use `and` instead of `&`
+     for chained comparisons
+
 Changes from 0.12.0
 
    [ Bug Fixes ]

--- a/hy/core/shadow.hy
+++ b/hy/core/shadow.hy
@@ -65,7 +65,7 @@
   "Helper for shadow comparison operators"
   (if (< (len args) 2)
     (raise (TypeError "Need at least 2 arguments to compare"))
-    (reduce operator.and_
+    (reduce (lambda [x y] (and x y))
             (list-comp (op x y)
                        [(, x y) (zip args (cut args 1))]))))
 (defn < [&rest args]

--- a/tests/native_tests/shadow.hy
+++ b/tests/native_tests/shadow.hy
@@ -50,6 +50,7 @@
 
 (defn test-shadow-compare []
   "NATIVE: test shadow compare"
+
   (for [x [< <= = != >= >]]
      (assert (try
               (x)
@@ -59,6 +60,7 @@
               (x 1)
               (except [TypeError] True)
               (else (raise AssertionError)))))
+
   (for [(, x y) [[< >=]
                  [<= >]
                  [= !=]]]
@@ -67,6 +69,7 @@
                 [1 1]
                 [2 2]]]
       (assert (= (apply x args) (not (apply y args))))))
+
   (let [s-lt <
         s-gt >
         s-le <=
@@ -84,4 +87,15 @@
     (assert (apply s-eq [1 1 1 1 1]))
     (assert (not (apply s-eq [1 1 2 1 1])))
     (assert (apply s-ne [1 2 3 4 5]))
-    (assert (not (apply s-ne [1 1 2 3 4])))))
+    (assert (not (apply s-ne [1 1 2 3 4]))))
+
+  ; Make sure chained comparisons use `and`, not `&`.
+  ; https://github.com/hylang/hy/issues/1191
+  (defclass C [object] [
+    __init__ (fn [self x]
+      (setv self.x x))
+    __lt__ (fn [self other]
+      self.x)])
+  (assert (= (< (C "a") (C "b") (C "c")) "b"))
+  (setv f <)
+  (assert (= (f (C "a") (C "b") (C "c")) "b")))


### PR DESCRIPTION
Makes shadow operator behavior match normal (Python) operator behavior
when said operators are used in chained comparisons.

Unlike Python's `and`, the usage of `and` here is not short-circuiting.

Resolves #1191