### PR TITLE
universal newlines in test

### DIFF
--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -23,9 +23,10 @@ def run_cmd(cmd, stdin_data=None, expect=0):
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
+                         universal_newlines=True,
                          shell=True)
     if stdin_data is not None:
-        p.stdin.write(stdin_data.encode('ASCII'))
+        p.stdin.write(stdin_data)
         p.stdin.flush()
         p.stdin.close()
     # Read stdout and stderr otherwise if the PIPE buffer is full, we might
@@ -33,8 +34,8 @@ def run_cmd(cmd, stdin_data=None, expect=0):
     stdout = ""
     stderr = ""
     while p.poll() is None:
-        stdout += p.stdout.read().decode('utf-8')
-        stderr += p.stderr.read().decode('utf-8')
+        stdout += p.stdout.read()
+        stderr += p.stderr.read()
     assert p.returncode == expect
     return stdout, stderr
 


### PR DESCRIPTION
Change run_cmd for test_bin.py to use universal newlines (text mode) for Windows compatibility.

Is there some reason this popen has to be done in binary mode? Windows does line endings differently, which makes a test fail on Windows. #1289. The other failing test shown in that issue isn't fixed by this though.