### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -144,7 +144,7 @@ def koan_macro():
 @macro("ideas")
 def ideas_macro():
     return HyExpression([HySymbol('print'),
-                         HyString("""
+                         HyString(r"""
 
     => (import [sh [figlet]])
     => (figlet "Hi, Hy!")

--- a/tests/compilers/test_compiler.py
+++ b/tests/compilers/test_compiler.py
@@ -42,7 +42,7 @@ class CompilerTest(unittest.TestCase):
         self.assert_(callable(compiler.builds("foo_bar")))
         self.assert_(callable(compiler.builds("-")))
         self.assertRaisesRegexp(TypeError,
-                                "\*post\* translated strings",
+                                r"\*post\* translated strings",
                                 compiler.builds, "foobar-with-dash-")
 
 

--- a/tests/lex/test_lex.py
+++ b/tests/lex/test_lex.py
@@ -264,7 +264,7 @@ def test_escapes():
     entry = tokenize("(foo \"foo\\n\")")[0]
     assert entry[1] == "foo\n"
 
-    entry = tokenize("(foo \"foo\s\")")[0]
+    entry = tokenize("(foo \"foo\\s\")")[0]
     assert entry[1] == "foo\\s"
 
 


### PR DESCRIPTION
Fixes:
```
hy/cmdline.py:175: DeprecationWarning: invalid escape sequence \_
tests/lex/test_lex.py:267: DeprecationWarning: invalid escape sequence \s
tests/compilers/test_compiler.py:45: DeprecationWarning: invalid escape sequence \*
```
when run against Python 3.6 with warnings enabled.

Found using [pydiatra](https://github.com/jwilk/pydiatra).