### PR TITLE
proper reprs for Hy models

### DIFF
--- a/docs/contrib/walk.rst
+++ b/docs/contrib/walk.rst
@@ -22,12 +22,18 @@ Example:
 
 .. code-block:: hy
 
-   => (import [hy.contrib.walk [walk]])
-   => (setv a '(a b c d e f))
-   => (walk ord identity a)
-   (97 98 99 100 101 102)
-   => (walk ord first a)
-   97
+    => (import [hy.contrib.walk [walk]])
+    => (setv a '(a b c d e f))
+    => (walk ord identity a)
+    HyExpression([
+      97,
+      98,
+      99,
+      100,
+      101,
+      102])
+    => (walk ord first a)
+    97
 
 postwalk
 ---------
@@ -41,25 +47,73 @@ each sub-form, uses ``f`` 's return value in place of the original.
 
 .. code-block:: hy
 
-   => (import [hy.contrib.walk [postwalk]])
-   => (def trail '([1 2 3] [4 [5 6 [7]]]))
-   => (defn walking [x]
-        (print "Walking:" x)
-        x )
-   => (postwalk walking trail)
-   Walking: 1
-   Walking: 2
-   Walking: 3
-   Walking: (1 2 3)
-   Walking: 4
-   Walking: 5
-   Walking: 6
-   Walking: 7
-   Walking: (7)
-   Walking: (5 6 [7])
-   Walking: (4 [5 6 [7]])
-   Walking: ([1 2 3] [4 [5 6 [7]]])
-   ([1 2 3] [4 [5 6 [7]]])
+    => (import [hy.contrib.walk [postwalk]])
+    => (def trail '([1 2 3] [4 [5 6 [7]]]))
+    => (defn walking [x]
+    ...  (print "Walking:" x :sep "\n")
+    ...  x)
+    => (postwalk walking trail)
+    Walking:
+    1
+    Walking:
+    2
+    Walking:
+    3
+    Walking:
+    HyExpression([
+      HyInteger(1),
+      HyInteger(2),
+      HyInteger(3)])
+    Walking:
+    4
+    Walking:
+    5
+    Walking:
+    6
+    Walking:
+    7
+    Walking:
+    HyExpression([
+      HyInteger(7)])
+    Walking:
+    HyExpression([
+      HyInteger(5),
+      HyInteger(6),
+      HyList([
+        HyInteger(7)])])
+    Walking:
+    HyExpression([
+      HyInteger(4),
+      HyList([
+        HyInteger(5),
+        HyInteger(6),
+        HyList([
+          HyInteger(7)])])])
+    Walking:
+    HyExpression([
+      HyList([
+        HyInteger(1),
+        HyInteger(2),
+        HyInteger(3)]),
+      HyList([
+        HyInteger(4),
+        HyList([
+          HyInteger(5),
+          HyInteger(6),
+          HyList([
+            HyInteger(7)])])])])
+    HyExpression([
+      HyList([
+        HyInteger(1),
+        HyInteger(2),
+        HyInteger(3)]),
+      HyList([
+        HyInteger(4),
+        HyList([
+          HyInteger(5),
+          HyInteger(6),
+          HyList([
+            HyInteger(7)])])])])
 
 prewalk
 --------
@@ -73,22 +127,70 @@ each sub-form, uses ``f`` 's return value in place of the original.
 
 .. code-block:: hy
 
-   => (import [hy.contrib.walk [prewalk]])
-   => (def trail '([1 2 3] [4 [5 6 [7]]]))
-   => (defn walking [x]
-        (print "Walking:" x)
-        x )
-   => (prewalk walking trail)
-   Walking: ([1 2 3] [4 [5 6 [7]]])
-   Walking: [1 2 3]
-   Walking: 1
-   Walking: 2
-   Walking: 3
-   Walking: [4 [5 6 [7]]]
-   Walking: 4
-   Walking: [5 6 [7]]
-   Walking: 5
-   Walking: 6
-   Walking: [7]
-   Walking: 7
-   ([1 2 3] [4 [5 6 [7]]])
+    => (import [hy.contrib.walk [prewalk]])
+    => (def trail '([1 2 3] [4 [5 6 [7]]]))
+    => (defn walking [x]
+    ...  (print "Walking:" x :sep "\n")
+    ...  x)
+    => (prewalk walking trail)
+    Walking:
+    HyExpression([
+      HyList([
+        HyInteger(1),
+        HyInteger(2),
+        HyInteger(3)]),
+      HyList([
+        HyInteger(4),
+        HyList([
+          HyInteger(5),
+          HyInteger(6),
+          HyList([
+            HyInteger(7)])])])])
+    Walking:
+    HyList([
+      HyInteger(1),
+      HyInteger(2),
+      HyInteger(3)])
+    Walking:
+    1
+    Walking:
+    2
+    Walking:
+    3
+    Walking:
+    HyList([
+      HyInteger(4),
+      HyList([
+        HyInteger(5),
+        HyInteger(6),
+        HyList([
+          HyInteger(7)])])])
+    Walking:
+    4
+    Walking:
+    HyList([
+      HyInteger(5),
+      HyInteger(6),
+      HyList([
+        HyInteger(7)])])
+    Walking:
+    5
+    Walking:
+    6
+    Walking:
+    HyList([
+      HyInteger(7)])
+    Walking:
+    7
+    HyExpression([
+      HyList([
+        HyInteger(1),
+        HyInteger(2),
+        HyInteger(3)]),
+      HyList([
+        HyInteger(4),
+        HyList([
+          HyInteger(5),
+          HyInteger(6),
+          HyList([
+            HyInteger(7)])])])])

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -869,7 +869,7 @@ doto
 .. code-block:: clj
 
   => (doto [] (.append 1) (.append 2) .reverse)
-  [2 1]
+  [2, 1]
 
 .. code-block:: clj
 
@@ -878,7 +878,7 @@ doto
   => (.append collection 2)
   => (.reverse collection)
   => collection
-  [2 1]
+  [2, 1]
 
 
 eval-and-compile
@@ -1362,9 +1362,10 @@ alternatively be written using the apostrophe (``'``) symbol.
 .. code-block:: clj
 
     => (setv x '(print "Hello World"))
-    ; variable x is set to expression & not evaluated
-    => x
-    (u'print' u'Hello World')
+    => x  ; varible x is set to unevaluated expression
+    HyExpression([
+      HySymbol('print'),
+      HyString('Hello World')])
     => (eval x)
     Hello World
 
@@ -1673,12 +1674,17 @@ is aliased to the tilde (``~``) symbol.
 
 .. code-block:: clj
 
-    (def name "Cuddles")
-    (quasiquote (= name (unquote name)))
-    ;=> (u'=' u'name' u'Cuddles')
-
-    `(= name ~name)
-    ;=> (u'=' u'name' u'Cuddles')
+    => (setv nickname "Cuddles")
+    => (quasiquote (= nickname (unquote nickname)))
+    HyExpression([
+      HySymbol('='),
+      HySymbol('nickname'),
+      'Cuddles'])
+    => `(= nickname ~nickname)
+    HyExpression([
+      HySymbol('='),
+      HySymbol('nickname'),
+      'Cuddles'])
 
 
 unquote-splice
@@ -1694,15 +1700,25 @@ into the form. ``unquote-splice`` is aliased to the ``~@`` syntax.
 
 .. code-block:: clj
 
-    (def nums [1 2 3 4])
-    (quasiquote (+ (unquote-splice nums)))
-    ;=> ('+' 1 2 3 4)
-
-    `(+ ~@nums)
-    ;=> ('+' 1 2 3 4)
-
-    `[1 2 ~@(if (< (nth nums 0) 0) nums)]
-    ;=> ('+' 1 2)
+    => (setv nums [1 2 3 4])
+    => (quasiquote (+ (unquote-splice nums)))
+    HyExpression([
+      HySymbol('+'),
+      1,
+      2,
+      3,
+      4])
+    => `(+ ~@nums)
+    HyExpression([
+      HySymbol('+'),
+      1,
+      2,
+      3,
+      4])
+    => `[1 2 ~@(if (neg? (first nums)) nums)]
+    HyList([
+      HyInteger(1),
+      HyInteger(2)])
 
 Here, the last example evaluates to ``('+' 1 2)``, since the condition
 ``(< (nth nums 0) 0)`` is ``False``, which makes this ``if`` expression

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -633,7 +633,7 @@ arguments. If the argument list only has one element, return it.
     => (list* 1 10  2 20 '{})
     HyDict([
       HyInteger(1), HyInteger(10),
-      HyInteger(2), HyInteger(20),])
+      HyInteger(2), HyInteger(20)])
     => (list* 1 10  2 20 {})
     <HyCons (
       HyInteger(1)

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -618,17 +618,29 @@ arguments. If the argument list only has one element, return it.
 
 .. code-block:: hy
 
-   => (list* 1 2 3 4)
-   (1 2 3 . 4)
-
-   => (list* 1 2 3 [4])
-   [1, 2, 3, 4]
-
-   => (list* 1)
-   1
-
-   => (cons? (list* 1 2 3 4))
-   True
+    => (list* 1 2 3 4)
+    <HyCons (
+      HyInteger(1)
+      HyInteger(2)
+      HyInteger(3)
+    . HyInteger(4))>
+    => (list* 1 2 3 [4])
+    [HyInteger(1), HyInteger(2), HyInteger(3), 4]
+    => (list* 1)
+    1
+    => (cons? (list* 1 2 3 4))
+    True
+    => (list* 1 10  2 20 '{})
+    HyDict([
+      HyInteger(1), HyInteger(10),
+      HyInteger(2), HyInteger(20),])
+    => (list* 1 10  2 20 {})
+    <HyCons (
+      HyInteger(1)
+      HyInteger(10)
+      HyInteger(2)
+      HyInteger(20)
+    . HyDict())>
 
 .. _macroexpand-fn:
 
@@ -643,11 +655,23 @@ Returns the full macro expansion of *form*.
 
 .. code-block:: hy
 
-   => (macroexpand '(-> (a b) (x y)))
-   (u'x' (u'a' u'b') u'y')
-
-   => (macroexpand '(-> (a b) (-> (c d) (e f))))
-   (u'e' (u'c' (u'a' u'b') u'd') u'f')
+    => (macroexpand '(-> (a b) (x y)))
+    HyExpression([
+      HySymbol('x'),
+      HyExpression([
+        HySymbol('a'),
+        HySymbol('b')]),
+      HySymbol('y')])
+    => (macroexpand '(-> (a b) (-> (c d) (e f))))
+    HyExpression([
+      HySymbol('e'),
+      HyExpression([
+        HySymbol('c'),
+        HyExpression([
+          HySymbol('a'),
+          HySymbol('b')]),
+        HySymbol('d')]),
+      HySymbol('f')])
 
 .. _macroexpand-1-fn:
 
@@ -662,8 +686,18 @@ Returns the single step macro expansion of *form*.
 
 .. code-block:: hy
 
-   => (macroexpand-1 '(-> (a b) (-> (c d) (e f))))
-   (u'_>' (u'a' u'b') (u'c' u'd') (u'e' u'f'))
+    => (macroexpand-1 '(-> (a b) (-> (c d) (e f))))
+    HyExpression([
+      HySymbol('_>'),
+      HyExpression([
+        HySymbol('a'),
+        HySymbol('b')]),
+      HyExpression([
+        HySymbol('c'),
+        HySymbol('d')]),
+      HyExpression([
+        HySymbol('e'),
+        HySymbol('f')])])
 
 
 .. _merge-with-fn:
@@ -839,26 +873,26 @@ Chunks *coll* into *n*-tuples (pairs by default).
 
 .. code-block:: hy
 
-   => (list (partition (range 10)))  ; n=2
-   [(, 0 1) (, 2 3) (, 4 5) (, 6 7) (, 8 9)]
+    => (list (partition (range 10)))  ; n=2
+    [(0, 1), (2, 3), (4, 5), (6, 7), (8, 9)]
 
 The *step* defaults to *n*, but can be more to skip elements, or less for a sliding window with overlap.
 
 .. code-block:: hy
 
-   => (list (partition (range 10) 2 3))
-   [(, 0 1) (, 3 4) (, 6 7)]
-   => (list (partition (range 5) 2 1))
-   [(, 0 1) (, 1 2) (, 2 3) (, 3 4)])
+    => (list (partition (range 10) 2 3))
+    [(0, 1), (3, 4), (6, 7)]
+    => (list (partition (range 5) 2 1))
+    [(0, 1), (1, 2), (2, 3), (3, 4)]
 
 The remainder, if any, is not included unless a *fillvalue* is specified.
 
 .. code-block:: hy
 
-   => (list (partition (range 10) 3))
-   [(, 0 1 2) (, 3 4 5) (, 6 7 8)]
-   => (list (partition (range 10) 3 :fillvalue "x"))
-   [(, 0 1 2) (, 3 4 5) (, 6 7 8) (, 9 "x" "x")]
+    => (list (partition (range 10) 3))
+    [(0, 1, 2), (3, 4, 5), (6, 7, 8)]
+    => (list (partition (range 10) 3 :fillvalue "x"))
+    [(0, 1, 2), (3, 4, 5), (6, 7, 8), (9, 'x', 'x')]
 
 .. _pos?-fn:
 
@@ -1220,36 +1254,43 @@ if *from-file* ends before a complete expression can be parsed.
 
 .. code-block:: hy
 
-   => (read)
-   (+ 2 2)
-   ('+' 2 2)
-   => (eval (read))
-   (+ 2 2)
-   4
+    => (read)
+    (+ 2 2)
+    HyExpression([
+      HySymbol('+'),
+      HyInteger(2),
+      HyInteger(2)])
+    => (eval (read))
+    (+ 2 2)
+    4
+    => (import io)
+    => (setv buffer (io.StringIO "(+ 2 2)\n(- 2 1)"))
+    => (eval (read :from_file buffer))
+    4
+    => (eval (read :from_file buffer))
+    1
 
-   => (import io)
-   => (def buffer (io.StringIO "(+ 2 2)\n(- 2 1)"))
-   => (eval (read :from_file buffer))
-   4
-   => (eval (read :from_file buffer))
-   1
-
-   => ; assuming "example.hy" contains:
-   => ;   (print "hello")
-   => ;   (print "hyfriends!")
-   => (with [f (open "example.hy")]
-   ...   (try
-   ...     (while True
-   ...            (setv exp (read f))
-   ...            (print "OHY" exp)
-   ...            (eval exp))
-   ...     (except [e EOFError]
-   ...            (print "EOF!"))))
-   OHY ('print' 'hello')
-   hello
-   OHY ('print' 'hyfriends!')
-   hyfriends!
-   EOF!
+    => (with [f (open "example.hy" "w")]
+    ...  (.write f "(print 'hello)\n(print \"hyfriends!\")"))
+    35
+    => (with [f (open "example.hy")]
+    ...  (try (while True
+    ...         (setv exp (read f))
+    ...         (print "OHY" exp)
+    ...         (eval exp))
+    ...       (except [e EOFError]
+    ...         (print "EOF!"))))
+    OHY HyExpression([
+      HySymbol('print'),
+      HyExpression([
+        HySymbol('quote'),
+        HySymbol('hello')])])
+    hello
+    OHY HyExpression([
+      HySymbol('print'),
+      HyString('hyfriends!')])
+    hyfriends!
+    EOF!
 
 read-str
 --------
@@ -1261,11 +1302,12 @@ string:
 
 .. code-block:: hy
 
-   => (read-str "(print 1)")
-   (u'print' 1L)
-   => (eval (read-str "(print 1)"))
-   1
-   =>
+    => (read-str "(print 1)")
+    HyExpression([
+      HySymbol('print'),
+      HyInteger(1)])
+    => (eval (read-str "(print 1)"))
+    1
 
 .. _remove-fn:
 
@@ -1409,3 +1451,4 @@ are available. Some of their names have been changed:
   - ``dropwhile`` has been changed to ``drop-while``
   
   - ``filterfalse`` has been changed to ``remove``
+

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -39,6 +39,15 @@ Compound Models
 Parenthesized and bracketed lists are parsed as compound models by the
 Hy parser.
 
+Hy uses pretty-printing reprs for its compound models by default.
+If this is causing issues,
+it can be turned off globally by setting ``hy.models.PRETTY`` to ``False``,
+or temporarily by using the ``hy.models.pretty`` context manager.
+
+Hy also attempts to color pretty reprs using ``clint.textui.colored``.
+This module has a flag to disable coloring,
+and a method ``clean`` to strip colored strings of their color tags.
+
 .. _hylist:
 
 HyList

--- a/hy/models.py
+++ b/hy/models.py
@@ -275,14 +275,14 @@ class HyDict(HyList):
                 for k, v in zip(self[::2],self[1::2]):
                     k, v = repr_indent(k), repr_indent(v)
                     pairs.append(
-                        ("{0}{c}\n  {1}\n  {c}"
+                        ("{0}{c}\n  {1}\n  "
                          if '\n' in k+v
-                         else "{0}{c} {1}{c}").format(k, v, c=g(',')))
+                         else "{0}{c} {1}").format(k, v, c=g(',')))
                 if len(self) % 2 == 1:
                     pairs.append("{}  {}\n".format(
                         repr_indent(self[-1]), g("# odd")))
                 return "{}\n  {}{}".format(
-                    g("HyDict(["), ("\n  ".join(pairs)), g("])"))
+                    g("HyDict(["), ("{c}\n  ".format(c=g(',')).join(pairs)), g("])"))
             else:
                 return '' + g("HyDict()")
 

--- a/hy/models.py
+++ b/hy/models.py
@@ -353,9 +353,13 @@ class HyCons(HyObject):
 
     def __repr__(self):
         if isinstance(self.cdr, self.__class__):
-            return "<HyCons (%s %s)>" % (repr(self.car), repr(self.cdr)[9:-2])
+            return "<HyCons (\n  %s%s" % (
+                repr(self.car).replace('\n', '\n  '),
+                repr(self.cdr)[9:])
         else:
-            return "<HyCons (%s . %s)>" % (repr(self.car), repr(self.cdr))
+            return "<HyCons (\n  %s\n. %s)>" % (
+                repr(self.car).replace('\n', '\n  '),
+                repr(self.cdr).replace('\n', '\n  '))
 
     def __eq__(self, other):
         return (

--- a/hy/models.py
+++ b/hy/models.py
@@ -63,7 +63,7 @@ def replace_hy_obj(obj, other):
 
 
 def repr_indent(obj):
-    return repr(obj).replace('\n','\n  ')
+    return repr(obj).replace("\n", "\n  ")
 
 
 class HyString(HyObject, str_type):
@@ -226,7 +226,7 @@ class HyList(HyObject, list):
         if self:
             return "%s([\n  %s])" % (
                 self.__class__.__name__,
-                ",\n  ".join([repr_indent(x) for x in self]))
+                ",\n  ".join([repr_indent(e) for e in self]))
         else:
             return self.__class__.__name__ + "()"
 
@@ -352,14 +352,14 @@ class HyCons(HyObject):
         HyObject.replace(self, other)
 
     def __repr__(self):
-        if isinstance(self.cdr, self.__class__):
-            return "<HyCons (\n  %s%s" % (
-                repr(self.car).replace('\n', '\n  '),
-                repr(self.cdr)[9:])
-        else:
-            return "<HyCons (\n  %s\n. %s)>" % (
-                repr(self.car).replace('\n', '\n  '),
-                repr(self.cdr).replace('\n', '\n  '))
+        lines = ["<HyCons ("]
+        while True:
+            lines.append("  " + repr_indent(self.car))
+            if not isinstance(self.cdr, HyCons):
+                break
+            self = self.cdr
+        lines.append(". %s)>" % (repr_indent(self.cdr),))
+        return '\n'.join(lines)
 
     def __eq__(self, other):
         return (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -213,27 +213,27 @@ PRETTY_STRINGS.update({
     '{{1j 2j} {1j 2j [][1j]} {[1j][] 1j 2j} {[1j][1j]}}':
         """HyDict([
   HyDict([
-    HyComplex(1j), HyComplex(2j),]),
+    HyComplex(1j), HyComplex(2j)]),
   HyDict([
     HyComplex(1j), HyComplex(2j),
     HyList(),
     HyList([
       HyComplex(1j)])
-    ,])
+    ])
   ,
   HyDict([
     HyList([
       HyComplex(1j)]),
     HyList()
     ,
-    HyComplex(1j), HyComplex(2j),]),
+    HyComplex(1j), HyComplex(2j)]),
   HyDict([
     HyList([
       HyComplex(1j)]),
     HyList([
       HyComplex(1j)])
-    ,])
-  ,])"""})
+    ])
+  ])"""})
 
 
 def test_compound_model_repr():


### PR DESCRIPTION
Closes #914.

This will make development of macros sooo much easier, since we can tell exactly what we're looking at in the repl with macroexpand or any other manipulations of Hy models.

The reprs for HyList and derivatives will use two-space indents, so even deeply nested structures are readable in the repl.

This also makes the reprs valid Python code to reconstruct the hytree in most cases, as is preferred in Python. This will improve Python interop somewhat, since if a Hy model leaks through, the error message will make sense as a Hy model, instead of looking like Hy code that could be confused for some kind of Python display.