### PR TITLE
fix example in documentation to unquote in quasi quote

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,4 @@
 * Sergey Sobko <s.sobko@profitware.ru>
 * Philip Xu <pyx@xrefactor.com>
 * Charles de Lacombe <ealhad@mail.com>
+* Kai Lüke <kailueke@riseup.net>

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -730,7 +730,7 @@ For example,
 .. code-block:: clj
 
     => (defn expensive-get-number [] (print "spam") 14)
-    => (defmacro triple-1 [n] `(+ n n n))
+    => (defmacro triple-1 [n] `(+ ~n ~n ~n))
     => (triple-1 (expensive-get-number))  ; evals n three times
     spam
     spam


### PR DESCRIPTION
Error message was
`NameError: name 'n' is not defined`