### PR TITLE
Allow `unquote-splice` to accept any false value as empty

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,3 +78,4 @@
 * John Patterson <john@johnppatterson.com>
 * Kai Lüke <kailueke@riseup.net>
 * Neil Lindquist <archer1mail@gmail.com
+* Hikaru Ikuta <woodrush924@gmail.com>

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 Changes from 0.13.0
 
    [ Language Changes ]
+   * The unquote-splice or ~@ form now accepts any false value as empty.
    * `yield-from` is no longer supported under Python 2
    * `apply` has been replaced with Python-style unpacking operators `#*` and
      `#**` (e.g., `(f #* args #** kwargs)`)

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -1604,19 +1604,31 @@ unquote-splice
 --------------
 
 ``unquote-splice`` forces the evaluation of a symbol within a quasiquoted form,
-much like ``unquote``. ``unquote-splice`` can only be used when the symbol
+much like ``unquote``. ``unquote-splice`` can be used when the symbol
 being unquoted contains an iterable value, as it "splices" that iterable into
-the quasiquoted form. ``unquote-splice`` is aliased to the ``~@`` symbol.
+the quasiquoted form. ``unquote-splice`` can also be used when the value
+evaluates to a false value such as ``None``, ``False``, or ``0``, in which
+case the value is treated as an empty list and thus does not splice anything
+into the form. ``unquote-splice`` is aliased to the ``~@`` syntax.
 
 .. code-block:: clj
 
     (def nums [1 2 3 4])
     (quasiquote (+ (unquote-splice nums)))
-    ;=> (u'+' 1L 2L 3L 4L)
+    ;=> ('+' 1 2 3 4)
 
     `(+ ~@nums)
-    ;=> (u'+' 1L 2L 3L 4L)
+    ;=> ('+' 1 2 3 4)
 
+    `[1 2 ~@(if (< (nth nums 0) 0) nums)]
+    ;=> ('+' 1 2)
+
+Here, the last example evaluates to ``('+' 1 2)``, since the condition
+``(< (nth nums 0) 0)`` is ``False``, which makes this ``if`` expression
+evaluate to ``None``, because the ``if`` expression here does not have an
+else clause. ``unquote-splice`` then evaluates this as an empty value,
+leaving no effects on the list it is enclosed in, therefore resulting in
+``('+' 1 2)``.
 
 when
 ----

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -707,7 +707,9 @@ class HyASTCompiler(object):
                                                                          level)
                 imports.update(f_imports)
                 if splice:
-                    to_add = HyExpression([HySymbol("list"), f_contents])
+                    to_add = HyExpression([
+                        HySymbol("list"),
+                        HyExpression([HySymbol("or"), f_contents, HyList()])])
                 else:
                     to_add = HyList([f_contents])
 

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -74,17 +74,17 @@
 (defn test-unquote-splice []
   "NATIVE: test splicing unquotes"
   (setv q (quote (c d e)))
-  (setv qq (quasiquote (a b (unquote-splice q) f (unquote-splice q))))
-  (assert (= (len qq) 9))
-  (assert (= qq (quote (a b c d e f c d e)))))
+  (setv qq `(a b ~@q f ~@q ~@0 ~@False ~@None g ~@(when False 1) h))
+  (assert (= (len qq) 11))
+  (assert (= qq (quote (a b c d e f c d e g h)))))
 
 
 (defn test-nested-quasiquote []
   "NATIVE: test nested quasiquotes"
-  (setv qq (quasiquote (1 (quasiquote (unquote (+ 1 (unquote (+ 2 3))))) 4)))
-  (setv q (quote (1 (quasiquote (unquote (+ 1 5))) 4)))
+  (setv qq `(1 `~(+ 1 ~(+ 2 3) ~@None) 4))
+  (setv q (quote (1 `~(+ 1 5) 4)))
   (assert (= (len q) 3))
-  (assert (= (get qq 1) (quote (quasiquote (unquote (+ 1 5))))))
+  (assert (= (get qq 1) (quote `~(+ 1 5))))
   (assert (= q qq)))
 
 


### PR DESCRIPTION
The original `unquote_splice` received a form stored in the variable `f_contents`, and produced the code
```clojure
`(list ~f_contents)
```
This PR modifies this to the following code, providing an additional `var = self.get_anon_var()`:
```clojure
`(do
   (setv ~var ~f_contents)
   (if* (= ~var None)
        []
        (list ~var)))
```
I have ran and passed the `tox` tests a Fedora Linux with Python versions 2.7, 3.3.6, 3.4.6, 3.5.3, 3.6.2, pypy-5.7.1, installed through pyenv. I also ran
```clojure
(defmacro splicetest []
  `[1 2 ~@[3 4] ~@None 5 6 ~@(when False 0) 7 8 ~@(when True None) 9 10 ~@(when True [None]) 11 12 ~None])
(splicetest)
```
through `hy2py`, and got
```python
import hy
from hy import HyInteger, HyList

def _hy_anon_fn_1():
    _hy_anon_var_1 = [3, 4]
    _hy_anon_var_2 = None
    _hy_anon_var_3 = None
    _hy_anon_var_4 = None
    _hy_anon_var_5 = [None]
    return HyList((((((((((((((((([] + [HyInteger(1)]) + [HyInteger(2)]) + ([] if (_hy_anon_var_1 == None) else list(_hy_anon_var_1))) + ([] if (_hy_anon_var_2 == None) else list(_hy_anon_var_2))) + [HyInteger(5)]) + [HyInteger(6)]) + ([] if (_hy_anon_var_3 == None) else list(_hy_anon_var_3))) + [HyInteger(7)]) + [HyInteger(8)]) + ([] if (_hy_anon_var_4 == None) else list(_hy_anon_var_4))) + [HyInteger(9)]) + [HyInteger(10)]) + ([] if (_hy_anon_var_5 == None) else list(_hy_anon_var_5))) + [HyInteger(11)]) + [HyInteger(12)]) + [None]))
hy.macros.macro('splicetest')(_hy_anon_fn_1)
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, None, 11, 12, None]
```
which is the expected result. (The last two `~`s are supposed to be evaluated to `None`.)

Edit: Closes #1335 .