### PR TITLE
[RFC] Variable annotation support

### DIFF
--- a/docs/contrib/walk.rst
+++ b/docs/contrib/walk.rst
@@ -48,7 +48,7 @@ each sub-form, uses ``f`` 's return value in place of the original.
 .. code-block:: hy
 
     => (import [hy.contrib.walk [postwalk]])
-    => (def trail '([1 2 3] [4 [5 6 [7]]]))
+    => (setv trail '([1 2 3] [4 [5 6 [7]]]))
     => (defn walking [x]
     ...  (print "Walking:" x :sep "\n")
     ...  x)
@@ -128,7 +128,7 @@ each sub-form, uses ``f`` 's return value in place of the original.
 .. code-block:: hy
 
     => (import [hy.contrib.walk [prewalk]])
-    => (def trail '([1 2 3] [4 [5 6 [7]]]))
+    => (setv trail '([1 2 3] [4 [5 6 [7]]]))
     => (defn walking [x]
     ...  (print "Walking:" x :sep "\n")
     ...  x)

--- a/docs/extra/anaphoric.rst
+++ b/docs/extra/anaphoric.rst
@@ -225,7 +225,7 @@ Returns a function which applies several forms in series from left to right. The
 
 .. code-block:: hy
 
-   => (def op (ap-compose (+ it 1) (* it 3)))
+   => (setv op (ap-compose (+ it 1) (* it 3)))
    => (op 2)
    9
 

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -544,7 +544,7 @@ For example:
 
 .. code-block:: clj
 
-    => (def names ["Alice" "Bob" "Charlie"])
+    => (setv names ["Alice" "Bob" "Charlie"])
     => (print names)
     [u'Alice', u'Bob', u'Charlie']
 
@@ -590,7 +590,7 @@ below:
     ...
     ...  (defn speak [self] (print "Meow")))
 
-    => (def spot (Cat))
+    => (setv spot (Cat))
     => (setv spot.colour "Black")
     'Black'
     => (.speak spot)
@@ -1077,8 +1077,8 @@ immediately.
 
 .. code-block:: hy
 
-    => (def collection (range 10))
-    => (def filtered (genexpr x [x collection] (even? x)))
+    => (setv collection (range 10))
+    => (setv filtered (genexpr x [x collection] (even? x)))
     => (list filtered)
     [0, 2, 4, 6, 8]
 
@@ -1295,7 +1295,7 @@ passed to another function for filtering output.
 
 .. code-block:: clj
 
-    => (def people [{:name "Alice" :age 20}
+    => (setv people [{:name "Alice" :age 20}
     ...             {:name "Bob" :age 25}
     ...             {:name "Charlie" :age 50}
     ...             {:name "Dave" :age 5}])
@@ -1359,7 +1359,7 @@ conditional expression. Some examples:
 
 .. code-block:: clj
 
-    => (def collection (range 10))
+    => (setv collection (range 10))
     => (list-comp x [x collection])
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
@@ -1653,7 +1653,7 @@ counted starting from the end of the list. Some example usage:
 
 .. code-block:: clj
 
-    => (def collection (range 10))
+    => (setv collection (range 10))
 
     => (cut collection)
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -536,10 +536,10 @@ Gets help for macros or tag macros, respectively.
     Gets help for a tag macro function available in this module.
 
 
-def / setv
-----------
+setv
+----
 
-``def`` and ``setv`` are used to bind a value, object, or function to a symbol.
+``setv`` is used to bind a value, object, or function to a symbol.
 For example:
 
 .. code-block:: clj
@@ -563,6 +563,23 @@ They can be used to assign multiple variables at once:
     => b
     2L
     =>
+
+
+def
+---
+
+``def`` is used to declare a variable with a type annotation, while
+optionally providing a default value.
+For example:
+
+.. code-block:: clj
+
+    => (defclass Person []
+    ...   (def name str)
+    ...   (def age int))
+
+    => (print (tying.get-type-hints (Person)))
+    {'name': <class 'str'>, 'age': <class 'int'>}
 
 
 defclass
@@ -1296,9 +1313,9 @@ passed to another function for filtering output.
 .. code-block:: clj
 
     => (setv people [{:name "Alice" :age 20}
-    ...             {:name "Bob" :age 25}
-    ...             {:name "Charlie" :age 50}
-    ...             {:name "Dave" :age 5}])
+    ...              {:name "Bob" :age 25}
+    ...              {:name "Charlie" :age 50}
+    ...              {:name "Dave" :age 5}])
 
     => (defn display-people [people filter]
     ...  (for [person people] (if (filter person) (print (:name person)))))

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -66,11 +66,11 @@ chain the given functions together, so ``((comp g f) x)`` is equivalent to
 
 .. code-block:: hy
 
-   => (def example (comp str +))
+   => (setv example (comp str +))
    => (example 1 2 3)
    "6"
 
-   => (def simple (comp))
+   => (setv simple (comp))
    => (simple "hello")
    "hello"
 
@@ -89,7 +89,7 @@ inverted. So, ``((complement f) x)`` is equivalent to ``(not (f x))``.
 
 .. code-block:: hy
 
-   => (def inverse (complement identity))
+   => (setv inverse (complement identity))
    => (inverse True)
    False
    => (inverse 1)
@@ -155,7 +155,7 @@ the arguments given to it.
 
 .. code-block:: hy
 
-   => (def answer (constantly 42))
+   => (setv answer (constantly 42))
    => (answer)
    42
    => (answer 1 2 3)

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -120,26 +120,6 @@ Layout & Indentation
 Coding Style
 ============
 
-+ As a convention, try not to use ``def`` for anything other than global
-  variables; use ``setv`` inside functions, loops, etc.
-
-  .. code-block:: clj
-
-     ;; Good (and preferred)
-     (def *limit* 400000)
-
-     (defn fibs [a b]
-       (while True
-         (yield a)
-         (setv (, a b) (, b (+ a b)))))
-
-     ;; Bad (and not preferred)
-     (defn fibs [a b]
-       (while True
-         (yield a)
-         (def (, a b) (, b (+ a b)))))
-
-
 + Do not use s-expression syntax where vector syntax is intended.
   For instance, the fact that the former of these two examples works
   is just because the compiler isn't overly strict. In reality, the

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1789,8 +1789,6 @@ class HyASTCompiler(object):
         root = expression.pop(0)
         if not expression:
             return asty.Name(root, id='None', ctx=ast.Load())
-        elif len(expression) == 2:
-            return self._compile_assign(expression[0], expression[1])
         elif len(expression) % 2 != 0:
             raise HyTypeError(expression,
                               "`{}' needs an even number of arguments".format(

--- a/hy/contrib/multi.hy
+++ b/hy/contrib/multi.hy
@@ -74,20 +74,20 @@
   (, (get l 0) (cut l 1)))
 
 (defmacro defn [name &rest bodies]
-  (def arity-overloaded? (fn [bodies]
-                           (if (isinstance (first bodies) HyString)
-                             (arity-overloaded? (rest bodies))
-                             (isinstance (first bodies) HyExpression))))
+  (setv arity-overloaded? (fn [bodies]
+                            (if (isinstance (first bodies) HyString)
+                                (arity-overloaded? (rest bodies))
+                                (isinstance (first bodies) HyExpression))))
 
   (if (arity-overloaded? bodies)
     (do
-     (def comment (HyString))
+     (setv comment (HyString))
      (if (= (type (first bodies)) HyString)
-       (def [comment bodies] (head-tail bodies)))
-     (def ret `(do))
+       (setv [comment bodies] (head-tail bodies)))
+     (setv ret `(do))
      (.append ret '(import [hy.contrib.multi [MultiDispatch]]))
      (for [body bodies]
-       (def [let-binds body] (head-tail body))
+       (setv [let-binds body] (head-tail body))
        (.append ret 
                 `(with-decorator MultiDispatch (defn ~name ~let-binds ~comment ~@body))))
      ret)

--- a/hy/contrib/sequences.hy
+++ b/hy/contrib/sequences.hy
@@ -55,7 +55,7 @@
   `(Sequence (fn ~param (do ~@seq-code))))
 
 (defmacro defseq [seq-name param &rest seq-code]
-  `(def ~seq-name (Sequence (fn ~param (do ~@seq-code)))))
+  `(setv ~seq-name (Sequence (fn ~param (do ~@seq-code)))))
 
 (defn end-sequence []
   "raise IndexError exception to signal end of sequence"

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -93,7 +93,7 @@ If the second argument `codegen` is true, generate python code instead."
        (.add seen val)))))
 
 (if-python2
- (def
+ (setv
    remove itertools.ifilterfalse
    zip-longest itertools.izip_longest
    ;; not builtin in Python3
@@ -104,7 +104,7 @@ If the second argument `codegen` is true, generate python code instead."
    map itertools.imap
    range xrange
    zip itertools.izip)
- (def
+ (setv
    remove itertools.filterfalse
    zip-longest itertools.zip_longest
    ;; was builtin in Python2
@@ -132,16 +132,16 @@ function with keyword arguments, which isn't supported by Python 3's `exec`."
       (none? $locals)
         (setv $locals $globals))
     (exec* $code $globals $locals))
-  (def exec exec))
+  (setv exec exec))
 
 ;; infinite iterators
-(def
+(setv
   count itertools.count
   cycle itertools.cycle
   repeat itertools.repeat)
 
 ;; shortest-terminating iterators
-(def
+(setv
   *map itertools.starmap
   chain itertools.chain
   compress itertools.compress
@@ -152,7 +152,7 @@ function with keyword arguments, which isn't supported by Python 3's `exec`."
   tee itertools.tee)
 
 ;; combinatoric iterators
-(def
+(setv
   combinations itertools.combinations
   multicombinations itertools.combinations_with_replacement
   permutations itertools.permutations
@@ -359,7 +359,7 @@ If a key occurs in more than one map, the mapping(s) from the latter
   "Check if `n` is an odd number."
   (= (% n 2) 1))
 
-(def -sentinel (object))
+(setv -sentinel (object))
 (defn partition [coll &optional [n 2] step [fillvalue -sentinel]]
   "Chunk `coll` into `n`-tuples (pairs by default).
 
@@ -485,7 +485,7 @@ Even objects with the __name__ magic will work."
     False
     (or a b)))
 
-(def *exports*
+(setv *exports*
   '[*map accumulate butlast calling-module-name chain coll? combinations
     comp complement compress cons cons? constantly count cycle dec distinct
     disassemble drop drop-last drop-while empty? eval even? every? exec first

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -7,11 +7,11 @@
 
 (import pytest)
 
-(def walk-form '(print {"foo" "bar"
-                        "array" [1 2 3 [4]]
-                        "something" (+ 1 2 3 4)
-                        "cons!" (cons 1 2)
-                        "quoted?" '(foo)}))
+(setv walk-form '(print {"foo" "bar"
+                         "array" [1 2 3 [4]]
+                         "something" (+ 1 2 3 4)
+                         "cons!" (cons 1 2)
+                         "quoted?" '(foo)}))
 
 (defn collector [acc x]
   (.append acc x)

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -651,14 +651,14 @@ result['y in globals'] = 'y' in globals()")
 
 (defn test-complement []
   "NATIVE: test complement"
-  (def helper (complement identity))
+  (setv helper (complement identity))
 
   (assert-true (helper False))
   (assert-false (helper True)))
 
 (defn test-constantly []
   "NATIVE: test constantly"
-  (def helper (constantly 42))
+  (setv helper (constantly 42))
 
   (assert-true (= (helper) 42))
   (assert-true (= (helper 1 2 3) 42))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1631,17 +1631,17 @@ macros()
     (import [io [StringIO]]))
   (import [hy.models [HyExpression]])
 
-  (def stdin-buffer (StringIO "(+ 2 2)\n(- 2 2)"))
+  (setv stdin-buffer (StringIO "(+ 2 2)\n(- 2 2)"))
   (assert (= (eval (read stdin-buffer)) 4))
   (assert (isinstance (read stdin-buffer) HyExpression))
 
   "Multiline test"
-  (def stdin-buffer (StringIO "(\n+\n41\n1\n)\n(-\n2\n1\n)"))
+  (setv stdin-buffer (StringIO "(\n+\n41\n1\n)\n(-\n2\n1\n)"))
   (assert (= (eval (read stdin-buffer)) 42))
   (assert (= (eval (read stdin-buffer)) 1))
 
   "EOF test"
-  (def stdin-buffer (StringIO "(+ 2 2)"))
+  (setv stdin-buffer (StringIO "(+ 2 2)"))
   (read stdin-buffer)
   (try
     (read stdin-buffer)

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -191,7 +191,7 @@
   "NATIVE: tests that native aliases show the correct names in errors"
   (try (eval '(setv 1 2 3))
        (except [e [Exception]] (assert (in "setv" (str e)))))
-  (try (eval '(def 1 2 3))
+  (try (eval '(def 1 2 3 4))
        (except [e [Exception]] (assert (in "def" (str e))))))
 
 

--- a/tests/native_tests/mathematics.hy
+++ b/tests/native_tests/mathematics.hy
@@ -177,17 +177,17 @@
        (.append result result-row))
      result)])
 
-(def first-test-matrix (HyTestMatrix [[1 2 3]
-                                      [4 5 6]
-                                      [7 8 9]]))
+(setv first-test-matrix (HyTestMatrix [[1 2 3]
+                                       [4 5 6]
+                                       [7 8 9]]))
 
-(def second-test-matrix (HyTestMatrix [[2 0 0]
-                                       [0 2 0]
-                                       [0 0 2]]))
+(setv second-test-matrix (HyTestMatrix [[2 0 0]
+                                        [0 2 0]
+                                        [0 0 2]]))
 
-(def product-of-test-matrices (HyTestMatrix [[ 2  4  6]
-                                             [ 8 10 12]
-                                             [14 16 18]]))
+(setv product-of-test-matrices (HyTestMatrix [[ 2  4  6]
+                                              [ 8 10 12]
+                                              [14 16 18]]))
 
 (defn test-matmul []
   "NATIVE: test matrix multiplication"

--- a/tests/native_tests/tag_macros.hy
+++ b/tests/native_tests/tag_macros.hy
@@ -89,7 +89,7 @@
   (deftag t [expr]
     `(, ~@expr))
 
-  (def a #t[1 2 3])
+  (setv a #t[1 2 3])
 
   (assert (= (type a) tuple))
   (assert (= (, 1 2 3) a)))


### PR DESCRIPTION
Hey, so I really would like to see some type hinting support, and putting this up to see if there's interest in this. If there is, I'm willing to see this though, tests and all, but I don't want to spend a lot of time on this if there's fundamentally no interest.

I think its still worth adding support even if there isn't any direct static analysis support as the typing module has and gaining a number of useful runtime tools. And as these techniques become more popular, probably visible in 3rd party python libraries.

This PR, which I do not expect to get merged in its current state, adds support for emitting `ast.AnnAssign`. This allows us to support PEP 526 and define variables without an initial value. Then, to test this, I added `(annv ...)` expression for defining a variable without an initial value.

This enables us support things like `typing.NamedTuple` and the coming `dataclasses.dataclass` easily:

```clojure
(import [typing [NamedTuple]])

(defclass Person [NamedTuple]
   (annv name str
         age int)) 


(defmain [&rest args]
  (setv person (Person "Jeff" 30))
  (print person))
```

Now why not just manipulate `__annotations__` like I suggested in #640? It becomes cumbersome when dealing with things like `dataclasses` that expect both type annotations *and* a default value.

Feedback? Opinions? Should I carry on, is it there no interest in maintaining this? 