### PR TITLE
update astor to 0.6

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -11,7 +11,7 @@ import sys
 import os
 import importlib
 
-import astor.codegen
+import astor.code_gen
 
 import hy
 
@@ -413,17 +413,17 @@ def hy2py_main():
             else pretty_error(import_buffer_to_ast, stdin_text, module_name))
     if options.with_ast:
         if PY3 and platform.system() == "Windows":
-            _print_for_windows(astor.dump(_ast))
+            _print_for_windows(astor.dump_tree(_ast))
         else:
-            print(astor.dump(_ast))
+            print(astor.dump_tree(_ast))
         print()
         print()
 
     if not options.without_python:
         if PY3 and platform.system() == "Windows":
-            _print_for_windows(astor.codegen.to_source(_ast))
+            _print_for_windows(astor.code_gen.to_source(_ast))
         else:
-            print(astor.codegen.to_source(_ast))
+            print(astor.code_gen.to_source(_ast))
 
     parser.exit(0)
 

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -79,9 +79,9 @@ If the second argument `codegen` is true, generate python code instead."
   (spoof-positions tree)
   (setv compiled (hy.compiler.hy-compile tree (calling-module-name)))
   ((if codegen
-            astor.codegen.to_source
-            astor.dump)
-          compiled))
+       astor.code-gen.to-source
+       astor.dump-tree)
+    compiled))
 
 (defn distinct [coll]
   "Return a generator from the original collection `coll` with no duplicates."

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class Install(install):
                         "." + filename[:-len(".hy")])
         install.run(self)
 
-install_requires = ['rply>=0.7.5', 'astor>=0.5', 'clint>=0.4']
+install_requires = ['rply>=0.7.5', 'astor>=0.6', 'clint>=0.4']
 if os.name == 'nt':
     install_requires.append('pyreadline>=2.1')
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1550,13 +1550,23 @@
   "NATIVE: Test the disassemble function"
   (if PY35
     (assert (= (disassemble '(do (leaky) (leaky) (macros)))
-               "Module(\n    body=[Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[]))])"))
+               "Module(
+    body=[Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),
+        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),
+        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[]))])"))
     (assert (= (disassemble '(do (leaky) (leaky) (macros)))
-               "Module(\n    body=[\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),\n        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[], starargs=None, kwargs=None))])")))
+               "Module(
+    body=[
+        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),
+        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[], starargs=None, kwargs=None)),
+        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[], starargs=None, kwargs=None))])")))
   (assert (= (disassemble '(do (leaky) (leaky) (macros)) True)
-             "leaky()\nleaky()\nmacros()"))
+             "leaky()
+leaky()
+macros()
+"))
   (assert (= (re.sub r"[L() ]" "" (disassemble `(+ ~(+ 1 1) 40) True))
-             "2+40")))
+             "2+40\n")))
 
 
 (defn test-attribute-access []

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -144,7 +144,7 @@
 
 (defn test-gensym-in-macros []
   (import ast)
-  (import [astor.codegen [to_source]])
+  (import [astor.code-gen [to-source]])
   (import [hy.importer [import_buffer_to_ast]])
   (setv macro1 "(defmacro nif [expr pos zero neg]
       (setv g (gensym))
@@ -170,7 +170,7 @@
 
 (defn test-with-gensym []
   (import ast)
-  (import [astor.codegen [to_source]])
+  (import [astor.code-gen [to-source]])
   (import [hy.importer [import_buffer_to_ast]])
   (setv macro1 "(defmacro nif [expr pos zero neg]
       (with-gensyms [a]
@@ -194,7 +194,7 @@
 
 (defn test-defmacro-g! []
   (import ast)
-  (import [astor.codegen [to_source]])
+  (import [astor.code-gen [to-source]])
   (import [hy.importer [import_buffer_to_ast]])
   (setv macro1 "(defmacro/g! nif [expr pos zero neg]
         `(do
@@ -223,7 +223,7 @@
 (defn test-defmacro! []
   ;; defmacro! must do everything defmacro/g! can
   (import ast)
-  (import [astor.codegen [to_source]])
+  (import [astor.code-gen [to-source]])
   (import [hy.importer [import_buffer_to_ast]])
   (setv macro1 "(defmacro! nif [expr pos zero neg]
         `(do

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -72,7 +72,7 @@ def test_bin_hy_stdin():
 
     output, _ = run_cmd("hy --spy", '(koan)')
     assert "monk" in output
-    assert "\\n  Ummon" in output
+    assert "\n  Ummon" in output
 
     # --spy should work even when an exception is thrown
     output, _ = run_cmd("hy --spy", '(foof)')
@@ -195,7 +195,7 @@ def test_bin_hy_icmd_file():
 
 def test_bin_hy_icmd_and_spy():
     output, _ = run_cmd("hy -i \"(+ [] [])\" --spy", "(+ 1 1)")
-    assert "([] + [])" in output
+    assert "[] + []" in output
 
 
 def test_bin_hy_missing_file():


### PR DESCRIPTION
Fixes #1446.

The new astor is much improved. You can actually read quasiquoted forms in Python now.

I've almost got this working, but Hy's `NaN` literal crashes astor and I'm not sure what to do about it.
Astor also prints off `Inf` as `1e1000` instead now.

One option is to remove the three literals, `Inf`, `-Inf`, and `NaN` from Hy. Python doesn't have them, but since 3.5 has a `math.nan` and `math.inf`. It would save on the extra code from #1294.

We're kind of exploiting an implementation detail of the ast to make these literals, so it's not that surprising that astor can't handle them. (We could kind of say the same of Hy's expanded character set for symbols, but that's used by more than Hy--e.g. by pytest's rewriting of `assert`s.) Our astor-based `hy2py` tool doesn't always produce valid Python because of this kind of thing. If we always mangled symbols to valid Python identifiers, we could improve on this though.

Another option is to request that astor allow the `NaN`s for us, or maintain a tweaked fork that does that. @berkerpeksag care to weigh in on this option? Can you remove the offending assertion?

Fixing Hy at astor 0.5 is not an option long-term. Hy has already fallen behind as Python adds new features. There are already things 0.5 can't render properly, like the extended * unpacking. We need to keep up with them.