### PR TITLE
Expose `read`, `read_str`, and `eval` as top-level functions in Python

### DIFF
--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -10,3 +10,7 @@ from hy.models import HyExpression, HyInteger, HyKeyword, HyComplex, HyString, H
 
 import hy.importer  # NOQA
 # we import for side-effects.
+
+
+from hy.core.language import read, read_str  # NOQA
+from hy.importer import hy_eval as eval  # NOQA


### PR DESCRIPTION
Fixes #1256 