### PR TITLE
Fixes #1350: try form in defmacro

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,7 @@ Changes from 0.13.0
      `(quit)` or `(exit)`
    * `exec` now works under Python 2
    * No TypeError from multi-arity defn returning values evaluating to None
+   * try form now possible in defmacro/deftag
 
    [ Misc. Improvements ]
    * `read`, `read_str`, and `eval` are exposed and documented as top-level

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -23,6 +23,7 @@ import codecs
 import ast
 import sys
 import keyword
+import copy
 
 from collections import defaultdict
 
@@ -2392,7 +2393,8 @@ class HyASTCompiler(object):
         """Compile-time hack: we want to get our new macro now
         We must provide __name__ in the namespace to make the Python
         compiler set the __module__ attribute of the macro function."""
-        hy.importer.hy_eval(expression,
+
+        hy.importer.hy_eval(copy.deepcopy(expression),
                             compile_time_ns(self.module_name),
                             self.module_name)
 

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -617,3 +617,10 @@ def test_exec_star():
         assert code.body.s == "print(a + b)"
         assert code.globals.keys[0].s == "a"
         assert code.locals.keys[0].s == "b"
+
+
+def test_compiler_macro_tag_try():
+    """Check that try forms within defmacro/deftag are compiled correctly"""
+    # https://github.com/hylang/hy/issues/1350
+    can_compile("(defmacro foo [] (try None (except [] None)) `())")
+    can_compile("(deftag foo [] (try None (except [] None)) `())")


### PR DESCRIPTION
This PR fixes Issue #1350 in a rather hacky way (at least I am fixing a method called `_compile_time_hack`). The problem seems to be, that the try form is compiled several times: once within `hy.importer.hy_eval` and the second time within `compiler.HyASTCompile._compile_time_hack`. The proposed solution simply passes a copy to the first method.

Not sure how to test this though...