### PR TITLE
Native support for Ellipsis

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,7 @@ Changes from 0.13.0
    * `#%` works on any expression and has a new `&kwargs` parameter `%**`
    * new `doc` macro and `#doc` tag macro
    * support for PEP 492 with `fn/a`, `defn/a`, `with/a` and `for/a`
+   * add support to understand `...` as `Ellipsis`
 
    [ Bug Fixes ]
    * Numeric literals are no longer parsed as symbols when followed by a dot

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2163,7 +2163,12 @@ class HyASTCompiler(object):
 
     @builds(HySymbol)
     def compile_symbol(self, symbol):
-        if "." in symbol:
+        if symbol == "...":
+            if not PY3:
+                raise HyTypeError(symbol, 'ellipsis syntax is only supported '
+                                          'for Python 3')
+            return asty.Ellipsis(symbol)
+        elif "." in symbol:
             glob, local = symbol.rsplit(".", 1)
 
             if not glob:

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -272,6 +272,10 @@ class Result(object):
         if isinstance(other, ast.excepthandler):
             return self + Result(stmts=[other])
 
+        if isinstance(other, ast.slice):
+            raise TypeError("Can't add %r with slice specific syntax %r" % (
+                self, other))
+
         if not isinstance(other, Result):
             raise TypeError("Can't add %r with non-compiler result %r" % (
                 self, other))

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -664,3 +664,9 @@ def test_ast_good_yield_from():
 def test_ast_bad_yield_from():
     "Make sure AST can't compile invalid yield-from"
     cant_compile("(yield-from)")
+
+
+@pytest.mark.skipif(not PY3, reason="Python 3 required")
+def test_ast_ellipsis():
+    "Make sure AST can compile Ellipsis"
+    can_compile("...")

--- a/tests/native_tests/py3_only_tests.hy
+++ b/tests/native_tests/py3_only_tests.hy
@@ -84,3 +84,16 @@
        (assert (= (foo :b 20 :a 10 :c 30)
                   (, 10 20 30)))))
 
+
+(defn test-ellipsis []
+  (assert (= ... Ellipsis)))
+
+
+(defn test-slice []
+  (defclass EllipsisTest []
+    (defn --getitem-- [self [start ellipsis end]]
+      (assert (= ellipsis Ellipsis))
+      (list (range start end))))
+
+  (assert (= (get (EllipsisTest) (, 1 ... 6))
+             [1 2 3 4 5])))


### PR DESCRIPTION
Looks like its a really trivial patch to add a special case to interpret `...` as `Ellipsis`.

Related to #541, #1481 