### PR TITLE
No implicit conversions between HySymbol and HyKeyword and str

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -21,8 +21,8 @@ from hy.compiler import HyTypeError
 from hy.importer import (hy_eval, import_buffer_to_module,
                          import_file_to_ast, import_file_to_hst,
                          import_buffer_to_ast, import_buffer_to_hst)
-from hy.completer import completion
-from hy.completer import Completer
+from hy.completer import Completer, completion
+from hy.contrib.hy_repr import hy_repr
 
 from hy.errors import HyIOError
 
@@ -59,7 +59,7 @@ class HyREPL(code.InteractiveConsole):
         self.spy = spy
 
         if output_fn is None:
-            self.output_fn = repr
+            self.output_fn = hy_repr
         elif callable(output_fn):
             self.output_fn = output_fn
         else:

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -699,20 +699,17 @@ class HyASTCompiler(object):
         We need to distinguish them as want to concatenate them instead of
         just nesting them.
         """
-        if level == 0:
-            if isinstance(form, HyExpression):
-                if expr_startswith(form, "unquote", "unquote_splice"):
-                    if len(form) != 2:
-                        raise HyTypeError(form,
-                                          ("`%s' needs 1 argument, got %s" %
-                                           form[0], len(form) - 1))
-                    return set(), form[1], (form[0] == HySymbol("unquote_splice"))
-
-        if isinstance(form, HyExpression):
-            if expr_startswith(form, "quasiquote"):
-                level += 1
-            if expr_startswith(form, "unquote", "unquote_splice"):
+        if expr_startswith(form, "unquote", "unquote_splice"):
+            if level == 0:
+                if len(form) != 2:
+                    raise HyTypeError(form,
+                                      ("`%s' needs 1 argument, got %s" %
+                                       form[0], len(form) - 1))
+                return set(), form[1], (form[0] == HySymbol("unquote_splice"))
+            else:
                 level -= 1
+        elif expr_startswith(form, "quasiquote"):
+            level += 1
 
         name = form.__class__.__name__
         imports = set([name])

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -768,6 +768,9 @@ class HyASTCompiler(object):
             return imports, HyExpression([HySymbol(name),
                                           HyString(form)]).replace(form), False
 
+        elif isinstance(form, HyKeyword):
+            return imports, form, False
+
         elif isinstance(form, HyString):
             x = [HySymbol(name), form]
             if form.brackets is not None:
@@ -2208,7 +2211,18 @@ class HyASTCompiler(object):
 
         return asty.Name(symbol, id=ast_str(symbol), ctx=ast.Load())
 
-    @builds(HyString, HyKeyword, HyBytes)
+    @builds(HyKeyword)
+    def compile_keyword(self, string, building):
+        ret = Result()
+        ret += asty.Call(
+            string,
+            func=asty.Name(string, id="HyKeyword", ctx=ast.Load()),
+            args=[asty.Str(string, s=str_type(string))],
+            keywords=[])
+        ret.add_imports("hy", {"HyKeyword"})
+        return ret
+
+    @builds(HyString, HyBytes)
     def compile_string(self, string, building):
         node = asty.Bytes if PY3 and building is HyBytes else asty.Str
         f = bytes_type if building is HyBytes else str_type

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -523,13 +523,13 @@ class HyASTCompiler(object):
                 except StopIteration:
                     raise HyTypeError(expr,
                                       "Keyword argument {kw} needs "
-                                      "a value.".format(kw=str(expr[1:])))
+                                      "a value.".format(kw=expr))
 
                 compiled_value = self.compile(value)
                 ret += compiled_value
 
                 # no unicode for py2 in ast names
-                keyword = str(expr[2:])
+                keyword = str(expr[1:])
                 if "-" in keyword and keyword != "-":
                     keyword = keyword.replace("-", "_")
 

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -9,6 +9,7 @@ import sys
 
 import hy.macros
 import hy.compiler
+from hy import HySymbol
 from hy._compat import builtins, string_types
 
 
@@ -76,10 +77,14 @@ class Completer(object):
         matches = []
         for p in self.path:
             for k in p.keys():
-                if isinstance(k, string_types):
-                    k = k.replace("_", "-")
-                    if k.startswith(text):
-                        matches.append(k)
+                if not isinstance(k, string_types):
+                    continue
+                elif isinstance(k, HySymbol):
+                    k = str(k)
+                k = k.replace("_", "-")
+                if k.startswith(text):
+                    matches.append(k)
+
         return matches
 
     def tag_matches(self, text):
@@ -87,9 +92,12 @@ class Completer(object):
         matches = []
         for p in self.tag_path:
             for k in p.keys():
-                if isinstance(k, string_types):
-                    if k.startswith(text):
-                        matches.append("#{}".format(k))
+                if not isinstance(k, string_types):
+                    continue
+                elif isinstance(k, HySymbol):
+                    k = str(k)
+                if k.startswith(text):
+                    matches.append("#{}".format(k))
         return matches
 
     def complete(self, text, state):

--- a/hy/contrib/hy_repr.hy
+++ b/hy/contrib/hy_repr.hy
@@ -21,7 +21,7 @@
     (defn catted []
       (if old? "..." (.join " " (list-comp (f it q) [it x]))))
     (setv prefix "")
-    (if (and (not q) (instance? HyObject x))
+    (if (and (not q) (not (instance? HyKeyword x)) (instance? HyObject x))
       (setv prefix "'"  q True))
     (+ prefix (if
       (hasattr x "__hy_repr__")
@@ -63,8 +63,6 @@
         (+ "(frozenset #{" (catted) "})")
       (is t HySymbol)
         x
-      (or (is t HyKeyword) (and (is t str-type) (.startswith x HyKeyword.PREFIX)))
-        (cut x 1)
       (in t [str-type HyString bytes-type HyBytes]) (do
         (setv r (.lstrip (base-repr x) "ub"))
         (+ (if (in t [bytes-type HyBytes]) "b" "") (if (.startswith "\"" r)

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -34,7 +34,7 @@
 
 (defmacro/g! fnr [signature &rest body]
   (setv new-body (prewalk
-    (fn [x] (if (and (symbol? x) (= x "recur")) g!recur-fn x))
+    (fn [x] (if (= x `recur) g!recur-fn x))
     body))
   `(do
     (import [hy.contrib.loop [--trampoline--]])

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -253,7 +253,7 @@ Arguments without a header are under None.
                    eval-and-compile
                    eval-when-compile]) (self.handle-base)
         (= head 'except) (self.handle-except)
-        (= head ".") (self.handle-dot)
+        (= head `.) (self.handle-dot)
         (= head 'defclass) (self.handle-defclass)
         (= head 'quasiquote) (self.+quote)
         ;; must be checked last!

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -62,8 +62,7 @@
 
 (defn keyword? [k]
   "Check whether `k` is a keyword."
-  (and (instance? (type :foo) k)
-       (.startswith k (get :foo 0))))
+  (instance? HyKeyword k))
 
 (defn dec [n]
   "Decrement `n` by 1."
@@ -458,8 +457,8 @@ as EOF (defaults to an empty string)."
   "Create a keyword from `value`.
 
 Strings numbers and even objects with the __name__ magic will work."
-  (if (and (string? value) (value.startswith HyKeyword.PREFIX))
-    (hyify value)
+  (if (keyword? value)
+    (HyKeyword (hyify (str value)))
     (if (string? value)
       (HyKeyword (+ ":" (hyify value)))
       (try
@@ -471,8 +470,8 @@ Strings numbers and even objects with the __name__ magic will work."
 
 Keyword special character will be stripped. String will be used as is.
 Even objects with the __name__ magic will work."
-  (if (and (string? value) (value.startswith HyKeyword.PREFIX))
-    (hyify (cut value 2))
+  (if (keyword? value)
+    (hyify (cut (str value) 1))
     (if (string? value)
       (hyify value)
       (try

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -113,7 +113,7 @@ used as the result."
   (if (empty? body)
     (macro-error None "`for' requires a body to evaluate"))
   (setv lst (get body -1))
-  (setv belse (if (and (isinstance lst HyExpression) (= (get lst 0) "else"))
+  (setv belse (if (and (isinstance lst HyExpression) (= (get lst 0) `else))
                 [(body.pop)]
                 []))
   (if

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -105,7 +105,7 @@ def reject_spurious_dots(*items):
     "Reject the spurious dots from items"
     for list in items:
         for tok in list:
-            if tok == "." and type(tok) == HySymbol:
+            if tok == HySymbol("."):
                 raise LexException("Malformed dotted list",
                                    tok.start_line, tok.start_column)
 
@@ -119,7 +119,7 @@ def paren(p):
     # (a b c . d)
     # that evaluate to nested cons cells of the form
     # (a . (b . (c . d)))
-    if len(cont) >= 3 and isinstance(cont[-2], HySymbol) and cont[-2] == ".":
+    if len(cont) >= 3 and isinstance(cont[-2], HySymbol) and cont[-2] == HySymbol("."):
 
         reject_spurious_dots(cont[:-2], cont[-1:])
 

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -3,8 +3,9 @@
 # license. See the LICENSE.
 
 from inspect import getargspec, formatargspec
-from hy.models import replace_hy_obj, HyExpression, HySymbol
 
+from hy._compat import str_type
+from hy.models import replace_hy_obj, HyExpression, HySymbol
 from hy.errors import HyTypeError, HyMacroExpansionError
 
 from collections import defaultdict
@@ -174,7 +175,7 @@ def macroexpand_1(tree, compiler):
             return tree
 
         fn = tree[0]
-        if fn in ("quote", "quasiquote"):
+        if fn in (HySymbol("quote"), HySymbol("quasiquote")):
             return tree
         ntree = HyExpression(tree[:])
         ntree.replace(tree)
@@ -182,9 +183,9 @@ def macroexpand_1(tree, compiler):
         opts = {}
 
         if isinstance(fn, HySymbol):
-            m = _hy_macros[compiler.module_name].get(fn)
+            m = _hy_macros[compiler.module_name].get(str_type(fn))
             if m is None:
-                m = _hy_macros[None].get(fn)
+                m = _hy_macros[None].get(str_type(fn))
             if m is not None:
                 if m._hy_macro_pass_compiler:
                     opts['compiler'] = compiler
@@ -216,7 +217,7 @@ def tag_macroexpand(tag, tree, compiler):
     """Expand the tag macro "tag" with argument `tree`."""
     load_macros(compiler.module_name)
 
-    tag_macro = _hy_tag[compiler.module_name].get(tag)
+    tag_macro = _hy_tag[compiler.module_name].get(str_type(tag))
     if tag_macro is None:
         try:
             tag_macro = _hy_tag[None][tag]

--- a/hy/models.py
+++ b/hy/models.py
@@ -117,6 +117,19 @@ class HySymbol(HyString):
     def __init__(self, string):
         self += string
 
+    def __hash__(self):
+        return str_type.__hash__(self)
+
+    def __eq__(self, other):
+        if not isinstance(other, HySymbol):
+            return False
+        return str_type.__eq__(self, other)
+
+    def __ne__(self, other):
+        if not isinstance(other, HySymbol):
+            return True
+        return str_type.__ne__(self, other)
+
 _wrappers[bool] = lambda x: HySymbol("True") if x else HySymbol("False")
 _wrappers[type(None)] = lambda foo: HySymbol("None")
 
@@ -338,7 +351,7 @@ class HyCons(HyObject):
             # Keep unquotes in the cdr of conses
             if type(cdr) == HyExpression:
                 if len(cdr) > 0 and type(cdr[0]) == HySymbol:
-                    if cdr[0] in ("unquote", "unquote_splice"):
+                    if cdr[0] in (HySymbol("unquote"), HySymbol("unquote_splice")):
                         return super(HyCons, cls).__new__(cls)
 
             return cdr.__class__([wrap_value(car)] + cdr)

--- a/hy/models.py
+++ b/hy/models.py
@@ -134,40 +134,39 @@ _wrappers[bool] = lambda x: HySymbol("True") if x else HySymbol("False")
 _wrappers[type(None)] = lambda foo: HySymbol("None")
 
 
-class HyKeyword(HyObject, str_type):
+class HyKeyword(HyObject):
     """Generic Hy Keyword object. It's either a ``str`` or a ``unicode``,
     depending on the Python version.
     """
 
-    PREFIX = "\uFDD0"
+    __slots__ = ['_value']
 
-    def __new__(cls, value):
-        if not value.startswith(cls.PREFIX):
-            value = cls.PREFIX + value
-
-        obj = str_type.__new__(cls, value)
-        return obj
+    def __init__(self, value):
+        self._value = value
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self[1:])
+        return "%s(%r)" % (self.__class__.__name__, self._value[1:])
 
     def __str__(self):
-        return self[1:]
+        return self._value
 
     __hy_repr__ = __str__
 
+    def __getitem__(self, slice):
+        return self._value[slice]
+
     def __hash__(self):
-        return str_type.__hash__(self)
+        return hash(self._value)
 
     def __eq__(self, other):
         if not isinstance(other, HyKeyword):
-            return False
-        return str_type.__eq__(self, other)
+            return NotImplemented
+        return self._value == other._value
 
     def __ne__(self, other):
         if not isinstance(other, HyKeyword):
-            return True
-        return str_type.__ne__(self, other)
+            return NotImplemented
+        return self._value != other._value
 
 
 def strip_digit_separators(number):

--- a/hy/models.py
+++ b/hy/models.py
@@ -149,7 +149,25 @@ class HyKeyword(HyObject, str_type):
         return obj
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self[1:]))
+        return "%s(%r)" % (self.__class__.__name__, self[1:])
+
+    def __str__(self):
+        return self[1:]
+
+    __hy_repr__ = __str__
+
+    def __hash__(self):
+        return str_type.__hash__(self)
+
+    def __eq__(self, other):
+        if not isinstance(other, HyKeyword):
+            return False
+        return str_type.__eq__(self, other)
+
+    def __ne__(self, other):
+        if not isinstance(other, HyKeyword):
+            return True
+        return str_type.__ne__(self, other)
 
 
 def strip_digit_separators(number):

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -560,9 +560,7 @@
   (assert (= (.a.b.meth x) "meth"))
   (assert (= (.a.b.meth x "foo" "bar") "meth foo bar"))
   (assert (= (.a.b.meth :b "1" :a "2" x "foo" "bar") "meth foo bar 2 1"))
-  (assert (= (.a.b.meth x #* ["foo" "bar"]) "meth foo bar"))
-
-  (assert (is (.isdigit :foo) False)))
+  (assert (= (.a.b.meth x #* ["foo" "bar"]) "meth foo bar")))
 
 
 (defn test-do []

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1674,11 +1674,6 @@ macros()
   (setv (. foo [1] test) "hello")
   (assert (= (getattr (. foo [1]) "test") "hello")))
 
-(defn test-keyword-quoting []
-  "NATIVE: test keyword quoting magic"
-  (assert (= :foo "\ufdd0:foo"))
-  (assert (= `:foo "\ufdd0:foo")))
-
 (defn test-only-parse-lambda-list-in-defn []
   "NATIVE: test lambda lists are only parsed in defn"
   (try

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1309,7 +1309,7 @@
 
 (defn test-eval-globals []
   "NATIVE: test eval with explicit global dict"
-  (assert (= 'bar (eval (quote foo) {'foo 'bar})))
+  (assert (= 'bar (eval (quote foo) {"foo" 'bar})))
   (assert (= 1 (do (setv d {}) (eval '(setv x 1) d) (eval (quote x) d))))
   (setv d1 {}  d2 {})
   (eval '(setv x 1) d1)

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -18,7 +18,7 @@
     (.append defns `(defn ~(HySymbol (+ "test_operator_" o "_real")) []
       (setv f-name ~(HyString o))
       ~@(prewalk :form body :f (fn [x]
-        (if (and (symbol? x) (= x "f")) o x)))))
+        (if (= x `f) o x)))))
     (.append defns `(defn ~(HySymbol (+ "test_operator_" o "_shadow")) []
       (setv f-name ~(HyString o))
       (setv f ~o)

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -19,10 +19,6 @@ from hy.importer import get_bytecode_path
 hy_dir = os.environ.get('HY_DIR', '')
 
 
-def hr(s=""):
-    return "hy --repl-output-fn=hy.contrib.hy-repr.hy-repr " + s
-
-
 def run_cmd(cmd, stdin_data=None, expect=0, dontwritebytecode=False):
     env = None
     if dontwritebytecode:
@@ -81,14 +77,14 @@ def test_bin_hy_stdin():
 
 def test_bin_hy_stdin_multiline():
     output, _ = run_cmd("hy", '(+ "a" "b"\n"c" "d")')
-    assert "'abcd'" in output
+    assert '"abcd"' in output
 
 
 def test_bin_hy_stdin_comments():
     _, err_empty = run_cmd("hy", '')
 
     output, err = run_cmd("hy", '(+ "a" "b") ; "c"')
-    assert "'ab'" in output
+    assert '"ab"' in output
     assert err == err_empty
 
     _, err = run_cmd("hy", '; 1')
@@ -160,17 +156,14 @@ def test_bin_hy_stdin_bad_repr():
 
 def test_bin_hy_stdin_hy_repr():
     output, _ = run_cmd("hy", '(+ [1] [2])')
-    assert "[1, 2]" in output.replace('L', '')
+    assert "[1 2]" in output.replace('L', '')
 
-    output, _ = run_cmd(hr(), '(+ [1] [2])')
-    assert "[1 2]" in output
-
-    output, _ = run_cmd(hr("--spy"), '(+ [1] [2])')
+    output, _ = run_cmd("hy --spy", '(+ [1] [2])')
     assert "[1]+[2]" in output.replace('L', '').replace(' ', '')
     assert "[1 2]" in output
 
     # --spy should work even when an exception is thrown
-    output, _ = run_cmd(hr("--spy"), '(+ [1] [2] (foof))')
+    output, _ = run_cmd("hy --spy", '(+ [1] [2] (foof))')
     assert "[1]+[2]" in output.replace('L', '').replace(' ', '')
 
 

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -245,12 +245,13 @@ def test_lex_line_counting_multi_inner():
 def test_dicts():
     """ Ensure that we can tokenize a dict. """
     objs = tokenize("{foo bar bar baz}")
-    assert objs == [HyDict(["foo", "bar", "bar", "baz"])]
+    assert objs == [HyDict([HySymbol("foo"), HySymbol("bar"),
+                            HySymbol("bar"), HySymbol("baz")])]
 
     objs = tokenize("(bar {foo bar bar baz})")
     assert objs == [HyExpression([HySymbol("bar"),
-                                  HyDict(["foo", "bar",
-                                          "bar", "baz"])])]
+                                  HyDict([HySymbol("foo"), HySymbol("bar"),
+                                          HySymbol("bar"), HySymbol("baz")])])]
 
     objs = tokenize("{(foo bar) (baz quux)}")
     assert objs == [HyDict([
@@ -265,7 +266,8 @@ def test_sets():
     assert objs == [HySet([HyInteger(1), HyInteger(2)])]
     objs = tokenize("(bar #{foo bar baz})")
     assert objs == [HyExpression([HySymbol("bar"),
-                                  HySet(["foo", "bar", "baz"])])]
+                                  HySet([HySymbol("foo"), HySymbol("bar"),
+                                         HySymbol("baz")])])]
 
     objs = tokenize("#{(foo bar) (baz quux)}")
     assert objs == [HySet([


### PR DESCRIPTION
Related to #1363 

This is a very large diff, and totally something I'm partially expecting to be a no, but this branch makes the following comparisons now resolve to false:

```clojure
(= 'foo "foo")
(= :foo '\ufdd0:foo')
```

Maybe this is my hubris, but I haven't seen good use case to support it. Clojure, nor any other lisp dialect I've played with does this. And if anything, it makes things the Python compiler easier understand and reason about (granted its gotten a bit wordier, but there's room to refactor this nicely).

It also helps open the door to adding type annotation for extra safety and not having to worry about having a large union type everywhere.

And one last detail, keywords in the repl now look like this:

```
=> :foo
HyKeyword(':foo')
```

Would it maybe be desirable to use hy-repl here?