### PR TITLE
Completer completes hy.core.language names

### DIFF
--- a/hy/completer.py
+++ b/hy/completer.py
@@ -7,10 +7,9 @@ import os
 import re
 import sys
 
-import hy.macros
 import hy.compiler
+import hy.macros
 from hy._compat import builtins, string_types
-
 
 docomplete = True
 
@@ -38,6 +37,7 @@ class Completer(object):
             raise TypeError('namespace must be a dictionary')
         self.namespace = namespace
         self.path = [hy.compiler._compile_table,
+                     dir(hy.core.language),
                      builtins.__dict__,
                      hy.macros._hy_macros[None],
                      namespace]
@@ -75,11 +75,12 @@ class Completer(object):
     def global_matches(self, text):
         matches = []
         for p in self.path:
-            for k in p.keys():
+            for k in p:
                 if isinstance(k, string_types):
                     k = k.replace("_", "-")
                     if k.startswith(text):
                         matches.append(k)
+
         return matches
 
     def tag_matches(self, text):

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -54,8 +54,8 @@ class Completer(object):
 
         if m:
             expr, attr = m.group(1, 3)
-            attr = attr.replace("-", "_")
-            expr = expr.replace("-", "_")
+            attr = hy_symbol_unmangle(attr)
+            expr = hy_symbol_unmangle(expr)
         else:
             return []
 
@@ -63,14 +63,19 @@ class Completer(object):
             obj = eval(expr, self.namespace)
             words = dir(obj)
         except Exception:
-            return []
+            try:
+                obj = eval(expr)
+                words = dir(obj)
+            except Exception:
+                return []
 
         n = len(attr)
         matches = []
-        for w in words:
+        for w in map(hy_symbol_unmangle, words):
             if w[:n] == attr:
                 matches.append("{}.{}".format(
-                    expr.replace("_", "-"), w.replace("_", "-")))
+                    expr,
+                    w))
         return matches
 
     def global_matches(self, text):

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -10,6 +10,7 @@ import sys
 import hy.compiler
 import hy.macros
 from hy._compat import builtins, string_types
+from hy.lex.parser import hy_symbol_unmangle
 
 docomplete = True
 
@@ -77,7 +78,7 @@ class Completer(object):
         for p in self.path:
             for k in p:
                 if isinstance(k, string_types):
-                    k = k.replace("_", "-")
+                    k = hy_symbol_unmangle(k)
                     if k.startswith(text):
                         matches.append(k)
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1,0 +1,53 @@
+import pytest
+from hy.completer import Completer
+
+
+def test_completion_hy_core_lang():
+    x = Completer()
+
+    assert "accumulate" in x.global_matches("acc")
+    assert "take-nth" in x.global_matches("t")
+
+
+def test_completion_hy_core_shadow():
+    x = Completer()
+
+    assert "+" in x.global_matches("+")
+    assert "+=" in x.global_matches("+")
+
+
+def test_completion_hy_attrs():
+    x = Completer()
+
+    assert "str.format" in x.attr_matches("str.f")
+    assert "print.--class--" in x.attr_matches("print.")
+
+
+def test_completion_modules():
+    import itertools
+    import itertools as it
+    x = Completer(namespace={"itertools": itertools,
+                             "it": itertools})
+
+    assert "itertools.tee" in x.attr_matches("itertools.")
+    assert "itertools.tee" in x.attr_matches("itertools.t")
+    assert "itertools.tee" not in x.attr_matches("itertools")
+
+    assert "itertools.chain.from-iterable" in x.attr_matches("itertools.chain.")
+    assert "itertools.chain.--class--" in x.attr_matches("itertools.chain.")
+    assert "itertools.chain.--class--" in x.attr_matches("itertools.chain.-")
+
+    assert "it.chain.--class--" not in x.attr_matches("itertools.chain.-")
+    assert "it.chain.--class--" in x.attr_matches("it.chain.-")
+
+    assert "it" in x.global_matches("it")
+    assert "itertools" in x.global_matches("it")
+
+
+def test_completion_unmangling():
+    x = Completer()
+
+    assert "numeric?" in x.global_matches("num")
+
+    x.path.append(["func_bang"])
+    assert "func!" in x.global_matches("fun")


### PR DESCRIPTION
This is a trivial update to catch `hy.core.language` constructs in autcompletion.

I don't recall if Python2 has iteration over a dict equivalent to iterating over its keys, the only thing to watch.

I'm going to do a more involved rewrite to catch modules eg. `numpy.add`, that will come later.