### PR TITLE
Fix bug: quoting a bytestring raises ImportError

### DIFF
--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -26,7 +26,7 @@ except ImportError:
     __version__ = 'unknown'
 
 
-from hy.models import HyExpression, HyInteger, HyKeyword, HyComplex, HyString, HySymbol, HyFloat, HyDict, HyList, HySet, HyCons  # NOQA
+from hy.models import HyExpression, HyInteger, HyKeyword, HyComplex, HyString, HyBytes, HySymbol, HyFloat, HyDict, HyList, HySet, HyCons  # NOQA
 
 
 import hy.importer  # NOQA

--- a/tests/compilers/native/quoting.hy
+++ b/tests/compilers/native/quoting.hy
@@ -1,10 +1,11 @@
 ;;;
 ;;;
 
-(import [hy [HyExpression HySymbol HyString]])
+(import [hy [HyExpression HySymbol HyString HyBytes]])
 
 
 (defn test-basic-quoting []
   (assert (= (type (quote (foo bar))) HyExpression))
   (assert (= (type (quote foo)) HySymbol))
-  (assert (= (type (quote "string")) HyString)))
+  (assert (= (type (quote "string")) HyString))
+  (assert (= (type (quote b"string")) HyBytes)))


### PR DESCRIPTION
No NEWS entry is required because bytestrings are already a new feature.