### PR TITLE
Don't parse 5.attr or :foo.attr as symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tox: venv
 	tox
 
 flake:
-	flake8 hy tests --ignore=E121,E123,E126,E226,E24,E704,W503,E305
+	flake8 hy tests --ignore=E121,E123,E126,E226,E24,E704,W503,E302,E305,E701
 
 clear:
 	clear

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ Changes from 0.13.0
    [ Language Changes ]
    * Single-character "sharp macros" changed to "tag macros", which can have
      longer names
+   * Periods are no longer allowed in keywords
+
+   [ Bug Fixes ]
+   * Numeric literals are no longer parsed as symbols when followed by a dot
+     and a symbol
 
 Changes from 0.12.1
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1446,7 +1446,6 @@
   (assert (= (keyword 'foo) :foo))
   (assert (= (keyword 'foo-bar) :foo-bar))
   (assert (= (keyword 1) :1))
-  (assert (= (keyword 1.0) :1.0))
   (assert (= (keyword :foo_bar) :foo-bar)))
 
 (defn test-name-conversion []

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -5,56 +5,31 @@
 from hy.models import (HyExpression, HyInteger, HyFloat, HyComplex, HySymbol,
                        HyString, HyDict, HyList, HySet, HyCons)
 from hy.lex import LexException, PrematureEndOfInput, tokenize
+import pytest
+
+def peoi(): return pytest.raises(PrematureEndOfInput)
+def lexe(): return pytest.raises(LexException)
 
 
 def test_lex_exception():
     """ Ensure tokenize throws a fit on a partial input """
-    try:
-        tokenize("(foo")
-        assert True is False
-    except PrematureEndOfInput:
-        pass
-    try:
-        tokenize("{foo bar")
-        assert True is False
-    except PrematureEndOfInput:
-        pass
-    try:
-        tokenize("(defn foo [bar]")
-        assert True is False
-    except PrematureEndOfInput:
-        pass
-    try:
-        tokenize("(foo \"bar")
-        assert True is False
-    except PrematureEndOfInput:
-        pass
+    with peoi(): tokenize("(foo")
+    with peoi(): tokenize("{foo bar")
+    with peoi(): tokenize("(defn foo [bar]")
+    with peoi(): tokenize("(foo \"bar")
 
 
 def test_unbalanced_exception():
     """Ensure the tokenization fails on unbalanced expressions"""
-    try:
-        tokenize("(bar))")
-        assert True is False
-    except LexException:
-        pass
-
-    try:
-        tokenize("(baz [quux]])")
-        assert True is False
-    except LexException:
-        pass
+    with lexe(): tokenize("(bar))")
+    with lexe(): tokenize("(baz [quux]])")
 
 
 def test_lex_single_quote_err():
     "Ensure tokenizing \"' \" throws a LexException that can be stringified"
     # https://github.com/hylang/hy/issues/1252
-    try:
-        tokenize("' ")
-    except LexException as e:
-        assert "Could not identify the next token" in str(e)
-    else:
-        assert False
+    with lexe() as e: tokenize("' ")
+    assert "Could not identify the next token" in str(e.value)
 
 
 def test_lex_expression_symbols():

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -129,6 +129,21 @@ def test_lex_digit_separators():
             [HySymbol(",,,,___,__1__,,__,,2__,q,__")])
 
 
+def test_lex_bad_attrs():
+    with lexe(): tokenize("1.foo")
+    with lexe(): tokenize("0.foo")
+    with lexe(): tokenize("1.5.foo")
+    with lexe(): tokenize("1e3.foo")
+    with lexe(): tokenize("5j.foo")
+    with lexe(): tokenize("3+5j.foo")
+    with lexe(): tokenize("3.1+5.1j.foo")
+    assert tokenize("j.foo")
+    with lexe(): tokenize("3/4.foo")
+    assert tokenize("a/1.foo")
+    assert tokenize("1/a.foo")
+    with lexe(): tokenize(":hello.foo")
+
+
 def test_lex_line_counting():
     """ Make sure we can count lines / columns """
     entry = tokenize("(foo (one two))")[0]


### PR DESCRIPTION
Fixes #1143.