### PR TITLE
Fix issue when installing on Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,20 @@ class Install(install):
     def run(self):
         # Import each Hy module to ensure it's compiled.
         import os, importlib
+        postpone_filenames = ('macros.hy')
+        import_modules_later = []
         for dirpath, _, filenames in os.walk("hy"):
             for filename in filenames:
                 if filename.endswith(".hy"):
-                    importlib.import_module(
-                        dirpath.replace("/", ".") + "." + filename[:-len(".hy")])
+                    module_to_import = dirpath.replace(
+                        "/", ".") + "." + filename[:-len(".hy")]
+                    if filename in postpone_filenames:
+                        import_modules_later.append(module_to_import)
+                        continue
+                    importlib.import_module(module_to_import)
+
+        for iml in import_modules_later:
+            importlib.import_module(iml)
         install.run(self)
 
 install_requires = ['rply>=0.7.0', 'astor>=0.5', 'clint>=0.4']


### PR DESCRIPTION
When doing `pip install git+https://github.com/hylang/hy.git` on Python 3.4 I get the exact same error as mentioned in #1016. This would not happen for me when installing on Python 3.5, which I assume is because of an underlying change in how [os.walk](https://docs.python.org/3/library/os.html#os.walk) works in 3.5:

> Changed in version 3.5: This function now calls os.scandir() instead of os.listdir(), making it faster by reducing the number of calls to os.stat().

...and that's somehow changing the order of import modules. Although that's purely speculation and honestly I don't know much about the differences between Python 3.4 and 3.5

Anyway, with this PR I was able to successfully install on Python 3.4 (`pip install git+https://github.com/jacktasia/hy.git@fix-install-3.4#egg=hy`)