### PR TITLE
add documentation macros

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,7 @@ Changes from 0.13.0
    * `while` loops may now contain an `else` clause, like `for` loops
    * `xi` from `hy.extra.anaphoric` is now the `#%` tag macro
    * `#%` works on any expression and has a new `&kwargs` parameter `%**`
+   * new `doc` macro and `#doc` tag macro
 
    [ Bug Fixes ]
    * Numeric literals are no longer parsed as symbols when followed by a dot

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -501,6 +501,41 @@ Some example usage:
 ``do`` can accept any number of arguments, from 1 to n.
 
 
+doc / #doc
+----------
+
+Documentation macro and tag macro.
+Gets help for macros or tag macros, respectively.
+
+.. code-block:: clj
+
+    => (doc doc)
+    Help on function (doc) in module hy.core.macros:
+
+    (doc)(symbol)
+        macro documentation
+
+        Gets help for a macro function available in this module.
+        Use ``require`` to make other macros available.
+
+        Use ``#doc foo`` instead for help with tag macro ``#foo``.
+        Use ``(help foo)`` instead for help with runtime objects.
+
+    => (doc comment)
+    Help on function (comment) in module hy.core.macros:
+
+    (comment)(*body)
+        Ignores body and always expands to None
+
+    => #doc doc
+    Help on function #doc in module hy.core.macros:
+
+    #doc(symbol)
+        tag macro documentation
+
+    Gets help for a tag macro function available in this module.
+
+
 def / setv
 ----------
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -232,6 +232,7 @@ Such 'o!' params are availible within `body` as the equivalent 'g!' symbol."
 
 
 (deftag @ [expr]
+  "with-decorator tag macro"
   (setv decorators (cut expr None -1)
         fndef (get expr -1))
   `(with-decorator ~@decorators ~fndef))
@@ -239,3 +240,41 @@ Such 'o!' params are availible within `body` as the equivalent 'g!' symbol."
 (defmacro comment [&rest body]
   "Ignores body and always expands to None"
   None)
+
+(defmacro doc [symbol]
+  "macro documentation
+
+   Gets help for a macro function available in this module.
+   Use ``require`` to make other macros available.
+
+   Use ``#doc foo`` instead for help with tag macro ``#foo``.
+   Use ``(help foo)`` instead for help with runtime objects."
+  `(try
+     (help (. (__import__ "hy")
+              macros
+              _hy_macros
+              [__name__]
+              ['~symbol]))
+     (except [KeyError]
+       (help (. (__import__ "hy")
+                macros
+                _hy_macros
+                [None]
+                ['~symbol])))))
+
+(deftag doc [symbol]
+  "tag macro documentation
+
+   Gets help for a tag macro function available in this module."
+  `(try
+     (help (. (__import__ "hy")
+              macros
+              _hy_tag
+              [__name__]
+              ['~symbol]))
+     (except [KeyError]
+       (help (. (__import__ "hy")
+                macros
+                _hy_tag
+                [None]
+                ['~symbol])))))

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -34,6 +34,7 @@ def macro(name):
 
     """
     def _(fn):
+        fn.__name__ = "({})".format(name)
         try:
             argspec = getargspec(fn)
             fn._hy_macro_pass_compiler = argspec.keywords is not None
@@ -63,6 +64,7 @@ def tag(name):
 
     """
     def _(fn):
+        fn.__name__ = '#{}'.format(name)
         module_name = fn.__module__
         if module_name.startswith("hy.core"):
             module_name = None


### PR DESCRIPTION
Closes #356.

This isn't exactly what was asked for, but we have three separate namespaces to deal with here--macros, tag macros, and runtime objects. It's entirely possible to have the same name in all three namespaces. Rather than trying to get `help` to work with all three somehow, this adds a `doc` macro for help with macros, and a `#doc` tag macro for help with tag macros. Using a macro to look up macros and a tag macro to look up tag macros seems easy to remember.

The other option would be to shadow the builtin `help` with a `help` macro. When passed a quoted symbol, it would look up the macro. When passed a keyword it would look up the tag macro with that name. When passed any other object, it would defer to Python's `help`. It seems a lot less intuitive though.