### PR TITLE
Added class use example to tutorial

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,5 @@
 * Sergey Sobko <s.sobko@profitware.ru>
 * Philip Xu <pyx@xrefactor.com>
 * Charles de Lacombe <ealhad@mail.com>
+* John Patterson <john@johnppatterson.com>
+

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -476,6 +476,11 @@ like::
           Return our copy of x
           """
           return self.x
+          
+And we might use it like::
+
+  bar = FooBar(1)
+  print bar.get_x()
 
 
 In Hy:
@@ -491,7 +496,20 @@ In Hy:
     (defn get-x [self]
       "Return our copy of x"
       self.x))
+      
+And we can use it like:
 
+.. code-block:: clj
+
+  (setv bar (FooBar 1))
+  (print (bar.get-x))
+  
+Or using the leading dot syntax!
+
+.. code-block:: clj
+
+  (print (.get-x (FooBar 1)))
+      
 
 You can also do class-level attributes.  In Python::
 


### PR DESCRIPTION
I was following along and noticed that it wasn't actually explained how to _use_ the object we just made. I include both the `setv` style of writing the Hy as we've been using in the rest of the docs up to this point and a more LISP-y style use of the object.