### PR TITLE
hy/completer.py:27 docomplete truth check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,3 +81,4 @@
 * Hikaru Ikuta <woodrush924@gmail.com>
 * David Schaefer <david.schaefe@gmail.com>
 * Jordan Danford <jordandanford@gmail.com>
+* Andrew Silva <asilva@law.harvard.edu>

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -24,10 +24,11 @@ except ImportError:
     except ImportError:
         docomplete = False
 
-if sys.platform == 'darwin' and 'libedit' in readline.__doc__:
-    readline_bind = "bind ^I rl_complete"
-else:
-    readline_bind = "tab: complete"
+if docomplete:
+    if sys.platform == 'darwin' and 'libedit' in readline.__doc__:
+        readline_bind = "bind ^I rl_complete"
+    else:
+        readline_bind = "tab: complete"
 
 
 class Completer(object):


### PR DESCRIPTION
Replaces malformatted PR #1356 

Without the check, the next line will reference readline even if the library was not successfully loaded.