### PR TITLE
Require HySymbols instead of HyStrings in more cases

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ Changes from 0.13.0
    * Numeric literals are no longer parsed as symbols when followed by a dot
      and a symbol
    * Hy now respects the environment variable PYTHONDONTWRITEBYTECODE
+   * String literals should no longer be interpreted as special forms or macros
 
 Changes from 0.12.1
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2006,7 +2006,7 @@ class HyASTCompiler(object):
         if isinstance(fn, HyKeyword):
             return self._compile_keyword_call(expression)
 
-        if isinstance(fn, HyString):
+        if isinstance(fn, HySymbol):
             ret = self.compile_atom(fn, expression)
             if ret:
                 return ret
@@ -2242,7 +2242,7 @@ class HyASTCompiler(object):
                 args[i] = var = HySymbol(self.get_anon_var())
                 expression = HyExpression([
                     HyExpression([
-                        HyString("setv"), arg, var
+                        HySymbol("setv"), arg, var
                     ])]
                 ) + expression
                 expression = expression.replace(arg[0])

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -3,7 +3,7 @@
 # license. See the LICENSE.
 
 from inspect import getargspec, formatargspec
-from hy.models import replace_hy_obj, HyExpression, HyString
+from hy.models import replace_hy_obj, HyExpression, HySymbol
 
 from hy.errors import HyTypeError, HyMacroExpansionError
 
@@ -179,7 +179,7 @@ def macroexpand_1(tree, compiler):
 
         opts = {}
 
-        if isinstance(fn, HyString):
+        if isinstance(fn, HySymbol):
             m = _hy_macros[compiler.module_name].get(fn)
             if m is None:
                 m = _hy_macros[None].get(fn)

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -169,6 +169,14 @@
       (assert (= e.message "Can't assign or delete a HyInteger")))))
 
 
+(defn test-no-str-as-sym []
+  "Don't treat strings as symbols in the calling position"
+  (with [(pytest.raises TypeError)] ("setv" True 3))  ; A special form
+  (with [(pytest.raises TypeError)] ("abs" -2))       ; A function
+  (with [(pytest.raises TypeError)] ("when" 1 2))     ; A macro
+  None)  ; Avoid https://github.com/hylang/hy/issues/1320
+
+
 (defn test-fn-corner-cases []
   "NATIVE: tests that fn/defn handles corner cases gracefully"
   (try (eval '(fn "foo"))


### PR DESCRIPTION
Fixes  #1317.