### PR TITLE
Fix Tuukka print example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -562,7 +562,7 @@ we used "Tuukka" as parameter):
 
 .. code-block:: clj
 
-  (print "Hello there," Tuukka)
+  (print "Hello there," "Tuukka")
 
 We can also manipulate code with macros:
 


### PR DESCRIPTION
It was missing quotes around "Tuukka". Output from hy to confirm everything's good:

```clojure
hy unknown using CPython(default) 3.6.1 on Linux
=> (print "Hello there," "Tuukka")
Hello there, Tuukka
```