### PR TITLE
docs/conf.py: make regexp string raw

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ extensions = ['sphinx.ext.intersphinx']
 
 from get_version import __version__ as hy_version
 # Read the Docs might dirty its checkout, so strip the dirty flag.
-hy_version = re.sub('[+.]dirty\Z', '', hy_version)
+hy_version = re.sub(r'[+.]dirty\Z', '', hy_version)
 
 templates_path = ['_templates']
 source_suffix = '.rst'


### PR DESCRIPTION
Fixes:

    conf.py:12: DeprecationWarning: invalid escape sequence \Z

when building docs using Python 3.6 with warnings enabled.