### PR TITLE
Fix runtime compliation of quoted expressions.

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -129,9 +129,9 @@ class Asty(object):
     def __getattr__(self, name):
         setattr(Asty, name, lambda self, x, **kwargs: getattr(ast, name)(
             lineno=getattr(
-                x, 'start_line', getattr(x, 'lineno', None)),
+                x, 'start_line', getattr(x, 'lineno', 0)),
             col_offset=getattr(
-                x, 'start_column', getattr(x, 'col_offset', None)),
+                x, 'start_column', getattr(x, 'col_offset', 0)),
             **kwargs))
         return getattr(self, name)
 asty = Asty()


### PR DESCRIPTION
So this is kinda insane, but also kinda cool and probably should be completely valid. Its probably better than `lineno` and `col_offset` defaults to 0 rather than None anyways, since that is what Python does if it can't give those fields a meaningful value.

The problem is any quoted expressions (or pure Python generated expressions) will generate AST with those attributes set to None.

I came across this playing with this snippet:

```clojure
(defn hy-compile [expr]
  (import [hy.compiler [hy-compile]]
          [hy.importer [ast-compile]])

  (setv namespace {})
  (-> (hy-compile expr "<STDIN>")
      (ast-compile "<STDIN>" "exec")
      (exec namespace))
  namespace)

(as-> `(defn test [] "Hello World") it
      (hy-compile it)
      (get it "test")
      (print (it)))
```

And as a pure Python alternative:

```python
from hy import *

expr = HyExpression([] + [HySymbol('defn')] + [HySymbol('test')] + [HyList([])] + [HyString('Hello')])
ast = hy.compiler.hy_compile(expr, "<STDIN>")
code = hy.importer.ast_compile(ast, filename="<STDIN>", mode="exec")
namespace = {}
exec(code, namespace)
namespace['test']()
```
