### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 Changes from 0.13.0
 
    [ Language Changes ]
+   * Python 3.3 is no longer supported
    * The unquote-splice or ~@ form now accepts any false value as empty.
    * `yield-from` is no longer supported under Python 2
    * `apply` has been replaced with Python-style unpacking operators `#*` and

--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -21,7 +21,6 @@ except ImportError:
 import sys
 
 PY3 = sys.version_info[0] >= 3
-PY34 = sys.version_info >= (3, 4)
 PY35 = sys.version_info >= (3, 5)
 
 str_type     = str   if PY3 else unicode      # NOQA

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -12,7 +12,7 @@ from hy.lex.parser import hy_symbol_mangle
 
 import hy.macros
 from hy._compat import (
-    str_type, string_types, bytes_type, long_type, PY3, PY34, PY35,
+    str_type, string_types, bytes_type, long_type, PY3, PY35,
     raise_empty)
 from hy.macros import require, macroexpand, tag_macroexpand
 import hy.importer
@@ -2207,7 +2207,7 @@ class HyASTCompiler(object):
                 ) + expression
                 expression = expression.replace(arg[0])
 
-        if PY34:
+        if PY3:
             # Python 3.4+ requires that args are an ast.arg object, rather
             # than an ast.Name or bare string.
             args = [ast.arg(arg=ast_str(x),

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -18,7 +18,7 @@ import inspect
 import os
 import __future__
 
-from hy._compat import PY3, PY34, MAGIC, builtins, long_type, wr_long
+from hy._compat import PY3, MAGIC, builtins, long_type, wr_long
 from hy._compat import string_types
 
 
@@ -271,7 +271,7 @@ def is_package(module_name):
 
 
 def get_bytecode_path(source_path):
-    if PY34:
+    if PY3:
         import importlib.util
         return importlib.util.cache_from_source(source_path)
     elif hasattr(imp, "cache_from_source"):

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -11,7 +11,7 @@
         pytest)
 (import sys)
 
-(import [hy._compat [PY3 PY34 PY35]])
+(import [hy._compat [PY3 PY35]])
 
 (defn test-sys-argv []
   "NATIVE: test sys.argv"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,py36,flake8
+envlist = py27,pypy,py34,py35,py36,flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
[3.3 will no longer be supported by the Python people on September 29th](https://docs.python.org/devguide/#status-of-python-branches), and our next release will be after that.