### PR TITLE
Implement take-nth with islice

### DIFF
--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -85,3 +85,10 @@
   (if (< (get sys.version_info 0) 3)
     python2-form
     python3-form))
+
+(defmacro if-pypy [pypy-form default-form]
+  "If running on pypy, execute pypy-form, else, execute the other form"
+  (import platform)
+  (if (= (.python-implementation platform) "PyPy")
+    pypy-form
+    default-form))

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -418,11 +418,15 @@ with overlap."
 Raises ValueError for (not (pos? n))."
   (if (not (pos? n))
     (raise (ValueError "n must be positive")))
-  (setv citer (iter coll) skip (dec n))
-  (for* [val citer]
-    (yield val)
-    (for* [_ (range skip)]
-      (next citer))))
+  (if-pypy
+    ;; Workaround PyPy issue #2643
+    (do
+      (setv citer (iter coll) skip (dec n))
+      (for* [val citer]
+        (yield val)
+        (for* [_ (range skip)]
+          (next citer))))
+    (islice coll None None n)))
 
 (defn zero? [n]
   "Check if `n` equals 0."


### PR DESCRIPTION
I was wondering why `take-nth` was implemented by hand, but it turns out its because of a pypy bug. Its been fixed upstream (works on 5.10), but pypy3 on Travis is still on 5.8.

Not sure if this one will be taken, but I've added a workaround to detect if we're on pypy and keep using the kludge and use islice everywhere else. 