### PR TITLE
make HyCons iter return non-iterable cdr

### DIFF
--- a/hy/models.py
+++ b/hy/models.py
@@ -318,9 +318,7 @@ class HyCons(HyObject):
         try:
             iterator = (i for i in self.cdr)
         except TypeError:
-            if self.cdr is not None:
-                yield self.cdr
-                raise TypeError("Iteration on malformed cons")
+            raise StopIteration(self.cdr)
         else:
             for i in iterator:
                 yield i


### PR DESCRIPTION
This makes the HyCons `__iter__` generator `return` the last cdr when it's non-iterable. The old behavior was to `yield` the cdr as the last element and raise a `TypeError`.

It seems more useful for a dotted list iter to return its cdr than yield it and then raise a `TypeError` like before. A `yield` should only be used on the cars, not the cdr. But we still want to be able to access the final cdr. This will make dotted lists easier to work with, since you will be able to use an iterator for them too. Before, you'd have to build one yourself with a while loop or recursion.

I noticed this possibility in #1360, but the `__repr__` method still shouldn't use this, because a non-`HyCons` `cdr` needs to print differently, even if it's iterable. These are separate issues.

On Python 3.3+, this would just be a `return self.cdr` statement. I explicitly raised the `StopIteration` exception for compatibility with Python 2.7, which doesn't allow `return` in generators at all. On Python3, the returned value is in the `.value` attr of the exception. On Python2, it's still available in `.args`, though I suppose we could explicitly set a `.value` attr on the exception object before raising it.