### PR TITLE
Safer returns

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -64,9 +64,16 @@ def load_stdlib():
 # True, False and None included here since they
 # are assignable in Python 2.* but become
 # keywords in Python 3.*
+_keywords = set(keyword.kwlist)
+if PY3:
+    _keywords = _keywords.difference(('True', 'False', 'None'))
+
+_is_hy_reserved = frozenset(_keywords).__contains__
+
+
 def _is_hy_builtin(name, module_name):
     extras = ['True', 'False', 'None']
-    if name in extras or keyword.iskeyword(name):
+    if name in extras or _is_hy_reserved(name):
         return True
     # for non-Hy modules, check for pre-existing name in
     # _compile_table

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -604,6 +604,14 @@ def test_defn():
     can_compile("(defn &hy [] 1)")
 
 
+def test_bad_return():
+    "Make sure returns are properly validated"
+    cant_compile("(return return)")
+    cant_compile("(fn [] return)")
+    cant_compile("(fn* [] return)")
+    cant_compile("(fn* [] (return return))")
+
+
 def test_setv_builtins():
     """Ensure that assigning to a builtin fails, unless in a class"""
     cant_compile("(setv None 42)")


### PR DESCRIPTION
Adds a sanity check to make certain forms no longer compile:

```
=> (fn [] return)
  File "<input>", line 1, column 1

  (fn [] return)
  ^------------^
HyTypeError: Can't return a keyword: `return'
```

Without this patch, Hy will generate invalid Python (`lambda : return` in the case above).