### PR TITLE
Un-xfail a passing test of `macroexpand`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,7 @@ Changes from 0.13.0
    * `exec` now works under Python 2
    * No TypeError from multi-arity defn returning values evaluating to None
    * try form now possible in defmacro/deftag
+   * Fixed a crash when `macroexpand`ing a macro with a named import
    * Fixed a crash when `with` suppresses an exception. `with` now returns
      `None` in this case.
    * `assoc` now evaluates its arguments only once each

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1425,13 +1425,12 @@
   (assert (= (macroexpand '(-> (a b) (-> (c d) (e f))))
              '(e (c (a b) d) f))))
 
-#@(pytest.mark.xfail
 (defn test-macroexpand-with-named-import []
   ; https://github.com/hylang/hy/issues/1207
   (defmacro m-with-named-import []
     (import [math [pow]])
     (pow 2 3))
-  (assert (= (macroexpand '(m-with-named-import)) (** 2 3)))))
+  (assert (= (macroexpand '(m-with-named-import)) (** 2 3))))
 
 (defn test-macroexpand-1 []
   "Test macroexpand-1 on ->"


### PR DESCRIPTION
Closes #1207.

It looks like #1374 fixed this bug and nobody noticed. Nice going, @schaefed.