### PR TITLE
Update interop doc: print function is lower-case

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,4 +84,5 @@
 * Andrew Silva <asilva@law.harvard.edu>
 * Zaheer Soebhan <z.soebhan@gmail.com>
 * Rob Day <rkd@rkd.me.uk>
-* Eric Kaschalk <ekaschalk@gmail.com> 
+* Eric Kaschalk <ekaschalk@gmail.com>
+* Yoan Tournade <yoan@ytotech.com>

--- a/docs/language/interop.rst
+++ b/docs/language/interop.rst
@@ -77,7 +77,7 @@ If you save the following in ``greetings.hy``:
 .. code-block:: clj
 
     (setv *this-will-be-in-caps-and-underscores* "See?")
-    (defn greet [name] (Print "hello from hy," name))
+    (defn greet [name] (print "hello from hy," name))
 
 Then you can use it directly from Python, by importing Hy before importing
 the module. In Python::


### PR DESCRIPTION
(A typo made use of Print function, which is not defined)