### PR TITLE
Fix bug: `loop` replaced strings equal to "recur"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,7 @@ Changes from 0.12.1
    * A `yield` inside of a `with` statement will properly suppress implicit
      returns.
    * `setv` no longer unnecessarily tries to get attributes
+   * `loop` no longer replaces string literals equal to "recur"
 
    [ Misc. Improvements ]
    * New contrib module `hy-repr`

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -44,3 +44,7 @@
      (assert True))
    (else
     (assert False))))
+
+(defn test-recur-string []
+  "test that `loop` doesn't touch a string named `recur`"
+  (assert (= (loop [] (+ "recur" "1")) "recur1")))


### PR DESCRIPTION
Since this change removes the undocumented function `hy.contrib.loop.recursive-replace` (I've used `hy.contrib.walk.prewalk` instead), it closes #465.