### PR TITLE
Fix self imports

### DIFF
--- a/hy/importer.py
+++ b/hy/importer.py
@@ -98,7 +98,7 @@ def import_file_to_module(module_name, fpath, loader=None):
         try:
             _ast = import_file_to_ast(fpath, module_name)
             module = imp.new_module(module_name)
-            module.__file__ = os.path.normpath(fpath)
+            sys.modules[module_name] = module
             code = ast_compile(_ast, fpath, "exec")
             if not os.environ.get('PYTHONDONTWRITEBYTECODE'):
                 try:
@@ -118,9 +118,10 @@ def import_file_to_module(module_name, fpath, loader=None):
         except Exception:
             sys.modules.pop(module_name, None)
             raise
+    else:
         sys.modules[module_name] = module
-        module.__name__ = module_name
 
+    module.__name__ = module_name
     module.__file__ = os.path.normpath(fpath)
     if loader:
         module.__loader__ = loader

--- a/tests/native_tests/test_self_import.hy
+++ b/tests/native_tests/test_self_import.hy
@@ -1,0 +1,12 @@
+;; Copyright 2018 the authors.
+;; This file is part of Hy, which is free software licensed under the Expat
+;; license. See the LICENSE.
+
+(defn test-sys-modules []
+  (import [sys])
+  (assert (get sys.modules __name__)))
+
+(defn test-self-import []
+  (import [sys] [. [test-self-import]])
+  (assert (= (get sys.modules __name__)
+             test-self-import)))


### PR DESCRIPTION
Make sure the proper `sys.modules` entry it created as soon as the module is loaded.

This was just a subtle bug - self import only worked so long as there was a module cache miss.

I need this fixed for #1482, as I'm attaching metadata to the module when appropriate and I'd like to be able to read it (like how `__annotations__` works).

I'll have a look at #1512 later.