### PR TITLE
fix testing for windows

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,13 @@
 import _pytest
 import hy
+import os
 from hy._compat import PY3, PY35
+
+NATIVE_TESTS = os.path.join("", "tests", "native_tests", "")
 
 def pytest_collect_file(parent, path):
     if (path.ext == ".hy"
-            and "/tests/native_tests/" in path.dirname + "/"
+            and NATIVE_TESTS in path.dirname + os.sep
             and path.basename != "__init__.hy"
             and not ("py3_only" in path.basename and not PY3)
             and not ("py35_only" in path.basename and not PY35)):

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -98,7 +98,7 @@ def import_file_to_module(module_name, fpath, loader=None):
         try:
             _ast = import_file_to_ast(fpath, module_name)
             module = imp.new_module(module_name)
-            module.__file__ = fpath
+            module.__file__ = os.path.normpath(fpath)
             code = ast_compile(_ast, fpath, "exec")
             if not os.environ.get('PYTHONDONTWRITEBYTECODE'):
                 try:
@@ -121,7 +121,7 @@ def import_file_to_module(module_name, fpath, loader=None):
         sys.modules[module_name] = module
         module.__name__ = module_name
 
-    module.__file__ = fpath
+    module.__file__ = os.path.normpath(fpath)
     if loader:
         module.__loader__ = loader
     if is_package(module_name):


### PR DESCRIPTION
Also improve `test_bin_hy_builtins` and warn that it fails from IPython.

The shell on Windows needs double quotes. This is a partial fix for #1289. It's *still* not runnning the native tests, but I wanted to push this much to make sure switching the quotes doesn't break it for Travis.

[Edit: got the native tests working on Windows too. Fixes #1289.]