### PR TITLE
Don't parse large floats as symbols

### DIFF
--- a/hy/models.py
+++ b/hy/models.py
@@ -179,7 +179,7 @@ if not PY3:  # do not add long on python3
 
 def check_inf_nan_cap(arg, value):
     if isinstance(arg, string_types):
-        if isinf(value) and "Inf" not in arg:
+        if isinf(value) and "i" in arg.lower() and "Inf" not in arg:
             raise ValueError('Inf must be capitalized as "Inf"')
         if isnan(value) and "NaN" not in arg:
             raise ValueError('NaN must be capitalized as "NaN"')

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -103,6 +103,12 @@ def test_lex_expression_float():
     assert objs == [HyExpression([HySymbol("foo"), HyFloat(1.e7)])]
 
 
+def test_lex_big_float():
+    # https://github.com/hylang/hy/issues/1448
+    assert tokenize("1e900") == [HyFloat(1e900)]
+    assert tokenize("1e900-1e900j") == [HyComplex(1e900, -1e900)]
+
+
 def test_lex_nan_and_inf():
 
     assert isnan(tokenize("NaN")[0])


### PR DESCRIPTION
Fixes #1448.

There's no NEWS entry because this was a regression since the previous release.