### PR TITLE
Fix TypeError when defn multi-arity method returns None

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,3 +79,4 @@
 * Kai Lüke <kailueke@riseup.net>
 * Neil Lindquist <archer1mail@gmail.com
 * Hikaru Ikuta <woodrush924@gmail.com>
+* David Schaefer <david.schaefe@gmail.com>

--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@ Changes from 0.13.0
    * Fixed a bug where REPL history wasn't saved if you quit the REPL with
      `(quit)` or `(exit)`
    * `exec` now works under Python 2
+   * No TypeError from multi-arity defn returning values evaluating to None
 
 Changes from 0.12.1
 

--- a/hy/contrib/multi.hy
+++ b/hy/contrib/multi.hy
@@ -26,13 +26,13 @@
       (.issubset (frozenset (.keys kwargs)) com)))
 
   __call__ (fn [self &rest args &kwargs kwargs]
-    (setv output None)
+    (setv func None)
     (for [[i f] (.items (get self._fns self.f.__module__ self.f.__name__))]
       (when (.fn? self i args kwargs)
-        (setv output (f #* args #** kwargs))
+        (setv func f)
         (break)))
-    (if output
-      output
+    (if func
+      (func #* args #** kwargs)
       (raise (TypeError "No matching functions with this signature"))))])
 
 (defn multi-decorator [dispatch-fn]

--- a/tests/native_tests/contrib/multi.hy
+++ b/tests/native_tests/contrib/multi.hy
@@ -26,6 +26,22 @@
   (assert (= (fun "a" "b") "a b"))
   (assert (= (fun "a" "b" "c") "a b c")))
 
+(defn test-different-signatures-defn []
+  "NATIVE: Test defn with different signatures"
+  (defn fun
+    ([] "")
+    ([a] "a")
+    ([a b] "a b"))
+
+  (assert (= (fun) ""))
+  (assert (= (fun "a") "a"))
+  (assert (= (fun "a" "b") "a b"))
+  (try
+    (do
+      (fun "a" "b" "c")
+      (assert False))
+    (except [e Exception]
+      (assert (isinstance e TypeError)))))
 
 (defn test-basic-dispatch []
   "NATIVE: Test basic dispatch"


### PR DESCRIPTION
A defn mult-arity method returning a value evaluating to None currently raises a TypeError:
```
(require [hy.contrib.multi [defn]])
(defn fun                                                                                              
  ([] ""))
(fun)  ;; raises TypeError
```
With this PR the value is returned instead.