### PR TITLE
add #_ discard syntax

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ Changes from 0.13.0
      ``(eval `(+ 1 ~(HyInteger n)))``
    * Literal `Inf`s and `NaN`s must now be capitalized like that
    * `get` is available as a function
+   * new `comment` macro
+   * support EDN `#_` syntax to discard the next term
 
    [ Bug Fixes ]
    * Numeric literals are no longer parsed as symbols when followed by a dot

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -89,6 +89,31 @@ the error ``Keyword argument :foo needs a value``. To avoid this, you can quote
 the keyword, as in ``(f ':foo)``, or use it as the value of another keyword
 argument, as in ``(f :arg :foo)``.
 
+discard prefix
+--------------
+
+Hy supports the Extensible Data Notation discard prefix, like Clojure.
+Any form prefixed with ``#_`` is discarded instead of compiled.
+This completely removes the form so it doesn't evaluate to anything,
+not even None.
+It's often more useful than linewise comments for commenting out a
+form, because it respects code structure even when part of another
+form is on the same line. For example:
+
+.. code-block:: clj
+
+   => (print "Hy" "cruel" "World!")
+   Hy cruel World!
+   => (print "Hy" #_"cruel" "World!")
+   Hy World!
+   => (+ 1 1 (print "Math is hard!"))
+   Math is hard!
+   Traceback (most recent call last):
+      ...
+   TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
+   => (+ 1 1 #_(print "Math is hard!"))
+   2
+
 Built-Ins
 =========
 
@@ -326,6 +351,30 @@ as the user enters *k*.
     (while True (if (= "k" (raw-input "? "))
                   (break)
                   (print "Try again")))
+
+
+comment
+----
+
+The ``comment`` macro ignores its body and always expands to ``None``.
+Unlike linewise comments, the body of the ``comment`` macro must
+be grammatically valid Hy, so the compiler can tell where the comment ends.
+Besides the semicolon linewise comments,
+Hy also has the ``#_`` discard prefix syntax to discard the next form.
+This is completely discarded and doesn't expand to anything, not even ``None``.
+
+.. code-block:: clj
+
+   => (print (comment <h1>Suprise!</h1>
+   ...                <p>You'd be surprised what's grammatically valid in Hy.</p>
+   ...                <p>(Keep delimiters in balance, and you're mostly good to go.)</p>)
+   ...        "Hy")
+   None Hy
+   => (print #_(comment <h1>Suprise!</h1>
+   ...                  <p>You'd be surprised what's grammatically valid in Hy.</p>
+   ...                  <p>(Keep delimiters in balance, and you're mostly good to go.)</p>))
+   ...        "Hy")
+   Hy
 
 
 cond

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -216,3 +216,7 @@
   (setv decorators (cut expr None -1)
         fndef (get expr -1))
   `(with-decorator ~@decorators ~fndef))
+
+(defmacro comment [&rest body]
+  "Ignores body and always expands to None"
+  None)

--- a/hy/lex/lexer.py
+++ b/hy/lex/lexer.py
@@ -25,6 +25,7 @@ lg.add('QUOTE', r'\'%s' % end_quote)
 lg.add('QUASIQUOTE', r'`%s' % end_quote)
 lg.add('UNQUOTESPLICE', r'~@%s' % end_quote)
 lg.add('UNQUOTE', r'~%s' % end_quote)
+lg.add('DISCARD', r'#_')
 lg.add('HASHSTARS', r'#\*+')
 lg.add('HASHOTHER', r'#%s' % identifier)
 

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -153,6 +153,17 @@ def list_contents_single(p):
     return [p[0]]
 
 
+@pg.production("list_contents : DISCARD term discarded_list_contents")
+def list_contents_empty(p):
+    return []
+
+
+@pg.production("discarded_list_contents : DISCARD term discarded_list_contents")
+@pg.production("discarded_list_contents :")
+def discarded_list_contents(p):
+    pass
+
+
 @pg.production("term : identifier")
 @pg.production("term : paren")
 @pg.production("term : dict")
@@ -161,6 +172,11 @@ def list_contents_single(p):
 @pg.production("term : string")
 def term(p):
     return p[0]
+
+
+@pg.production("term : DISCARD term term")
+def term_discard(p):
+    return p[2]
 
 
 @pg.production("term : QUOTE term")

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -635,3 +635,7 @@
                 [1 6 21])
   (assert-equal ((juxt identity) 42)
                 [42]))
+
+(defn test-comment []
+  (assert-none (comment <h1>This is merely a comment.</h1>
+                        <p> Move along. (Nothing to see here.)</p>)))


### PR DESCRIPTION
Closes #1058.

This still needs docs, a `comment` macro, and lots of tests. [Edit: and a news mention!] But I'd like to verify my approach first.

The `#_` syntax needs to be at the "reader" level. It can't be a simple macro. The lexer is too low-level for this. A regex is enough for `;` comments, but the `#_` syntax needs to be able to identify Hy forms properly, even when they contain nested brackets. So I added an "empty" production to the grammar in the parser to make it work. 

I had to add the "empty" production in a lot of places to avoid shift/reduce warnings. This does complicate the parser a bit. If someone has a more elegant approach, I'd like to see it.