### PR TITLE
fix loop/recur nesting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@ Changes from 0.13.0
    * `xi` from `hy.extra.anaphoric` is now the `#%` tag macro
    * `#%` works on any expression and has a new `&kwargs` parameter `%**`
    * new `doc` macro and `#doc` tag macro
+   * removed redundant brackets in loop/recur
 
    [ Bug Fixes ]
    * Numeric literals are no longer parsed as symbols when followed by a dot
@@ -51,6 +52,7 @@ Changes from 0.13.0
      a for loop
    * `else` clauses in `for` and `while` are recognized more reliably
    * Argument destructuring no longer interferes with function docstrings.
+   * In nested `loop`s, `recur` uses the current loop instead of the outermost.
 
    [ Misc. Improvements ]
    * `read`, `read_str`, and `eval` are exposed and documented as top-level

--- a/docs/contrib/loop.rst
+++ b/docs/contrib/loop.rst
@@ -29,15 +29,34 @@ tail-call optimization (TCO) in their Hy code.
 Macros
 ======
 
+.. _defnr:
+
+defnr
+-----
+Function definition with tail-call optimized ``recur`` anaphor.
+
+Tail recursion via the ``recur`` anaphor instead of the function name will not
+cause stack overflow.
+
+.. _fnr:
+
+fnr
+---
+Function with tail-call optimized ``recur`` anaphor.
+
+Tail recursion via the ``recur`` anaphor will not cause stack overflow.
+
 .. _loop:
 
 loop
 -----
+Tail-call optimized loop/recur macro.
 
-``loop`` establishes a recursion point. With ``loop``, ``recur``
-rebinds the variables set in the recursion point and sends code
-execution back to that recursion point. If ``recur`` is used in a
-non-tail position, an exception is raised.
+``loop`` declares a new function and immediately calls it with the given
+argument bindings--it establishes a recursion point. Within a ``loop``,
+``recur`` rebinds the variables set in the recursion point and continues
+execution from that recursion point, but without a new stack frame.
+If ``recur`` is used in a non-tail position, an exception is raised.
 
 Usage: ``(loop bindings &rest body)``
 

--- a/docs/contrib/loop.rst
+++ b/docs/contrib/loop.rst
@@ -48,7 +48,8 @@ Example:
     (require [hy.contrib.loop [loop]])
 
     (defn factorial [n]
-      (loop [[i n] [acc 1]]
+      (loop [i n
+             acc 1]
         (if (zero? i)
           acc
           (recur (dec i) (* acc i)))))

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -33,6 +33,9 @@
 
 
 (defmacro/g! fnr [signature &rest body]
+  "Function with tail-call optimized `recur` anaphor.
+
+  Tail recursion via the `recur` anaphor will not cause stack overflow."
   (setv new-body (prewalk
                    (fn [x]
                      (if (and (symbol? x)
@@ -47,8 +50,25 @@
      ~g!recur-fn))
 
 
+(defmacro defnr [name lambda-list &rest body]
+  "Function definition with tail-call optimized `recur` anaphor.
+
+  Tail recursion via the `recur` anaphor instead of the function name will not
+  cause stack overflow."
+  (if (not (= (type name) HySymbol))
+      (macro-error name "defnr takes a name as first argument"))
+  `(do (require hy.contrib.loop)
+       (setv ~name (hy.contrib.loop.fnr ~lambda-list ~@body))))
+
+
 (defmacro loop [bindings &rest body]
-  " Use inside functions like so:
+  "Tail-call optimized loop/recur macro.
+
+  `loop` declares a new function and immediately calls it with the given
+  argument bindings. Use the `recur` anaphor to call the function again
+  with new bindings, but without a new stack frame.
+
+  Use inside functions like so:
   (defn factorial [n]
     (loop [i n
            acc 1]
@@ -58,8 +78,7 @@
 
   If recur is used in a non-tail-call position, None is returned, which
   causes chaos. Fixing this to detect if recur is in a tail-call position
-  and erroring if not is a giant TODO.
-"
+  and erroring if not is a giant TODO."
   (setv fn-args (cut bindings None None 2)
         init-args (cut bindings 1 None 2))
   `(do (require hy.contrib.loop)

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -8,7 +8,7 @@
 
 (import [hy.contrib.walk [macroexpand-all prewalk]])
 
-(defn --trampoline-- [f]
+(defn __trampoline__ [f]
   "Wrap f function and make it tail-call optimized."
   ;; Takes the function "f" and returns a wrapper that may be used for tail-
   ;; recursive algorithms. Note that the returned function is not side-effect
@@ -40,9 +40,9 @@
                          g!recur-fn x))
                    (macroexpand-all body &name)))
   `(do
-     (import [hy.contrib.loop [--trampoline--]])
+     (import [hy.contrib.loop [__trampoline__]])
      (with-decorator
-       --trampoline--
+       __trampoline__
        (defn ~g!recur-fn [~@signature] ~@new-body))
      ~g!recur-fn))
 
@@ -50,8 +50,8 @@
 (defmacro loop [bindings &rest body]
   " Use inside functions like so:
   (defn factorial [n]
-    (loop [[i n]
-           [acc 1]]
+    (loop [i n
+           acc 1]
           (if (= i 0)
             acc
             (recur (dec i) (* acc i)))))
@@ -60,8 +60,8 @@
   causes chaos. Fixing this to detect if recur is in a tail-call position
   and erroring if not is a giant TODO.
 "
-  (setv fnargs (map (fn [x] (first x)) bindings)
-        initargs (map second bindings))
+  (setv fn-args (cut bindings None None 2)
+        init-args (cut bindings 1 None 2))
   `(do (require hy.contrib.loop)
-       ((hy.contrib.loop.fnr [~@fnargs]
-          ~@body) ~@initargs)))
+       ((hy.contrib.loop.fnr [~@fn-args]
+          ~@body) ~@init-args)))

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -34,19 +34,19 @@
 
 (defmacro/g! fnr [signature &rest body]
   (setv new-body (prewalk
-    (fn [x] (if (and (symbol? x) (= x "recur")) g!recur-fn x))
-    body))
+                   (fn [x] (if (and (symbol? x) (= x "recur")) g!recur-fn x))
+                   body))
   `(do
-    (import [hy.contrib.loop [--trampoline--]])
-    (with-decorator
-      --trampoline--
-      (defn ~g!recur-fn [~@signature] ~@new-body))
-    ~g!recur-fn))
+     (import [hy.contrib.loop [--trampoline--]])
+     (with-decorator
+       --trampoline--
+       (defn ~g!recur-fn [~@signature] ~@new-body))
+     ~g!recur-fn))
 
 
 (defmacro defnr [name lambda-list &rest body]
   (if (not (= (type name) HySymbol))
-    (macro-error name "defnr takes a name as first argument"))
+      (macro-error name "defnr takes a name as first argument"))
   `(do (require hy.contrib.loop)
        (setv ~name (hy.contrib.loop.fnr ~lambda-list ~@body))))
 

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -55,7 +55,7 @@
           (if (= i 0)
             acc
             (recur (dec i) (* acc i)))))
-  
+
   If recur is used in a non-tail-call position, None is returned, which
   causes chaos. Fixing this to detect if recur is in a tail-call position
   and erroring if not is a giant TODO.

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -6,7 +6,7 @@
 ;;; The loop/recur macro allows you to construct functions that use tail-call
 ;;; optimization to allow arbitrary levels of recursion.
 
-(import [hy.contrib.walk [prewalk]])
+(import [hy.contrib.walk [macroexpand-all prewalk]])
 
 (defn --trampoline-- [f]
   "Wrap f function and make it tail-call optimized."
@@ -34,8 +34,11 @@
 
 (defmacro/g! fnr [signature &rest body]
   (setv new-body (prewalk
-                   (fn [x] (if (and (symbol? x) (= x "recur")) g!recur-fn x))
-                   body))
+                   (fn [x]
+                     (if (and (symbol? x)
+                              (= x "recur"))
+                         g!recur-fn x))
+                   (macroexpand-all body &name)))
   `(do
      (import [hy.contrib.loop [--trampoline--]])
      (with-decorator
@@ -44,27 +47,21 @@
      ~g!recur-fn))
 
 
-(defmacro defnr [name lambda-list &rest body]
-  (if (not (= (type name) HySymbol))
-      (macro-error name "defnr takes a name as first argument"))
-  `(do (require hy.contrib.loop)
-       (setv ~name (hy.contrib.loop.fnr ~lambda-list ~@body))))
-
-
-(defmacro/g! loop [bindings &rest body]
-  ;; Use inside functions like so:
-  ;; (defn factorial [n]
-  ;;   (loop [[i n]
-  ;;          [acc 1]]
-  ;;         (if (= i 0)
-  ;;           acc
-  ;;           (recur (dec i) (* acc i)))))
-  ;;
-  ;; If recur is used in a non-tail-call position, None is returned, which
-  ;; causes chaos. Fixing this to detect if recur is in a tail-call position
-  ;; and erroring if not is a giant TODO.
+(defmacro loop [bindings &rest body]
+  " Use inside functions like so:
+  (defn factorial [n]
+    (loop [[i n]
+           [acc 1]]
+          (if (= i 0)
+            acc
+            (recur (dec i) (* acc i)))))
+  
+  If recur is used in a non-tail-call position, None is returned, which
+  causes chaos. Fixing this to detect if recur is in a tail-call position
+  and erroring if not is a giant TODO.
+"
   (setv fnargs (map (fn [x] (first x)) bindings)
         initargs (map second bindings))
   `(do (require hy.contrib.loop)
-       (hy.contrib.loop.defnr ~g!recur-fn [~@fnargs] ~@body)
-       (~g!recur-fn ~@initargs)))
+       ((hy.contrib.loop.fnr [~@fnargs]
+          ~@body) ~@initargs)))

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -73,3 +73,14 @@
                  [2 1]
                  [1 2]
                  [1 1]])))
+
+(defn test-loop-shadow []
+  (setv xs [])
+  (loop [x 3]
+        (loop [x x]
+              (when (pos? x)
+                (.append xs x)
+                (recur (dec x))))
+        (when (pos? x)
+          (recur (dec x))))
+  (assert (= xs [3 2 1 2 1 1])))

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -6,7 +6,8 @@
 (import sys)
 
 (defn tco-sum [x y]
-  (loop [[x x] [y y]]
+  (loop [x x
+         y y]
         (cond
           [(> y 0) (recur (inc x) (dec y))]
           [(< y 0) (recur (dec x) (inc y))]
@@ -37,7 +38,7 @@
 
 (defn test-recur-in-wrong-loc []
   (defn bad-recur [n]
-    (loop [[i n]]
+    (loop [i n]
           (if (= i 0)
               0
               (inc (recur (dec i))))))
@@ -55,13 +56,13 @@
 
 (defn test-loop-nested []
   (setv xs [])
-  (loop [[i 3]]
+  (loop [i 3]
         ;; failure could cause an infinite loop
         ;; so assert we're not appending too much
         (assert (< (len xs)
                    10))
         (when (pos? i)
-          (loop [[j 2]]
+          (loop [j 2]
                 (when (pos? j)
                   (.append xs [i j])
                   (recur (dec j))))

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -8,46 +8,46 @@
 (defn tco-sum [x y]
   (loop [[x x] [y y]]
         (cond
-         [(> y 0) (recur (inc x) (dec y))]
-         [(< y 0) (recur (dec x) (inc y))]
-         [True x])))
+          [(> y 0) (recur (inc x) (dec y))]
+          [(< y 0) (recur (dec x) (inc y))]
+          [True x])))
 
 (defn non-tco-sum [x y]
   (cond
-   [(> y 0) (inc (non-tco-sum x (dec y)))]
-   [(< y 0) (dec (non-tco-sum x (inc y)))]
-   [True x]))
+    [(> y 0) (inc (non-tco-sum x (dec y)))]
+    [(< y 0) (dec (non-tco-sum x (inc y)))]
+    [True x]))
 
 (defn test-loop []
   ;; non-tco-sum should fail
   (try
-   (setv n (non-tco-sum 100 10000))
-   (except [e RuntimeError]
-     (assert True))
-   (else
-    (assert False)))
+    (setv n (non-tco-sum 100 10000))
+    (except [e RuntimeError]
+      (assert True))
+    (else
+      (assert False)))
 
   ;; tco-sum should not fail
   (try
-   (setv n (tco-sum 100 10000))
-   (except [e RuntimeError]
-     (assert False))
-   (else
-    (assert (= n 10100)))))
+    (setv n (tco-sum 100 10000))
+    (except [e RuntimeError]
+      (assert False))
+    (else
+      (assert (= n 10100)))))
 
 (defn test-recur-in-wrong-loc []
   (defn bad-recur [n]
     (loop [[i n]]
           (if (= i 0)
-            0
-            (inc (recur (dec i))))))
+              0
+              (inc (recur (dec i))))))
 
   (try
-   (bad-recur 3)
-   (except [e TypeError]
-     (assert True))
-   (else
-    (assert False))))
+    (bad-recur 3)
+    (except [e TypeError]
+      (assert True))
+    (else
+      (assert False))))
 
 (defn test-recur-string []
   "test that `loop` doesn't touch a string named `recur`"

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(require [hy.contrib.loop [loop]])
+(require [hy.contrib.loop [loop fnr defnr]])
 (import sys)
 
 (defn tco-sum [x y]
@@ -28,6 +28,30 @@
     (else
       (assert False)))
 
+  ;; tco-sum should not fail
+  (try
+    (setv n (tco-sum 100 10000))
+    (except [e RuntimeError]
+      (assert False))
+    (else
+      (assert (= n 10100)))))
+
+(defn test-loop-fnr []
+  (assert (= ((fnr [xs]
+                (if (< (len xs)
+                       7)
+                    (recur (+ "x" xs))
+                    xs)
+               "foo"))
+             "xxxxfoo")))
+
+(defnr defnr-tco-sum [x y]
+  (cond
+    [(> y 0) (recur (inc x) (dec y))]
+    [(< y 0) (recur (dec x) (inc y))]
+    [True x]))
+
+(defn test-loop-defnr []
   ;; tco-sum should not fail
   (try
     (setv n (tco-sum 100 10000))

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -52,3 +52,23 @@
 (defn test-recur-string []
   "test that `loop` doesn't touch a string named `recur`"
   (assert (= (loop [] (+ "recur" "1")) "recur1")))
+
+(defn test-loop-nested []
+  (setv xs [])
+  (loop [[i 3]]
+        ;; failure could cause an infinite loop
+        ;; so assert we're not appending too much
+        (assert (< (len xs)
+                   10))
+        (when (pos? i)
+          (loop [[j 2]]
+                (when (pos? j)
+                  (.append xs [i j])
+                  (recur (dec j))))
+          (recur (dec i))))
+  (assert (= xs [[3 2]
+                 [3 1]
+                 [2 2]
+                 [2 1]
+                 [1 2]
+                 [1 1]])))


### PR DESCRIPTION
**mo\`** on IRC pointed out that `loop`/`recur` doesn't nest properly. 

Fixing this probably wasn't possible before the upgraded `macroexpand-all` from #1426. `loop` now uses a body pre-expansion strategy like our new `let`.

It was also surprising to **mo\`** that `loop` used extra brackets unlike Clojure's `loop` and our current `let`. This PR fixes both issues.

It also removes a useless extra assignment in the expansion.