### PR TITLE
Policy: allow PRs to be merged more easily

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -120,15 +120,20 @@ handy. Conversely, avoid this exact language if you want to mention
 an issue without closing it (because e.g. you've partly but not
 entirely fixed a bug).
 
-Before any PR is merged, it must be approved by members of Hy's core team
-other than the PR's author. Changes to the documentation, or trivial changes
-to code, need to be approved by **one** member; all other PRs need to be
-approved by **two** members.
+There are two situations in which a PR is allowed to be merged:
 
-Anybody on the team may perform the merge. Merging should create a merge commit
-(don't squash unnecessarily, because that would remove separation between
-logically separate commits, and don't fast-forward, because that would throw
-away the history of the commits as a separate branch), which should
+1. When it is approved by **two** members of Hy's core team other than the PR's
+   author. Changes to the documentation, or trivial changes to code, need only
+   **one** approving member.
+2. When the PR is at least **two weeks** old and **no** member of the Hy core
+   team has expressed disapproval of the PR in its current state. (Exception: a
+   PR to create a new release is not eligible to be merged under this criterion,
+   only the first one.)
+
+Anybody on the Hy core team may perform the merge. Merging should create a
+merge commit (don't squash unnecessarily, because that would remove separation
+between logically separate commits, and don't fast-forward, because that would
+throw away the history of the commits as a separate branch), which should
 include the PR number in the commit message.
 
 Contributor Code of Conduct


### PR DESCRIPTION
@hylang/core

It's not a secret that in the year and a half I've been working on Hy, I've been frustrated by how slowly PRs get reviewed and merged. I think the current policy of requiring two core-team reviewers other than the author would be fine if the core team were more active. But the core team isn't very active. It's nobody's fault; it's just that we're often busy with our jobs and other responsibilities.

I'm proposing a policy change that allows for an alternative way for a PR to be cleared to merge: if it's at least **two weeks** old and **no** member of the Hy core team has expressed disapproval of the PR in its current state. This means that the author can merge the PR without help if he's a core member, or with only one core member's help if he isn't. At the same time, any core member who has concerns with the PR can effectively veto this method (and later rescind the veto if the PR is changed to his satisfaction).

I realize this is a less conservative approach than we've taken in the past and hence may result in a less stable Hy. But I think an approach leaning more towards the move-fast-and-break-things end of the spectrum could be what Hy needs to speed up progress on the long road to 1.0 after more than 5 years of development. The potential for things to go wrong will be checked by the veto part of the rule, as well as the fact that PRs that simply undo previous PRs can be merged through the same policy.

If this policy is approved, let it not be applied retroactively to preexisting PRs. But, authors are free to close such PRs and make new ones with substantially the same commits to take advantage of the policy.