### PR TITLE
Use HTTPS for github.com, docs.python.org and notes.pault.ag URLs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -105,7 +105,7 @@ http://contributor-covenant.org/version/1/1/0/.
 .. _issue tracker: https://github.com/hylang/hy/issues
 .. _Fork the Repo: https://help.github.com/articles/fork-a-repo/
 .. _Start Here: http://rogerdudler.github.io/git-guide/
-.. _good-first-bug: http://github.com/hylang/hy/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-bug
+.. _good-first-bug: https://github.com/hylang/hy/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-bug
 .. _latest: http://hylang.org/
 .. _stable: http://docs.hylang.org/en/stable/
 

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -1763,4 +1763,4 @@ yield-from
 ``yield-from`` is used to call a subgenerator.  This is useful if you
 want your coroutine to be able to delegate its processes to another
 coroutine, say, if using something fancy like
-`asyncio <http://docs.python.org/3.4/library/asyncio.html>`_.
+`asyncio <https://docs.python.org/3.4/library/asyncio.html>`_.

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -221,6 +221,6 @@ Thanks
   Survival Guide`_
 + The `Clojure Style Guide`_
 
-.. _`Hy Survival Guide`: http://notes.pault.ag/hy-survival-guide/
+.. _`Hy Survival Guide`: https://notes.pault.ag/hy-survival-guide/
 .. _`Clojure Style Guide`: https://github.com/bbatsov/clojure-style-guide
 .. _`@paultag`: https://github.com/paultag


### PR DESCRIPTION
Found using [urlycue](https://github.com/jwilk/urlycue).