### PR TITLE
Implement #qC string literals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tox: venv
 	tox
 
 flake:
-	flake8 hy tests --ignore=E121,E123,E126,E226,E24,E704,W503,E302,E305,E701
+	flake8 hy tests --ignore=E121,E123,E126,E203,E226,E24,E704,W503,E302,E305,E701
 
 clear:
 	clear

--- a/hy/lex/lexer.py
+++ b/hy/lex/lexer.py
@@ -1,8 +1,11 @@
+# -*- encoding: utf-8 -*-
 # Copyright 2017 the authors.
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.
 
+import re
 from rply import LexerGenerator
+from rply.lexergenerator import Rule, Match
 
 
 lg = LexerGenerator()
@@ -13,6 +16,12 @@ lg = LexerGenerator()
 end_quote = r'(?![\s\)\]\}])'
 
 identifier = r'[^()\[\]{}\'"\s;]+'
+
+hashstring_paired_delims = (
+  # Unicode General Category "Pi" with the matching closing mark
+  (u"«", u"»"), (u"‘", u"’"), (u"‛", u"’"), (u"“", u"”"), (u"‹", u"›"), (u"⸂", u"⸃"), (u"⸄", u"⸅"), (u"⸉", u"⸊"), (u"⸌", u"⸍"), (u"⸜", u"⸝"), (u"⸠", u"⸡"),  # noqa
+  # BidiBrackets.txt
+  (u"(", u")"), (u"[", u"]"), (u"{", u"}"), (u"༺", u"༻"), (u"༼", u"༽"), (u"᚛", u"᚜"), (u"⁅", u"⁆"), (u"⁽", u"⁾"), (u"₍", u"₎"), (u"⌈", u"⌉"), (u"⌊", u"⌋"), (u"〈", u"〉"), (u"❨", u"❩"), (u"❪", u"❫"), (u"❬", u"❭"), (u"❮", u"❯"), (u"❰", u"❱"), (u"❲", u"❳"), (u"❴", u"❵"), (u"⟅", u"⟆"), (u"⟦", u"⟧"), (u"⟨", u"⟩"), (u"⟪", u"⟫"), (u"⟬", u"⟭"), (u"⟮", u"⟯"), (u"⦃", u"⦄"), (u"⦅", u"⦆"), (u"⦇", u"⦈"), (u"⦉", u"⦊"), (u"⦋", u"⦌"), (u"⦍", u"⦐"), (u"⦏", u"⦎"), (u"⦑", u"⦒"), (u"⦓", u"⦔"), (u"⦕", u"⦖"), (u"⦗", u"⦘"), (u"⧘", u"⧙"), (u"⧚", u"⧛"), (u"⧼", u"⧽"), (u"⸢", u"⸣"), (u"⸤", u"⸥"), (u"⸦", u"⸧"), (u"⸨", u"⸩"), (u"〈", u"〉"), (u"《", u"》"), (u"「", u"」"), (u"『", u"』"), (u"【", u"】"), (u"〔", u"〕"), (u"〖", u"〗"), (u"〘", u"〙"), (u"〚", u"〛"), (u"﹙", u"﹚"), (u"﹛", u"﹜"), (u"﹝", u"﹞"), (u"（", u"）"), (u"［", u"］"), (u"｛", u"｝"), (u"｟", u"｠"), (u"｢", u"｣"))  # noqa
 
 lg.add('LPAREN', r'\(')
 lg.add('RPAREN', r'\)')
@@ -27,6 +36,46 @@ lg.add('UNQUOTESPLICE', r'~@%s' % end_quote)
 lg.add('UNQUOTE', r'~%s' % end_quote)
 lg.add('HASHBANG', r'#!.*[^\r\n]')
 lg.add('HASHSTARS', r'#\*+')
+
+class BalancedQStringRule(Rule):
+    # We use this class instead of a regex so we can match nested
+    # matching delimiters. (Python's `re` doesn't support recursive
+    # regexes.)
+    name = 'QSTRING'
+
+    def __init__(self, opener, closer):
+        self.opener, self.closer = opener, closer
+
+    def matches(self, s, pos):
+        # Match `#q{ ... }`, where the curly braces stand for the
+        # delimiters and `...` can contain nested pairs of matching
+        # delimiters.
+        start = pos
+        if not s[pos:pos + 3] == '#q' + self.opener:
+            return None
+        pos += 3
+        depth = 1
+        while True:
+            if pos >= len(s):
+                return None
+            elif s[pos] == self.opener:
+                depth += 1
+            elif s[pos] == self.closer:
+                depth -= 1
+                if depth == 0:
+                    break
+            pos += 1
+        return Match(start, pos + 1)
+
+# q-string, balanced style: #q{ ... }
+for opener, closer in hashstring_paired_delims:
+    lg.rules.append(BalancedQStringRule(opener, closer))
+# q-string, pointy style: #q<foo> ... foo
+lg.add('QSTRING', r'#q<([^>]+)>(?:.|\n)*?\1')
+# q-string, plain style: #qX ... X
+lg.add('QSTRING', u'#q([^<{}])(?:.|\\n)*?\\1'.format(''.join(
+    re.escape(opener) for opener, _ in hashstring_paired_delims)))
+
 lg.add('HASHOTHER', r'#%s' % identifier)
 
 # A regexp which matches incomplete strings, used to support

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -2,6 +2,7 @@
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.
 
+import re
 from functools import wraps
 from ast import literal_eval
 
@@ -297,6 +298,24 @@ def t_string(p):
 def t_partial_string(p):
     # Any unterminated string requires more input
     raise PrematureEndOfInput("Premature end of input")
+
+
+@pg.production("string : QSTRING")
+@set_boundaries
+def t_qstring(p):
+    # Remove the leading "#q".
+    s = p[0].value[2:]
+    # Remove the delimiters.
+    if s.startswith('<'):
+        m = re.match('<([^>]+)', s)
+        s = s[1 + len(m.group(1)) + 1 : -len(m.group(1))]
+    else:
+        s = s[1:-1]
+    # Remove any leading newline.
+    if s.startswith('\n'):
+        s = s[1:]
+    # The rest is interpreted as a raw Unicode string.
+    return HyString(s)
 
 
 @pg.production("identifier : IDENTIFIER")


### PR DESCRIPTION
Closes #1287.

There's no documentation or NEWS update yet.

~~Note that matching delimiters are supported, but not inner pairs of matching delimiters (e.g., `#q(())` is parsed the same as `"(" )`). This is because the lexer is regex-based, and Python doesn't implement recursive regexes.~~ Matching delimiters are supported.

~~@gilch, I didn't reserve a character for indicating multi-character delimiters since you hadn't seemed to settle on `[`,`=`, or `<`.~~ Multi-character delimiters are indicated with `<`.