### PR TITLE
Make unary comparison ops evaluate their argument

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,6 +3,12 @@
 Unreleased
 ==============================
 
+Other Breaking Changes
+------------------------------
+* Non-shadow unary `=`, `is`, `<`, etc. now evaluate their argument
+  instead of ignoring it. This change increases consistency a bit
+  and makes accidental unary uses easier to notice.
+
 Bug Fixes
 ------------------------------
 * Fix `(return)` so it works correctly to exit a Python 2 generator

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1574,7 +1574,8 @@ class HyASTCompiler(object):
     @checkargs(min=1)
     def compile_compare_op_expression(self, expression):
         if len(expression) == 2:
-            return asty.Name(expression, id="True", ctx=ast.Load())
+            return (self.compile(expression[1]) +
+                asty.Name(expression, id="True", ctx=ast.Load()))
         return self._compile_compare_op_expression(expression)
 
     @builds("!=", "is_not")

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1815,5 +1815,5 @@ macros()
 
 (defn test-relative-import []
   "Make sure relative imports work properly"
-  (import [..resources [tlib]]))
-  (assert (= (tlib.*secret-message* "Hello World")))
+  (import [..resources [tlib]])
+  (assert (= tlib.*secret-message* "Hello World")))

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -154,9 +154,9 @@
 
 (op-and-shadow-test ~
   (forbid (f))
-  (assert (= (f (chr 0b00101111)
-                (chr 0b11010000))))
-  (forbid (f (chr 0b00101111) (chr 0b11010000))))
+  (assert (= (& (f 0b00101111) 0xFF)
+                   0b11010000))
+  (forbid (f 0b00101111 0b11010000)))
 
 
 (op-and-shadow-test <

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -219,7 +219,15 @@
 
 (op-and-shadow-test [= is]
   (forbid (f))
+
   (assert (is (f "hello") True))
+
+  ; Unary comparison operators, despite always returning True,
+  ; should evaluate their argument.
+  (setv p "a")
+  (assert (is (f (do (setv p "b") "hello")) True))
+  (assert (= p "b"))
+
   (defclass C)
   (setv x (get {"is" (C) "=" 0} f-name))
   (setv y (get {"is" (C) "=" 1} f-name))
@@ -229,6 +237,7 @@
   (assert (is (f y x) False))
   (assert (is (f x x x x x) True))
   (assert (is (f x x x y x) False))
+
   (setv n None)
   (assert (is (f n None) True))
   (assert (is (f n "b") False)))

--- a/tests/native_tests/tag_macros.hy
+++ b/tests/native_tests/tag_macros.hy
@@ -81,7 +81,7 @@
   (deftag + [n]
     (+ n 1))
 
-  (assert (= #+2 3)))
+  (assert (= #+ 2 3)))
 
 
 (defn test-tag-macros-macros []


### PR DESCRIPTION
There were a bunch of tests where we had typos like `(= (f a b))` instead of `(= (f a) b)`.