### PR TITLE
Never generate lambas, only function definitions

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1922,15 +1922,11 @@ class HyASTCompiler(object):
 
         return ret
 
-    @builds("fn", "fn*")
+    @builds("fn")
     @builds("fn/a", iff=PY35)
-    # The starred version is for internal use (particularly, in the
-    # definition of `defn`). It ensures that a FunctionDef is
-    # produced rather than a Lambda.
     @checkargs(min=1)
     def compile_function_def(self, expression):
         root = expression.pop(0)
-        force_functiondef = root in ("fn*", "fn/a")
         asyncdef = root == "fn/a"
 
         arglist = expression.pop(0)
@@ -1998,10 +1994,6 @@ class HyASTCompiler(object):
             defaults=defaults)
 
         body = self._compile_branch(expression)
-        if not force_functiondef and not body.stmts:
-            ret += asty.Lambda(expression, args=args, body=body.force_expr)
-            return ret
-
         if body.expr:
             if body.contains_yield and not PY3:
                 # Prior to PEP 380 (introduced in Python 3.3)

--- a/hy/contrib/multi.hy
+++ b/hy/contrib/multi.hy
@@ -93,4 +93,4 @@
      ret)
     (do
      (setv [lambda-list body] (head-tail bodies))
-     `(setv ~name (fn* ~lambda-list ~@body)))))
+     `(setv ~name (fn ~lambda-list ~@body)))))

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -246,7 +246,7 @@ Arguments without a header are under None.
   ;; and local bindings should shadow those made by let.
   (defn handle-call [self]
     (setv head (first self.form))
-    (if (in head '[fn fn*]) (self.handle-fn)
+    (if (in head '[fn fn]) (self.handle-fn)
         (in head '[import
                    require
                    quote
@@ -341,7 +341,6 @@ as can nested let forms.
    ;;; can shadow let bindings with Python locals
    ;; protect its bindings for the lexical scope of its body.
    'fn',
-   'fn*',
    ;; protect as bindings for the lexical scope of its body
    'except',
 

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -68,7 +68,7 @@
     (macro-error name "defn takes a name as first argument"))
   (if (not (isinstance lambda-list hy.HyList))
     (macro-error name "defn takes a parameter list as second argument"))
-  `(setv ~name (fn* ~lambda-list ~@body)))
+  `(setv ~name (fn ~lambda-list ~@body)))
 
 (defmacro defn/a [name lambda-list &rest body]
   "Define `name` as a function with `lambda-list` signature and body `body`."

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -364,16 +364,6 @@ def test_ast_expression_basics():
     _ast_spotcheck("value.func.id", code, tree)
 
 
-def test_ast_anon_fns_basics():
-    """ Ensure anon fns work. """
-    code = can_compile("(fn (x) (* x x))").body[0].value
-    assert type(code) == ast.Lambda
-    code = can_compile("(fn (x) (print \"multiform\") (* x x))").body[0]
-    assert type(code) == ast.FunctionDef
-    can_compile("(fn (x))")
-    cant_compile("(fn)")
-
-
 def test_ast_non_decoratable():
     """ Ensure decorating garbage breaks """
     cant_compile("(with-decorator (foo) (* x x))")


### PR DESCRIPTION
There is no downside to this change:

- Lambdas and functions has identical performance characteristics on python 3 (and functions are slightly faster on python 2).
- It simplifies the compiler slightly.
- And there should be less surprises with the generated code (decorating lambas, for example, see #1506 ).