### PR TITLE
Better slicing with ellipsis support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,7 @@ Changes from 0.13.0
    * new `doc` macro and `#doc` tag macro
    * support for PEP 492 with `fn/a`, `defn/a`, `with/a` and `for/a`
    * remove `def`
+   * optimize `slice` inside subscriptions to generate slice AST
 
    [ Bug Fixes ]
    * Numeric literals are no longer parsed as symbols when followed by a dot

--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,7 @@ Changes from 0.13.0
    * support for PEP 492 with `fn/a`, `defn/a`, `with/a` and `for/a`
    * remove `def`
    * optimize `slice` inside subscriptions to generate slice AST
+   * add support to understand `...` as `Ellipsis`
 
    [ Bug Fixes ]
    * Numeric literals are no longer parsed as symbols when followed by a dot

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -562,6 +562,8 @@ class HyASTCompiler(object):
                 nodes[i] = ret.force_expr
 
             index = ast.Slice(lower=nodes[0], upper=nodes[1], step=nodes[2])
+        elif not PY3 and isinstance(sub_expr, HySymbol) and sub_expr == "...":
+            index = ast.Ellipsis()
         else:
             index = ast.Index(self.compile(sub_expr).force_expr)
 
@@ -2172,7 +2174,12 @@ class HyASTCompiler(object):
 
     @builds(HySymbol)
     def compile_symbol(self, symbol):
-        if "." in symbol:
+        if symbol == "...":
+            if not PY3:
+                raise HyTypeError(symbol, 'in Python 2, ellipsis is only '
+                                          'supported in slices')
+            return asty.Ellipsis(symbol)
+        elif "." in symbol:
             glob, local = symbol.rsplit(".", 1)
 
             if not glob:

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -272,6 +272,10 @@ class Result(object):
         if isinstance(other, ast.excepthandler):
             return self + Result(stmts=[other])
 
+        if isinstance(other, ast.slice):
+            raise TypeError("Can't add %r with slice specific syntax %r" % (
+                self, other))
+
         if not isinstance(other, Result):
             raise TypeError("Can't add %r with non-compiler result %r" % (
                 self, other))

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -32,7 +32,7 @@
 
 (defmacro cut [node &rest body]
   "Take a subset of a list and create a new list from it."
-  `(get ~node (__builtin__slice ~@body)))
+  `(get ~node (: ~@body)))
 
 (defmacro if [&rest args]
   "Conditionally evaluate alternating test and then expressions."
@@ -42,7 +42,7 @@
             (get args 0)
             `(if* ~(get args 0)
                   ~(get args 1)
-                  (if ~@(get args (slice 2)))))))
+                  (if ~@(get args (: 2)))))))
 
 (defmacro deftag [tag-name lambda-list &rest body]
   (if (and (not (isinstance tag-name hy.models.HySymbol))

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -30,6 +30,10 @@
          (fn ~(+ `[&name] lambda-list)
            ~@body))))))
 
+(defmacro cut [node &rest body]
+  "Take a subset of a list and create a new list from it."
+  `(get ~node (__builtin__slice ~@body)))
+
 (defmacro if [&rest args]
   "Conditionally evaluate alternating test and then expressions."
   (setv n (len args))
@@ -38,7 +42,7 @@
             (get args 0)
             `(if* ~(get args 0)
                   ~(get args 1)
-                  (if ~@(cut args 2))))))
+                  (if ~@(get args (slice 2)))))))
 
 (defmacro deftag [tag-name lambda-list &rest body]
   (if (and (not (isinstance tag-name hy.models.HySymbol))

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -275,12 +275,17 @@ def test_ast_no_pointless_imports():
 def test_ast_good_get():
     "Make sure AST can compile valid get"
     can_compile("(get x y)")
+    can_compile("(get x (:))")
+    can_compile("(get x (: a b))")
+    can_compile("(get x ...)")
+    can_compile("(get x (, a b c))")
 
 
 def test_ast_bad_get():
     "Make sure AST can't compile invalid get"
     cant_compile("(get)")
     cant_compile("(get 1)")
+    cant_compile("(get x (: a b c d))")
 
 
 def test_ast_good_take():

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -283,20 +283,6 @@ def test_ast_bad_get():
     cant_compile("(get 1)")
 
 
-def test_ast_good_cut():
-    "Make sure AST can compile valid cut"
-    can_compile("(cut x)")
-    can_compile("(cut x y)")
-    can_compile("(cut x y z)")
-    can_compile("(cut x y z t)")
-
-
-def test_ast_bad_cut():
-    "Make sure AST can't compile invalid cut"
-    cant_compile("(cut)")
-    cant_compile("(cut 1 2 3 4 5)")
-
-
 def test_ast_good_take():
     "Make sure AST can compile valid 'take'"
     can_compile("(take 1 [2 3])")

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -650,3 +650,9 @@ def test_ast_good_yield_from():
 def test_ast_bad_yield_from():
     "Make sure AST can't compile invalid yield-from"
     cant_compile("(yield-from)")
+
+
+@pytest.mark.skipif(not PY3, reason="Python 3 required")
+def test_ast_ellipsis():
+    "Make sure AST can compile Ellipsis"
+    can_compile("...")

--- a/tests/compilers/test_compiler.py
+++ b/tests/compilers/test_compiler.py
@@ -73,3 +73,32 @@ def test_compiler_yield_return():
         # In earlier versions, the expression is not returned
         assert isinstance(body[1], ast.Expr)
         assert isinstance(body[1].value, ast.BinOp)
+
+
+def test_compiler_get_index():
+    e = make_expression(HySymbol('get'), HySymbol('foo'), HyInteger(1))
+
+    ret = compiler.HyASTCompiler('test').compile_index_expression(e)
+    assert isinstance(ret.expr, ast.Subscript)
+
+    slice = ret.expr.slice
+    assert isinstance(slice, ast.Index)
+    assert slice.value.n == 1
+
+
+def test_compiler_get_slice():
+    e = make_expression(HySymbol('get'),
+                        HySymbol('foo'),
+                        HyExpression([HySymbol('slice'),
+                                      HyInteger(1),
+                                      HyInteger(2),
+                                      HyInteger(3)]))
+
+    ret = compiler.HyASTCompiler('test').compile_index_expression(e)
+    assert isinstance(ret.expr, ast.Subscript)
+
+    slice = ret.expr.slice
+    assert isinstance(slice, ast.Slice)
+    assert slice.lower.n == 1
+    assert slice.upper.n == 2
+    assert slice.step.n == 3

--- a/tests/compilers/test_compiler.py
+++ b/tests/compilers/test_compiler.py
@@ -86,6 +86,20 @@ def test_compiler_get_index():
     assert slice.value.n == 1
 
 
+def test_compiler_get_ellipsis():
+    e = make_expression(HySymbol('get'), HySymbol('foo'), HySymbol('...'))
+
+    ret = compiler.HyASTCompiler('test').compile_index_expression(e)
+    assert isinstance(ret.expr, ast.Subscript)
+
+    slice = ret.expr.slice
+    if PY3:
+        assert isinstance(slice, ast.Index)
+        assert isinstance(slice.value, ast.Ellipsis)
+    else:
+        assert isinstance(slice, ast.Ellipsis)
+
+
 def test_compiler_get_slice():
     e = make_expression(HySymbol('get'),
                         HySymbol('foo'),

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -860,6 +860,14 @@
   (assert (is (first []) None)))
 
 
+(defn test-slice []
+  (defclass CutTest []
+    (defn --getitem-- [self index]
+      (assert (= index (slice 1 6)))))
+
+  (get (CutTest) (: 1 6)))
+
+
 (defn test-cut []
   "NATIVE: test cut"
   (assert (= (cut [1 2 3 4 5] 1) [2 3 4 5]))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -267,6 +267,16 @@
   (assert (= (if-not False :yes)
              :yes)))
 
+(defn test-cut []
+  "test that cut works as expected"
+  (assert (= (cut [1 2 3 4 5])
+             [1 2 3 4 5]))
+  (assert (= (cut [1 2 3 4 5] 1)
+             [2 3 4 5]))
+  (assert (= (cut [1 2 3 4 5] 1 4)
+             [2 3 4]))
+  (assert (= (cut [1 2 3 4 5] 1 4 2)
+             [2 4])))
 
 (defn test-lif []
   "test that lif works as expected"

--- a/tests/native_tests/py3_only_tests.hy
+++ b/tests/native_tests/py3_only_tests.hy
@@ -84,3 +84,16 @@
        (assert (= (foo :b 20 :a 10 :c 30)
                   (, 10 20 30)))))
 
+
+(defn test-ellipsis []
+  (assert (= ... Ellipsis)))
+
+
+(defn test-slice []
+  (defclass EllipsisTest []
+    (defn --getitem-- [self [start ellipsis end]]
+      (assert (= ellipsis Ellipsis))
+      (list (range start end))))
+
+  (assert (= (get (EllipsisTest) (, 1 ... 6))
+             [1 2 3 4 5])))

--- a/tests/native_tests/py3_only_tests.hy
+++ b/tests/native_tests/py3_only_tests.hy
@@ -87,13 +87,3 @@
 
 (defn test-ellipsis []
   (assert (= ... Ellipsis)))
-
-
-(defn test-slice []
-  (defclass EllipsisTest []
-    (defn --getitem-- [self [start ellipsis end]]
-      (assert (= ellipsis Ellipsis))
-      (list (range start end))))
-
-  (assert (= (get (EllipsisTest) (, 1 ... 6))
-             [1 2 3 4 5])))


### PR DESCRIPTION
Proof that its possible to optimize slicing. This code:

```clojure
(setv foo [1 2 3])
(get foo (slice 1 2))
(slice 1 2)
```

Is now equivalent to:

```
foo = [1, 2, 3]
foo[1:2]
slice(1, 2)
```

I've also demoted `cut` to a macro as its now redundant, but imho still a useful form (still nicer to use when updating a list in place: `(setv (cut foo) [1 2 3])`