### PR TITLE
Remove the Python 2 yield-from macro

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 Changes from 0.13.0
 
    [ Language Changes ]
+   * `yield-from` is no longer supported under Python 2
    * Single-character "sharp macros" changed to "tag macros", which can have
      longer names
    * Periods are no longer allowed in keywords

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1128,13 +1128,9 @@ class HyASTCompiler(object):
 
         return ret
 
-    @builds("yield_from")
+    @builds_if("yield_from", PY3)
     @checkargs(max=1)
     def compile_yield_from_expression(self, expr):
-        if not PY3:
-            raise HyCompileError(
-                "yield-from only supported in python 3.3+!")
-
         expr.pop(0)
         ret = Result(contains_yield=True)
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -201,24 +201,6 @@
      `(do (setv ~@(interleave ~gs ~os))
           ~@~body)))
 
-(if-python2
-  (defmacro/g! yield-from [expr]
-    `(do (import types)
-         (setv ~g!iter (iter ~expr))
-         (setv ~g!return None)
-         (setv ~g!message None)
-         (while True
-           (try (if (isinstance ~g!iter types.GeneratorType)
-                  (setv ~g!message (yield (.send ~g!iter ~g!message)))
-                  (setv ~g!message (yield (next ~g!iter))))
-           (except [~g!e StopIteration]
-             (do (setv ~g!return (if (hasattr ~g!e "value")
-                                     (. ~g!e value)
-                                     None))
-               (break)))))
-           ~g!return))
-  None)
-
 
 (defmacro defmain [args &rest body]
   "Write a function named \"main\" and do the if __main__ dance"

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -306,31 +306,6 @@
   (assert (= (lif-not 0 "false" "true") "true")))
 
 
-(defn test-yield-from []
-  "NATIVE: testing yield from"
-  (defn yield-from-test []
-    (for* [i (range 3)]
-      (yield i))
-    (yield-from [1 2 3]))
-  (assert (= (list (yield-from-test)) [0 1 2 1 2 3])))
-
-(defn test-yield-from-exception-handling []
-  "NATIVE: Ensure exception handling in yield from works right"
-  (defn yield-from-subgenerator-test []
-    (yield 1)
-    (yield 2)
-    (yield 3)
-    (assert 0))
-  (defn yield-from-test []
-    (for* [i (range 3)]
-       (yield i))
-    (try
-     (yield-from (yield-from-subgenerator-test))
-     (except [e AssertionError]
-       (yield 4))))
-  (assert (= (list (yield-from-test)) [0 1 2 1 2 3 4])))
-
-
 (defn test-defmain []
   "NATIVE: make sure defmain is clean"
   (global --name--)

--- a/tests/native_tests/py3_only_tests.hy
+++ b/tests/native_tests/py3_only_tests.hy
@@ -35,3 +35,29 @@
   (assert (= (apply function-of-various-args
                     [1 2 3 4] {"foo" 5 "bar" 6 "quux" 7})
              (, 1 2 (, 3 4)  5 {"bar" 6 "quux" 7}))))
+
+
+(defn test-yield-from []
+  "NATIVE: testing yield from"
+  (defn yield-from-test []
+    (for* [i (range 3)]
+      (yield i))
+    (yield-from [1 2 3]))
+  (assert (= (list (yield-from-test)) [0 1 2 1 2 3])))
+
+
+(defn test-yield-from-exception-handling []
+  "NATIVE: Ensure exception handling in yield from works right"
+  (defn yield-from-subgenerator-test []
+    (yield 1)
+    (yield 2)
+    (yield 3)
+    (assert 0))
+  (defn yield-from-test []
+    (for* [i (range 3)]
+       (yield i))
+    (try
+     (yield-from (yield-from-subgenerator-test))
+     (except [e AssertionError]
+       (yield 4))))
+  (assert (= (list (yield-from-test)) [0 1 2 1 2 3 4])))


### PR DESCRIPTION
Backports of Python 3 features to Hy under Python 2 aren't worth the effort of supporting. It's Hy time for people to upgrade.

- Closes #691.
- Closes #692.