### PR TITLE
Fix some documentation problems

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ if "+" in hy_version:
 exclude_patterns = ['_build', 'coreteam.rst']
 
 pygments_style = 'sphinx'
+highlight_language = 'hylang'
 
 import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'

--- a/docs/contrib/hy_repr.rst
+++ b/docs/contrib/hy_repr.rst
@@ -21,9 +21,7 @@ hy-repr
 Usage: ``(hy-repr x)``
 
 This function is Hy's equivalent of Python's built-in ``repr``.
-It returns a string representing the input object in Hy syntax.
-
-.. code-block:: hy
+It returns a string representing the input object in Hy syntax.::
 
    => (hy-repr [1 2 3])
    '[1 2 3]'
@@ -43,9 +41,7 @@ hy-repr-register
 Usage: ``(hy-repr-register the-type fun)``
 
 ``hy-repr-register`` lets you set the function that ``hy-repr`` calls to
-represent a type.
-
-.. code-block:: hy
+represent a type.::
 
     => (defclass C)
     => (hy-repr-register C (fn [x] "cuddles"))
@@ -62,9 +58,7 @@ automatically detect self-references, even deeply nested ones, and
 output ``"..."`` for them instead of calling the usual registered
 function. To use a placeholder other than ``"..."``, pass a string of
 your choice to the keyword argument ``:placeholder`` of
-``hy-repr-register``.
-
-.. code-block:: hy
+``hy-repr-register``.::
 
    (defclass Container [object]
      [__init__ (fn [self value]

--- a/docs/contrib/loop.rst
+++ b/docs/contrib/loop.rst
@@ -41,9 +41,7 @@ non-tail position, an exception is raised.
 
 Usage: ``(loop bindings &rest body)``
 
-Example:
-
-.. code-block:: hy
+Example:::
 
     (require [hy.contrib.loop [loop]])
 

--- a/docs/contrib/multi.rst
+++ b/docs/contrib/multi.rst
@@ -8,9 +8,7 @@ defn
 
 ``defn`` lets you arity-overload a function by the given number of
 args and/or kwargs. This version of ``defn`` works with regular syntax and
-with the arity overloaded one. Inspired by Clojures take on ``defn``.
-
-.. code-block:: clj
+with the arity overloaded one. Inspired by Clojures take on ``defn``.::
 
     => (require [hy.contrib.multi [defn]])
     => (defn fun
@@ -39,9 +37,7 @@ defmulti
 ``defmulti``, ``defmethod`` and ``default-method`` lets you define
 multimethods where a dispatching function is used to select between different
 implementations of the function. Inspired by Clojure's multimethod and based
-on the code by `Adam Bard`_.
-
-.. code-block:: clj
+on the code by `Adam Bard`_.::
 
     => (require [hy.contrib.multi [defmulti defmethod default-method]])
     => (defmulti area [shape]
@@ -87,9 +83,7 @@ called when no other implementation matches.
 Interfaces of multimethod and different implementation don't have to be
 exactly identical, as long as they're compatible enough. In practice this
 means that multimethod should accept the broadest range of parameters and
-different implementations can narrow them down.
-
-.. code-block:: clj
+different implementations can narrow them down.::
 
     => (require [hy.contrib.multi [defmulti defmethod]])
     => (defmulti fun [&rest args]

--- a/docs/contrib/profile.rst
+++ b/docs/contrib/profile.rst
@@ -23,9 +23,7 @@ installed for this to work.
 
 Usage: `(profile/calls (body))` 
 
-Example:
-
-.. code-block:: hy
+Example:::
 
    (require [hy.contrib.profile [profile/calls]])
    (profile/calls (print "hey there"))
@@ -38,9 +36,7 @@ profile/cpu
 
 Usage: `(profile/cpu (body))`
 
-Example:
-
-.. code-block:: hy
+Example:::
 
     (require [hy.contrib.profile [profile/cpu]])
     (profile/cpu (print "hey there"))

--- a/docs/contrib/sequences.rst
+++ b/docs/contrib/sequences.rst
@@ -11,9 +11,7 @@ and the implementation allows for recursive definition of sequences without
 resulting in recursive computation.
 
 To use these macros, you need to require them and import some other names like
-so:
-
-.. code-block:: hy
+so:::
 
    (require [hy.contrib.sequences [defseq seq]])
    (import [hy.contrib.sequences [Sequence end-sequence]])
@@ -21,9 +19,7 @@ so:
 The simplest sequence can be defined as ``(seq [n] n)``. This defines a sequence
 that starts as ``[0 1 2 3 ...]`` and continues forever. In order to define a
 finite sequence, you need to call ``end-sequence`` to signal the end of the
-sequence:
-
-.. code-block:: hy
+sequence:::
 
    (seq [n]
         "sequence of 5 integers"
@@ -37,9 +33,7 @@ one on an infinite sequence would take forever (or at least until available
 memory has been exhausted).
 
 Sequences can be defined recursively. For example, the Fibonacci sequence could
-be defined as:
-
-.. code-block:: hy
+be defined as:::
 
    (defseq fibonacci [n]
      "infinite sequence of fibonacci numbers"

--- a/docs/contrib/walk.rst
+++ b/docs/contrib/walk.rst
@@ -18,9 +18,7 @@ Usage: `(walk inner outer form)`
 ``inner`` to each element of form, building up a data structure of the
 same type.  Applies ``outer`` to the result.
 
-Example:
-
-.. code-block:: hy
+Example:::
 
     => (import [hy.contrib.walk [walk]])
     => (setv a '(a b c d e f))
@@ -43,9 +41,7 @@ postwalk
 Usage: `(postwalk f form)`
 
 Performs depth-first, post-order traversal of ``form``. Calls ``f`` on
-each sub-form, uses ``f`` 's return value in place of the original.
-
-.. code-block:: hy
+each sub-form, uses ``f`` 's return value in place of the original.::
 
     => (import [hy.contrib.walk [postwalk]])
     => (setv trail '([1 2 3] [4 [5 6 [7]]]))
@@ -123,9 +119,7 @@ prewalk
 Usage: `(prewalk f form)`
 
 Performs depth-first, pre-order traversal of ``form``. Calls ``f`` on
-each sub-form, uses ``f`` 's return value in place of the original.
-
-.. code-block:: hy
+each sub-form, uses ``f`` 's return value in place of the original.::
 
     => (import [hy.contrib.walk [prewalk]])
     => (setv trail '([1 2 3] [4 [5 6 [7]]]))
@@ -211,9 +205,7 @@ let
 
 ``let`` creates lexically-scoped names for local variables.
 A let-bound name ceases to refer to that local outside the ``let`` form.
-Arguments in nested functions and bindings in nested ``let`` forms can shadow these names.
-
-.. code-block:: hy
+Arguments in nested functions and bindings in nested ``let`` forms can shadow these names.::
 
     => (let [x 5]  ; creates a new local bound to name 'x
     ...  (print x)
@@ -238,9 +230,7 @@ The ``let`` macro takes two parameters: a list defining *variables*
 and the *body* which gets executed. *variables* is a vector of
 variable and value pairs.
 
-``let`` executes the variable assignments one-by-one, in the order written.
-
-.. code-block:: hy
+``let`` executes the variable assignments one-by-one, in the order written.::
 
     => (let [x 5
     ...      y (+ x 1)]

--- a/docs/extra/anaphoric.rst
+++ b/docs/extra/anaphoric.rst
@@ -46,9 +46,7 @@ ap-each-while
 Usage: ``(ap-each-while list pred body)``
 
 Evaluate the form for each element where the predicate form returns
-``True``.
-
-.. code-block:: hy
+``True``.::
 
    => (ap-each-while [1 2 3 4 5 6] (< it 4) (print it))
    1
@@ -64,9 +62,7 @@ Usage: ``(ap-map form list)``
 
 The anaphoric form of map works just like regular map except that
 instead of a function object it takes a Hy form. The special name
-``it`` is bound to the current object from the list in the iteration.
-
-.. code-block:: hy
+``it`` is bound to the current object from the list in the iteration.::
 
     => (list (ap-map (* it 2) [1 2 3]))
     [2, 4, 6]
@@ -80,9 +76,7 @@ ap-map-when
 Usage: ``(ap-map-when predfn rep list)``
 
 Evaluate a mapping over the list using a predicate function to
-determin when to apply the form.
-
-.. code-block:: hy
+determin when to apply the form.::
 
     => (list (ap-map-when odd? (* it 2) [1 2 3 4]))
     [2, 2, 6, 4]
@@ -100,9 +94,7 @@ Usage: ``(ap-filter form list)``
 
 As with ``ap-map`` we take a special form instead of a function to
 filter the elements of the list. The special name ``it`` is bound to
-the current element in the iteration.
-
-.. code-block:: hy
+the current element in the iteration.::
 
     => (list (ap-filter (> (* it 2) 6) [1 2 3 4 5]))
     [4, 5]
@@ -117,9 +109,7 @@ Usage: ``(ap-reject form list)``
 
 This function does the opposite of ``ap-filter``, it rejects the
 elements passing the predicate . The special name ``it`` is bound to
-the current element in the iteration.
-
-.. code-block:: hy
+the current element in the iteration.::
 
     => (list (ap-reject (> (* it 2) 6) [1 2 3 4 5]))
     [1, 2, 3]
@@ -133,9 +123,7 @@ ap-dotimes
 Usage ``(ap-dotimes n body)``
 
 This function evaluates the body *n* times, with the special
-variable ``it`` bound from *0* to *1-n*. It is useful for side-effects.
-
-.. code-block:: hy
+variable ``it`` bound from *0* to *1-n*. It is useful for side-effects.::
 
     => (setv n [])
     => (ap-dotimes 3 (.append n it))
@@ -152,9 +140,7 @@ Usage ``(ap-first predfn list)``
 
 This function returns the first element that passes the predicate or
 ``None``, with the special variable ``it`` bound to the current element in
-iteration.
-
-.. code-block:: hy
+iteration.::
 
    =>(ap-first (> it 5) (range 10))
    6
@@ -169,9 +155,7 @@ Usage ``(ap-last predfn list)``
 
 This function returns the last element that passes the predicate or
 ``None``, with the special variable ``it`` bound to the current element in
-iteration.
-
-.. code-block:: hy
+iteration.::
 
    =>(ap-last (> it 5) (range 10))
    9
@@ -189,9 +173,7 @@ elements in the body and applying the result and the 3rd element
 etc. until the list is exhausted. Optionally an initial value can be
 supplied so the function will be applied to initial value and the
 first element instead. This exposes the element being iterated as
-``it`` and the current accumulated value as ``acc``.
-
-.. code-block:: hy
+``it`` and the current accumulated value as ``acc``.::
 
    =>(ap-reduce (+ it acc) (range 10))
    45
@@ -204,9 +186,7 @@ ap-pipe
 
 Usage ``(ap-pipe value form1 form2 ...)``
 
-Applies several forms in series to a value from left to right. The special variable ``ìt`` in each form is replaced by the result of the previous form.
-
-.. code-block:: hy
+Applies several forms in series to a value from left to right. The special variable ``ìt`` in each form is replaced by the result of the previous form.::
 
    => (ap-pipe 3 (+ it 1) (/ 5 it))
    1.25
@@ -217,19 +197,17 @@ Applies several forms in series to a value from left to right. The special varia
 .. _ap-compose:
 
 ap-compose
-=========
+==========
 
 Usage ``(ap-compose form1 form2 ...)``
 
-Returns a function which applies several forms in series from left to right. The special variable ``ìt`` in each form is replaced by the result of the previous form.
-
-.. code-block:: hy
+Returns a function which applies several forms in series from left to right. The special variable ``ìt`` in each form is replaced by the result of the previous form.::
 
    => (setv op (ap-compose (+ it 1) (* it 3)))
    => (op 2)
    9
 
-.. _#%
+.. _#%:
 
 #%
 ==
@@ -241,9 +219,7 @@ Makes an expression into a function with an implicit ``%`` parameter list.
 A ``%i`` symbol designates the (1-based) *i* th parameter (such as ``%3``).
 Only the maximum ``%i`` determines the number of ``%i`` parameters--the
 others need not appear in the expression.
-``%*`` and ``%**`` name the ``&rest`` and ``&kwargs`` parameters, respectively.
-
-.. code-block:: hy
+``%*`` and ``%**`` name the ``&rest`` and ``&kwargs`` parameters, respectively.::
 
     => (#%[%1 %6 42 [%2 %3] %* %4] 1 2 3 4 555 6 7 8)
     [1, 6, 42, [2, 3], (7, 8), 4]
@@ -251,9 +227,7 @@ others need not appear in the expression.
     {"foo": 2}
 
 When used on an s-expression,
-``#%`` is similar to Clojure's anonymous function literals--``#()``.
-
-.. code-block:: hy
+``#%`` is similar to Clojure's anonymous function literals--``#()``.::
 
     => (setv add-10 #%(+ 10 %1))
     => (add-10 6)

--- a/docs/extra/reserved.rst
+++ b/docs/extra/reserved.rst
@@ -10,9 +10,7 @@ Usage: ``(names)``
 This function can be used to get a list (actually, a ``frozenset``) of the
 names of Hy's built-in functions, macros, and special forms. The output
 also includes all Python reserved words. All names are in unmangled form
-(e.g., ``list-comp`` rather than ``list_comp``).
-
-.. code-block:: hy
+(e.g., ``list-comp`` rather than ``list_comp``).::
 
    => (import hy.extra.reserved)
    => (in "defclass" (hy.extra.reserved.names))

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -1,6 +1,6 @@
-=================
+=========
 Built-Ins
-=================
+=========
 
 Hy features a number of special forms that are used to help generate
 correct Python AST. The following are "special" forms, which may have
@@ -14,9 +14,7 @@ behavior that's slightly unexpected in some situations.
 ``.`` is used to perform attribute access on objects. It uses a small DSL
 to allow quick access to attributes and items in a nested data structure.
 
-For instance,
-
-.. code-block:: clj
+For instance,::
 
     (. foo bar baz [(+ 1 2)] frob)
 
@@ -41,9 +39,7 @@ unknown keys raises an :exc:`IndexError` (on lists and tuples) or a
 
 ``->`` (or the *threading macro*) is used to avoid nesting of expressions. The
 threading macro inserts each expression into the next expression's first argument
-place. The following code demonstrates this:
-
-.. code-block:: clj
+place. The following code demonstrates this:::
 
     => (defn output [a b] (print a b))
     => (-> (+ 4 6) (output 5))
@@ -55,9 +51,7 @@ place. The following code demonstrates this:
 
 ``->>`` (or the *threading tail macro*) is similar to the *threading macro*, but
 instead of inserting each expression into the next expression's first argument,
-it appends it as the last argument. The following code demonstrates this:
-
-.. code-block:: clj
+it appends it as the last argument. The following code demonstrates this:::
 
     => (defn output [a b] (print a b))
     => (->> (+ 4 6) (output 5))
@@ -69,9 +63,7 @@ and
 
 ``and`` is used in logical expressions. It takes at least two parameters. If
 all parameters evaluate to ``True``, the last parameter is returned. In any
-other case, the first false value will be returned. Example usage:
-
-.. code-block:: clj
+other case, the first false value will be returned. Example usage:::
 
     => (and True False)
     False
@@ -88,12 +80,10 @@ other case, the first false value will be returned. Example usage:
 .. note::
 
     ``and`` short-circuits and stops evaluating parameters as soon as the first
-    false is encountered.
+    false is encountered.::
 
-.. code-block:: clj
-
-    => (and False (print "hello"))
-    False
+	=> (and False (print "hello"))
+	False
 
 
 as->
@@ -105,9 +95,7 @@ Expands to sequence of assignments to the provided name, starting with head.
 The previous result is thus available in the subsequent form. Returns the final
 result, and leaves the name bound to it in the local scope. This behaves much
 like the other threading macros, but requires you to specify the threading
-point per form via the name instead of always the first or last argument.
-
-.. code-block:: clj
+point per form via the name instead of always the first or last argument.::
 
   ;; example how -> and as-> relate
 
@@ -132,7 +120,7 @@ point per form via the name instead of always the first or last argument.
   ...             :discovered {:year 1907
   ...                          :name "Sir Joseph Cooke Verco"}}])
 
-  ;; retrieve name of first entry      
+  ;; retrieve name of first entry
   => (as-> (first data) it
   ...      (:name it))
   'hooded cuttlefish'
@@ -160,11 +148,11 @@ point per form via the name instead of always the first or last argument.
   ...      (take 30 it)
   ...      (list it)
   ...      (.join "" it))
-  'Welcome to Hy’s documentation!
+  'Welcome to Hy's documentation!
 
 .. note::
 
-  In these examples, the REPL will report a tuple (e.g. `('Sepia prashadi', 
+  In these examples, the REPL will report a tuple (e.g. `('Sepia prashadi',
   'Sepia prashadi')`) as the result, but only a single value is actually
   returned.
 
@@ -178,9 +166,7 @@ raised. ``assert`` may take one or two parameters.  The first
 parameter is the condition to check, and it should evaluate to either
 ``True`` or ``False``. The second parameter, optional, is a label for
 the assert, and is the string that will be raised with the
-:exc:`AssertionError`. For example:
-
-.. code-block:: clj
+:exc:`AssertionError`. For example:::
 
   (assert (= variable expected-value))
 
@@ -199,9 +185,7 @@ index of a list to a value. It takes at least three parameters: the *data
 structure* to be modified, a *key* or *index*, and a *value*. If more than
 three parameters are used, it will associate in pairs.
 
-Examples of usage:
-
-.. code-block:: clj
+Examples of usage:::
 
   =>(do
   ... (setv collection {})
@@ -229,9 +213,7 @@ break
 
 ``break`` is used to break out from a loop. It terminates the loop immediately.
 The following example has an infinite ``while`` loop that is terminated as soon
-as the user enters *k*.
-
-.. code-block:: clj
+as the user enters *k*.::
 
     (while True (if (= "k" (raw-input "? "))
                   (break)
@@ -239,16 +221,14 @@ as the user enters *k*.
 
 
 comment
-----
+-------
 
 The ``comment`` macro ignores its body and always expands to ``None``.
 Unlike linewise comments, the body of the ``comment`` macro must
 be grammatically valid Hy, so the compiler can tell where the comment ends.
 Besides the semicolon linewise comments,
 Hy also has the ``#_`` discard prefix syntax to discard the next form.
-This is completely discarded and doesn't expand to anything, not even ``None``.
-
-.. code-block:: clj
+This is completely discarded and doesn't expand to anything, not even ``None``.::
 
    => (print (comment <h1>Surprise!</h1>
    ...                <p>You'd be surprised what's grammatically valid in Hy.</p>
@@ -266,9 +246,7 @@ cond
 ----
 
 ``cond`` can be used to build nested ``if`` statements. The following example
-shows the relationship between the macro and its expansion:
-
-.. code-block:: clj
+shows the relationship between the macro and its expansion:::
 
     (cond [condition-1 result-1]
           [condition-2 result-2])
@@ -278,9 +256,7 @@ shows the relationship between the macro and its expansion:
 
 If only the condition is given in a branch, then the condition is also used as
 the result. The expansion of this single argument version is demonstrated
-below:
-
-.. code-block:: clj
+below:::
 
     (cond [condition-1]
           [condition-2])
@@ -288,9 +264,7 @@ below:
     (if condition-1 condition-1
       (if condition-2 condition-2))
 
-As shown below, only the first matching result block is executed.
-
-.. code-block:: clj
+As shown below, only the first matching result block is executed.::
 
     => (defn check-value [value]
     ...  (cond [(< value 5) (print "value is smaller than 5")]
@@ -307,9 +281,7 @@ continue
 
 ``continue`` returns execution to the start of a loop. In the following example,
 ``(side-effect1)`` is called for each iteration. ``(side-effect2)``, however,
-is only called on every other value in the list.
-
-.. code-block:: clj
+is only called on every other value in the list.::
 
     ;; assuming that (side-effect1) and (side-effect2) are functions and
     ;; collection is a list of numerical values
@@ -328,9 +300,7 @@ dict-comp
 The first two parameters are for controlling the return value (key-value pair)
 while the third is used to select items from a sequence. The fourth and optional
 parameter can be used to filter out some of the items in the sequence based on a
-conditional expression.
-
-.. code-block:: hy
+conditional expression.::
 
     => (dict-comp x (* x 2) [x (range 10)] (odd? x))
     {1: 2, 3: 6, 9: 18, 5: 10, 7: 14}
@@ -344,9 +314,7 @@ last one. Return values from every other than the last argument are discarded.
 It can be used in ``list-comp`` to perform more complex logic as shown in one
 of the following examples.
 
-Some example usage:
-
-.. code-block:: clj
+Some example usage:::
 
     => (if True
     ...  (do (print "Side effects rock!")
@@ -369,9 +337,7 @@ doc / #doc
 ----------
 
 Documentation macro and tag macro.
-Gets help for macros or tag macros, respectively.
-
-.. code-block:: clj
+Gets help for macros or tag macros, respectively.::
 
     => (doc doc)
     Help on function (doc) in module hy.core.macros:
@@ -404,9 +370,7 @@ setv
 ----
 
 ``setv`` is used to bind a value, object, or function to a symbol.
-For example:
-
-.. code-block:: clj
+For example:::
 
     => (setv names ["Alice" "Bob" "Charlie"])
     => (print names)
@@ -416,9 +380,7 @@ For example:
     => (counter [1 2 3 4 5 2 3] 2)
     2
 
-They can be used to assign multiple variables at once:
-
-.. code-block:: hy
+They can be used to assign multiple variables at once:::
 
     => (setv a 1 b 2)
     (1L, 2L)
@@ -434,9 +396,7 @@ defclass
 
 New classes are declared with ``defclass``. It can takes two optional parameters:
 a vector defining a possible super classes and another vector containing
-attributes of the new class as two item vectors.
-
-.. code-block:: clj
+attributes of the new class as two item vectors.::
 
     (defclass class-name [super-class-1 super-class-2]
       [attribute value]
@@ -444,9 +404,7 @@ attributes of the new class as two item vectors.
       (defn method [self] (print "hello!")))
 
 Both values and functions can be bound on the new class as shown by the example
-below:
-
-.. code-block:: clj
+below:::
 
     => (defclass Cat []
     ...  [age None
@@ -468,9 +426,7 @@ defn
 
 ``defn`` macro is used to define functions. It takes three
 parameters: the *name* of the function to define, a vector of *parameters*,
-and the *body* of the function:
-
-.. code-block:: clj
+and the *body* of the function:::
 
     (defn name [params] body)
 
@@ -480,9 +436,7 @@ Parameters may have the following keywords in front of them:
     Parameter is optional. The parameter can be given as a two item list, where
     the first element is parameter name and the second is the default value. The
     parameter can be also given as a single item, in which case the default
-    value is ``None``.
-
-    .. code-block:: clj
+    value is ``None``.::
 
         => (defn total-value [value &optional [value-added-tax 10]]
         ...  (+ (/ (* value value-added-tax) 100) value))
@@ -496,9 +450,7 @@ Parameters may have the following keywords in front of them:
 &key
     Parameter is a dict of keyword arguments. The keys of the dict
     specify the parameter names and the values give the default values
-    of the parameters.
-
-    .. code-block:: clj
+    of the parameters.::
 
        => (defn key-parameters [&key {"a" 1 "b" 2}]
        ... (print "a is" a "and b is" b))
@@ -507,9 +459,7 @@ Parameters may have the following keywords in front of them:
        => (key-parameters :b 1 :a 2)
        a is 2 and b is 1
 
-    The following declarations are equivalent:
-
-    .. code-block:: clj
+    The following declarations are equivalent:::
 
        (defn key-parameters [&key {"a" 1 "b" 2}])
 
@@ -519,9 +469,7 @@ Parameters may have the following keywords in front of them:
     Parameter will contain 0 or more keyword arguments.
 
     The following code examples defines a function that will print all keyword
-    arguments and their values.
-
-    .. code-block:: clj
+    arguments and their values.::
 
         => (defn print-parameters [&kwargs kwargs]
         ...    (for [(, k v) (.items kwargs)] (print k v)))
@@ -541,9 +489,7 @@ Parameters may have the following keywords in front of them:
 
     The following code example defines a function that can be given 0 to n
     numerical parameters. It then sums every odd number and subtracts
-    every even number.
-
-    .. code-block:: clj
+    every even number.::
 
         => (defn zig-zag-sum [&rest numbers]
              (setv odd-numbers (list-comp x [x numbers] (odd? x))
@@ -564,9 +510,7 @@ Parameters may have the following keywords in front of them:
     keyword-only arguments are declared with the argument's name;
     optional keyword-only arguments are declared as a two-element list
     containing the argument name followed by the default value (as
-    with `&optional` above).
-
-    .. code-block:: clj
+    with `&optional` above).::
 
         => (defn compare [a b &kwonly keyfn [reverse False]]
         ...  (setv result (keyfn a b))
@@ -598,9 +542,7 @@ defn/a
 
 ``defn/a`` macro is a variant of ``defn`` that instead defines
 coroutines. It takes three parameters: the *name* of the function to
-define, a vector of *parameters*, and the *body* of the function:
-
-.. code-block:: clj
+define, a vector of *parameters*, and the *body* of the function:::
 
     (defn/a name [params] body)
 
@@ -611,14 +553,14 @@ defmain
 
 The ``defmain`` macro defines a main function that is immediately called
 with ``sys.argv`` as arguments if and only if this file is being executed
-as a script.  In other words, this:
-
-.. code-block:: clj
+as a script.  In other words, this:::
 
    (defmain [&rest args]
      (do-something-with args))
 
-is the equivalent of::
+is the equivalent of
+
+.. code-block:: python
 
    def main(*args):
        do_something_with(args)
@@ -639,9 +581,7 @@ non-integer return from ``defmain``, it's a good idea to put ``(defmain)``
 as the last piece of code in your file.
 
 If you want fancy command-line arguments, you can use the standard Python
-module ``argparse`` in the usual way:
-
-.. code-block:: clj
+module ``argparse`` in the usual way:::
 
     (import argparse)
 
@@ -667,9 +607,7 @@ defmacro
 
 The following example defines a macro that can be used to swap order of elements
 in code, allowing the user to write code in infix notation, where operator is in
-between the operands.
-
-.. code-block:: clj
+between the operands.::
 
   => (defmacro infix [code]
   ...  (quasiquote (
@@ -706,9 +644,7 @@ defmacro!
 ``defmacro!`` is like ``defmacro/g!`` plus automatic once-only evaluation for
 ``o!`` parameters, which are available as the equivalent ``g!`` symbol.
 
-For example,
-
-.. code-block:: clj
+For example,::
 
     => (defn expensive-get-number [] (print "spam") 14)
     => (defmacro triple-1 [n] `(+ ~n ~n ~n))
@@ -735,9 +671,7 @@ deftag
 ``deftag`` defines a tag macro. A tag macro is a unary macro that has the
 same semantics as an ordinary macro defined with ``defmacro``. It is called with
 the syntax ``#tag FORM``, where ``tag`` is the name of the macro, and ``FORM``
-is any form. The ``tag`` is often only one character, but it can be any symbol.
-
-.. code-block:: clj
+is any form. The ``tag`` is often only one character, but it can be any symbol.::
 
     => (deftag ♣ [expr] `[~expr ~expr])
     <function <lambda> at 0x7f76d0271158>
@@ -762,9 +696,7 @@ del
 
 .. versionadded:: 0.9.12
 
-``del`` removes an object from the current namespace.
-
-.. code-block:: clj
+``del`` removes an object from the current namespace.::
 
   => (setv foo 42)
   => (del foo)
@@ -773,9 +705,7 @@ del
     File "<console>", line 1, in <module>
   NameError: name 'foo' is not defined
 
-``del`` can also remove objects from mappings, lists, and more.
-
-.. code-block:: clj
+``del`` can also remove objects from mappings, lists, and more.::
 
   => (setv test (list (range 10)))
   => test
@@ -795,14 +725,12 @@ doto
 
 .. versionadded:: 0.10.1
 
-``doto`` is used to simplify a sequence of method calls to an object.
-
-.. code-block:: clj
+``doto`` is used to simplify a sequence of method calls to an object.::
 
   => (doto [] (.append 1) (.append 2) .reverse)
   [2, 1]
 
-.. code-block:: clj
+::
 
   => (setv collection [])
   => (.append collection 1)
@@ -834,9 +762,7 @@ Had the ``defn`` not been wrapped in ``eval-and-compile``, ``m`` wouldn't be abl
 eval-when-compile
 -----------------
 
-``eval-when-compile`` is like ``eval-and-compile``, but the code isn't executed at run-time. Hence, ``eval-when-compile`` doesn't directly contribute any code to the final program, although it can still change Hy's state while compiling (e.g., by defining a function).
-
-.. code-block:: clj
+``eval-when-compile`` is like ``eval-and-compile``, but the code isn't executed at run-time. Hence, ``eval-when-compile`` doesn't directly contribute any code to the final program, although it can still change Hy's state while compiling (e.g., by defining a function).::
 
     (eval-when-compile
       (defn add [x y]
@@ -851,18 +777,14 @@ eval-when-compile
 first
 -----
 
-``first`` is a function for accessing the first element of a collection.
-
-.. code-block:: clj
+``first`` is a function for accessing the first element of a collection.::
 
     => (first (range 10))
     0
 
 It is implemented as ``(next (iter coll) None)``, so it works with any
 iterable, and if given an empty iterable, it will return ``None`` instead of
-raising an exception.
-
-.. code-block:: clj
+raising an exception.::
 
     => (first (repeat 10))
     10
@@ -876,9 +798,7 @@ for
 The results of each call are discarded and the ``for`` expression returns
 ``None`` instead. The example code iterates over *collection* and for each
 *element* in *collection* calls the ``side-effect`` function with *element*
-as its argument:
-
-.. code-block:: clj
+as its argument:::
 
     ;; assuming that (side-effect) is a function that takes a single parameter
     (for [element collection] (side-effect element))
@@ -889,9 +809,7 @@ as its argument:
 
 The optional ``else`` block is only executed if the ``for`` loop terminates
 normally. If the execution is halted with ``break``, the ``else`` block does
-not execute.
-
-.. code-block:: clj
+not execute.::
 
     => (for [element [1 2 3]] (if (< element 3)
     ...                             (print element)
@@ -916,9 +834,7 @@ for/a
 ``for/a`` behaves like ``for`` but is used to call a function for each
 element generated by an asynchronous generator expression. The results
 of each call are discarded and the ``for/a`` expression returns
-``None`` instead.
-
-.. code-block:: clj
+``None`` instead.::
 
     ;; assuming that (side-effect) is a function that takes a single parameter
     (for/a [element (agen)] (side-effect element))
@@ -937,9 +853,7 @@ while the second is used to select items from a list. The third and optional
 parameter can be used to filter out some of the items in the list based on a
 conditional expression. ``genexpr`` is similar to ``list-comp``, except it
 returns an iterable that evaluates values one by one instead of evaluating them
-immediately.
-
-.. code-block:: hy
+immediately.::
 
     => (setv collection (range 10))
     => (setv filtered (genexpr x [x collection] (even? x)))
@@ -955,9 +869,7 @@ gensym
 .. versionadded:: 0.9.12
 
 ``gensym`` is used to generate a unique symbol that allows macros to be
-written without accidental variable name clashes.
-
-.. code-block:: clj
+written without accidental variable name clashes.::
 
    => (gensym)
    u':G_1235'
@@ -976,9 +888,7 @@ get
 least two parameters: the *data structure* and the *index* or *key* of the
 item. It will then return the corresponding value from the collection. If
 multiple *index* or *key* values are provided, they are used to access
-successive elements in a nested structure. Example usage:
-
-.. code-block:: clj
+successive elements in a nested structure. Example usage:::
 
    => (do
    ...  (setv animals {"dog" "bark" "cat" "meow"}
@@ -1008,9 +918,7 @@ assign a value to a global symbol. Reading a global symbol does not require the
 
 The following example shows how the global symbol ``a`` is assigned a value in a
 function and is later on printed in another function. Without the ``global``
-keyword, the second function would have raised a ``NameError``.
-
-.. code-block:: clj
+keyword, the second function would have raised a ``NameError``.::
 
     (defn set-a [value]
       (global a)
@@ -1053,9 +961,7 @@ when the condition fails while the third and final expression is executed when
 the test succeeds -- the opposite order of ``if*``. The final expression is
 again optional and defaults to ``None``.
 
-Example usage:
-
-.. code-block:: clj
+Example usage:::
 
     (print (if (< n 0.0) "negative"
                (= n 0.0) "zero"
@@ -1085,9 +991,7 @@ For those that prefer a more Lispy ``if`` clause, we have
 "false-ish" Python values are considered true. Conversely, we have
 ``lif-not`` in parallel to ``if`` and ``if-not`` which
 reverses the comparison.
-
-
-.. code-block:: clj
+::
 
     => (lif True "true" "false")
     "true"
@@ -1108,9 +1012,7 @@ import
 ------
 
 ``import`` is used to import modules, like in Python. There are several ways
-that ``import`` can be used.
-
-.. code-block:: clj
+that ``import`` can be used.::
 
     ;; Imports each of these modules
     ;;
@@ -1155,9 +1057,7 @@ Unlike Python's ``lambda``, the body of the function can comprise several
 statements. The parameters are similar to ``defn``: the first parameter is
 vector of parameters and the rest is the body of the function. ``fn`` returns a
 new function. In the following example, an anonymous function is defined and
-passed to another function for filtering output.
-
-.. code-block:: clj
+passed to another function for filtering output.::
 
     => (setv people [{:name "Alice" :age 20}
     ...             {:name "Bob" :age 25}
@@ -1173,9 +1073,7 @@ passed to another function for filtering output.
 
 Just as in normal function definitions, if the first element of the
 body is a string, it serves as a docstring. This is useful for giving
-class methods docstrings.
-
-.. code-block:: clj
+class methods docstrings.::
 
     => (setv times-three
     ...   (fn [x]
@@ -1204,9 +1102,7 @@ last
 
 .. versionadded:: 0.11.0
 
-``last`` can be used for accessing the last element of a collection:
-
-.. code-block:: clj
+``last`` can be used for accessing the last element of a collection:::
 
     => (last [2 4 6])
     6
@@ -1219,9 +1115,7 @@ list-comp
 The first parameter is the expression controlling the return value, while
 the second is used to select items from a list. The third and optional
 parameter can be used to filter out some of the items in the list based on a
-conditional expression. Some examples:
-
-.. code-block:: clj
+conditional expression. Some examples:::
 
     => (setv collection (range 10))
     => (list-comp x [x collection])
@@ -1243,9 +1137,7 @@ nonlocal
 
 ``nonlocal`` can be used to mark a symbol as not local to the current scope.
 The parameters are the names of symbols to mark as nonlocal.  This is necessary
-to modify variables through nested ``fn`` scopes:
-
-.. code-block:: clj
+to modify variables through nested ``fn`` scopes:::
 
     (defn some-function []
       (setv x 0)
@@ -1267,9 +1159,7 @@ not
 
 ``not`` is used in logical expressions. It takes a single parameter and
 returns a reversed truth value. If ``True`` is given as a parameter, ``False``
-will be returned, and vice-versa. Example usage:
-
-.. code-block:: clj
+will be returned, and vice-versa. Example usage:::
 
     => (not True)
     False
@@ -1286,9 +1176,7 @@ or
 
 ``or`` is used in logical expressions. It takes at least two parameters. It
 will return the first non-false parameter. If no such value exists, the last
-parameter will be returned.
-
-.. code-block:: clj
+parameter will be returned.::
 
     => (or True False)
     True
@@ -1300,20 +1188,16 @@ parameter will be returned.
     1
 
 .. note:: ``or`` short-circuits and stops evaluating parameters as soon as the
-          first true value is encountered.
+          first true value is encountered.::
 
-.. code-block:: clj
-
-    => (or True (print "hello"))
-    True
+	    j> (or True (print "hello"))
+	    True
 
 
 print
 -----
 
-``print`` is used to output on screen. Example usage:
-
-.. code-block:: clj
+``print`` is used to output on screen. Example usage:::
 
     (print "Hello world!")
 
@@ -1327,9 +1211,7 @@ quasiquote
 expressions. Expressions inside a ``quasiquote`` can be selectively evaluated
 using ``unquote`` (``~``). The evaluated form can also be spliced using
 ``unquote-splice`` (``~@``). Quasiquote can be also written using the backquote
-(`````) symbol.
-
-.. code-block:: clj
+(`````) symbol.::
 
     ;; let `qux' be a variable with value (bar baz)
     `(foo ~qux)
@@ -1342,9 +1224,7 @@ quote
 -----
 
 ``quote`` returns the form passed to it without evaluating it. ``quote`` can
-alternatively be written using the apostrophe (``'``) symbol.
-
-.. code-block:: clj
+alternatively be written using the apostrophe (``'``) symbol.::
 
     => (setv x '(print "Hello World"))
     => x  ; variable x is set to unevaluated expression
@@ -1364,9 +1244,7 @@ produces no code in the final program: its effect is purely at compile-time, for
 the benefit of macro expansion. Specifically, ``require`` imports each named
 module and then makes each requested macro available in the current module.
 
-The following are all equivalent ways to call a macro named ``foo`` in the module ``mymodule``:
-
-.. code-block:: clj
+The following are all equivalent ways to call a macro named ``foo`` in the module ``mymodule``:::
 
     (require mymodule)
     (mymodule.foo 1)
@@ -1387,9 +1265,7 @@ Macros that call macros
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 One aspect of ``require`` that may be surprising is what happens when one
-macro's expansion calls another macro. Suppose ``mymodule.hy`` looks like this:
-
-.. code-block:: clj
+macro's expansion calls another macro. Suppose ``mymodule.hy`` looks like this:::
 
     (defmacro repexpr [n expr]
       ; Evaluate the expression n times
@@ -1399,9 +1275,7 @@ macro's expansion calls another macro. Suppose ``mymodule.hy`` looks like this:
     (defmacro foo [n]
       `(repexpr ~n (input "Gimme some input: ")))
 
-And then, in your main program, you write:
-
-.. code-block:: clj
+And then, in your main program, you write:::
 
     (require [mymodule [foo]])
 
@@ -1413,9 +1287,7 @@ main program doesn't have the macro ``repexpr`` available, since it wasn't
 imported (and imported under exactly that name, as opposed to a qualified name).
 You could do ``(require [mymodule [*]])`` or ``(require [mymodule [foo
 repexpr]])``, but a less error-prone approach is to change the definition of
-``foo`` to require whatever sub-macros it needs:
-
-.. code-block:: clj
+``foo`` to require whatever sub-macros it needs:::
 
     (defmacro foo [n]
       `(do
@@ -1441,16 +1313,12 @@ rest
 ----
 
 ``rest`` takes the given collection and returns an iterable of all but the
-first element.
-
-.. code-block:: clj
+first element.::
 
     => (list (rest (range 10)))
     [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-Given an empty collection, it returns an empty iterable.
-
-.. code-block:: clj
+Given an empty collection, it returns an empty iterable.::
 
     => (list (rest []))
     []
@@ -1460,9 +1328,7 @@ return
 
 ``return`` compiles to a :py:keyword:`return` statement. It exits the
 current function, returning its argument if provided with one or
-``None`` if not.
-
-.. code-block:: hy
+``None`` if not.::
 
     => (defn f [x] (for [n (range 10)] (when (> n x) (return n))))
     => (f 3.9)
@@ -1470,18 +1336,14 @@ current function, returning its argument if provided with one or
 
 Note that in Hy, ``return`` is necessary much less often than in Python,
 since the last form of a function is returned automatically. Hence, an
-explicit ``return`` is only necessary to exit a function early.
-
-.. code-block:: hy
+explicit ``return`` is only necessary to exit a function early.::
 
     => (defn f [x] (setv y 10) (+ x y))
     => (f 4)
     14
 
 To get Python's behavior of returning ``None`` when execution reaches
-the end of a function, put ``None`` there yourself.
-
-.. code-block:: hy
+the end of a function, put ``None`` there yourself.::
 
     => (defn f [x] (setv y 10) (+ x y) None)
     => (print (f 4))
@@ -1494,9 +1356,7 @@ set-comp
 The first parameter is for controlling the return value, while the second is
 used to select items from a sequence. The third and optional parameter can be
 used to filter out some of the items in the sequence based on a conditional
-expression.
-
-.. code-block:: hy
+expression.::
 
     => (setv data [1 2 3 4 5 2 3 4 5 3 4 5])
     => (set-comp x [x data] (odd? x))
@@ -1513,9 +1373,7 @@ subset. If they are not supplied, the default value of ``None`` will be used
 instead. The third optional parameter is used to control step between the elements.
 
 ``cut`` follows the same rules as its Python counterpart. Negative indices are
-counted starting from the end of the list. Some example usage:
-
-.. code-block:: clj
+counted starting from the end of the list. Some example usage:::
 
     => (setv collection (range 10))
 
@@ -1539,9 +1397,7 @@ raise
 -------------
 
 The ``raise`` form can be used to raise an ``Exception`` at
-runtime. Example usage:
-
-.. code-block:: clj
+runtime. Example usage:::
 
     (raise)
     ; re-rase the last exception
@@ -1561,9 +1417,7 @@ try
 ---
 
 The ``try`` form is used to catch exceptions (``except``) and run cleanup
-actions (``finally``).
-
-.. code-block:: clj
+actions (``finally``).::
 
     (try
       (error-prone-function)
@@ -1598,9 +1452,7 @@ unless
 ------
 
 The ``unless`` macro is a shorthand for writing an ``if`` statement that checks if
-the given conditional is ``False``. The following shows the expansion of this macro.
-
-.. code-block:: clj
+the given conditional is ``False``. The following shows the expansion of this macro.::
 
     (unless conditional statement)
 
@@ -1614,25 +1466,19 @@ unpack-iterable, unpack-mapping
 
 ``unpack-iterable`` and ``unpack-mapping`` allow an iterable or mapping
 object (respectively) to provide positional or keywords arguments
-(respectively) to a function.
-
-.. code-block:: clj
+(respectively) to a function.::
 
     => (defn f [a b c d] [a b c d])
     => (f (unpack-iterable [1 2]) (unpack-mapping {"c" 3 "d" 4}))
     [1, 2, 3, 4]
 
 ``unpack-iterable`` is usually written with the shorthand ``#*``, and
-``unpack-mapping`` with ``#**``.
-
-.. code-block:: clj
+``unpack-mapping`` with ``#**``.::
 
     => (f #* [1 2] #** {"c" 3 "d" 4})
     [1, 2, 3, 4]
 
-With Python 3, you can unpack in an assignment list (:pep:`3132`).
-
-.. code-block:: clj
+With Python 3, you can unpack in an assignment list (:pep:`3132`).::
 
     => (setv [a #* b c] [1 2 3 4 5])
     => [a b c]
@@ -1640,9 +1486,7 @@ With Python 3, you can unpack in an assignment list (:pep:`3132`).
 
 With Python 3.5 or greater, unpacking is allowed in more contexts than just
 function calls, and you can unpack more than once in the same expression
-(:pep:`448`).
-
-.. code-block:: clj
+(:pep:`448`).::
 
     => [#* [1 2] #* [3 4]]
     [1, 2, 3, 4]
@@ -1656,9 +1500,7 @@ unquote
 -------
 
 Within a quasiquoted form, ``unquote`` forces evaluation of a symbol. ``unquote``
-is aliased to the tilde (``~``) symbol.
-
-.. code-block:: clj
+is aliased to the tilde (``~``) symbol.::
 
     => (setv nickname "Cuddles")
     => (quasiquote (= nickname (unquote nickname)))
@@ -1682,9 +1524,7 @@ being unquoted contains an iterable value, as it "splices" that iterable into
 the quasiquoted form. ``unquote-splice`` can also be used when the value
 evaluates to a false value such as ``None``, ``False``, or ``0``, in which
 case the value is treated as an empty list and thus does not splice anything
-into the form. ``unquote-splice`` is aliased to the ``~@`` syntax.
-
-.. code-block:: clj
+into the form. ``unquote-splice`` is aliased to the ``~@`` syntax.::
 
     => (setv nums [1 2 3 4])
     => (quasiquote (+ (unquote-splice nums)))
@@ -1718,9 +1558,7 @@ when
 
 ``when`` is similar to ``unless``, except it tests when the given conditional is
 ``True``. It is not possible to have an ``else`` block in a ``when`` macro. The
-following shows the expansion of the macro.
-
-.. code-block:: clj
+following shows the expansion of the macro.::
 
     (when conditional statement)
 
@@ -1733,16 +1571,12 @@ while
 ``while`` compiles to a :py:keyword:`while` statement. It is used to execute a
 set of forms as long as a condition is met. The first argument to ``while`` is
 the condition, and any remaining forms constitute the body. The following
-example will output "Hello world!" to the screen indefinitely:
-
-.. code-block:: clj
+example will output "Hello world!" to the screen indefinitely:::
 
     (while True (print "Hello world!"))
 
 The last form of a ``while`` loop can be an ``else`` clause, which is executed
-after the loop terminates, unless it exited abnormally (e.g., with ``break``). So,
-
-.. code-block:: clj
+after the loop terminates, unless it exited abnormally (e.g., with ``break``). So,::
 
     (setv x 2)
     (while x
@@ -1763,9 +1597,7 @@ If you put a ``break`` or ``continue`` form in the condition of a ``while``
 loop, it will apply to the very same loop rather than an outer loop, even if
 execution is yet to ever reach the loop body. (Hy compiles a ``while`` loop
 with statements in its condition by rewriting it so that the condition is
-actually in the body.) So,
-
-.. code-block:: clj
+actually in the body.) So,::
 
     (for [x [1]]
        (print "In outer loop")
@@ -1792,9 +1624,7 @@ with
 ``with`` is used to wrap the execution of a block within a context manager. The
 context manager can then set up the local system and tear it down in a controlled
 manner. The archetypical example of using ``with`` is when processing files.
-``with`` can bind context to an argument or ignore it completely, as shown below:
-
-.. code-block:: clj
+``with`` can bind context to an argument or ignore it completely, as shown below:::
 
     (with [arg (expr)] block)
 
@@ -1803,17 +1633,13 @@ manner. The archetypical example of using ``with`` is when processing files.
     (with [arg (expr) (expr)] block)
 
 The following example will open the ``NEWS`` file and print its content to the
-screen. The file is automatically closed after it has been processed.
-
-.. code-block:: clj
+screen. The file is automatically closed after it has been processed.::
 
     (with [f (open "NEWS")] (print (.read f)))
 
 ``with`` returns the value of its last form, unless it suppresses an exception
 (because the context manager's ``__exit__`` method returned true), in which
-case it returns ``None``. So, the previous example could also be written
-
-.. code-block:: clj
+case it returns ``None``. So, the previous example could also be written::
 
     (print (with [f (open "NEWS")] (.read f)))
 
@@ -1823,9 +1649,7 @@ with/a
 ``with/a`` behaves like ``with``, but is used to wrap the execution of
 a block within an asynchronous context manager. The context manager can
 then set up the local system and tear it down in a controlled manner
-asynchronously.
-
-.. code-block:: clj
+asynchronously.::
 
     (with/a [arg (expr)] block)
 
@@ -1847,9 +1671,7 @@ of two parameters: the function performing decoration and the function
 being decorated. More than one decorator function can be applied; they
 will be applied in order from outermost to innermost, ie. the first
 decorator will be the outermost one, and so on. Decorators with arguments
-are called just like a function call.
-
-.. code-block:: clj
+are called just like a function call.::
 
    (with-decorator decorator-fun
       (defn some-function [] ...)
@@ -1865,9 +1687,7 @@ In the following example, ``inc-decorator`` is used to decorate the function
 ``addition`` with a function that takes two parameters and calls the
 decorated function with values that are incremented by 1. When
 the decorated ``addition`` is called with values 1 and 1, the end result
-will be 4 (``1+1 + 1+1``).
-
-.. code-block:: clj
+will be 4 (``1+1 + 1+1``).::
 
     => (defn inc-decorator [func]
     ...  (fn [value-1 value-2] (func (+ value-1 1) (+ value-2 1))))
@@ -1888,9 +1708,7 @@ will be 4 (``1+1 + 1+1``).
 .. versionadded:: 0.12.0
 
 The tag macro ``#@`` can be used as a shorthand for ``with-decorator``. With
-``#@``, the previous example becomes:
-
-.. code-block:: clj
+``#@``, the previous example becomes:::
 
     => #@(inc-decorator (defn addition [a b] (+ a b)))
     => (addition 1 1)
@@ -1909,16 +1727,12 @@ with-gensyms
 .. versionadded:: 0.9.12
 
 ``with-gensym`` is used to generate a set of :ref:`gensym` for use in a macro.
-The following code:
-
-.. code-block:: hy
+The following code:::
 
    (with-gensyms [a b c]
      ...)
 
-expands to:
-
-.. code-block:: hy
+expands to:::
 
    (do
      (setv a (gensym)
@@ -1939,9 +1753,7 @@ xor
 ``xor`` performs the logical operation of exclusive OR. It takes two arguments.
 If exactly one argument is true, that argument is returned. If neither is true,
 the second argument is returned (which will necessarily be false). Otherwise,
-when both arguments are true, the value ``False`` is returned.
-
-.. code-block:: clj
+when both arguments are true, the value ``False`` is returned.::
 
     => [(xor 0 0) (xor 0 1) (xor 1 0) (xor 1 1)]
     [0, 1, 1, False]
@@ -1955,9 +1767,7 @@ The generator is iterable and therefore can be used in loops, list
 comprehensions and other similar constructs.
 
 The function ``random-numbers`` shows how generators can be used to generate
-infinite series without consuming infinite amount of memory.
-
-.. code-block:: clj
+infinite series without consuming infinite amount of memory.::
 
     => (defn multiply [bases coefficients]
     ...  (for [(, base coefficient) (zip bases coefficients)]

--- a/docs/language/cli.rst
+++ b/docs/language/cli.rst
@@ -76,9 +76,7 @@ Command Line Options
 .. cmdoption:: file[, fileN]
 
    Compile Hy code to Python bytecode. For example, save the
-   following code as ``hyname.hy``:
-
-   .. code-block:: hy
+   following code as ``hyname.hy``:::
 
       (defn hy-hy [name]
         (print (+ "Hy " name "!")))

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -13,9 +13,7 @@ butlast
 
 Usage: ``(butlast coll)``
 
-Returns an iterator of all but the last item in *coll*.
-
-.. code-block:: hy
+Returns an iterator of all but the last item in *coll*.::
 
    => (list (butlast (range 10)))
    [0, 1, 2, 3, 4, 5, 6, 7, 8]
@@ -39,9 +37,7 @@ coll?
 
 Usage: ``(coll? x)``
 
-Returns ``True`` if *x* is iterable and not a string.
-
-.. code-block:: hy
+Returns ``True`` if *x* is iterable and not a string.::
 
    => (coll? [1 2 3 4])
    True
@@ -62,9 +58,7 @@ Usage: ``(comp f g)``
 
 Compose zero or more functions into a new function. The new function will
 chain the given functions together, so ``((comp g f) x)`` is equivalent to
-``(g (f x))``. Called without arguments, ``comp`` returns ``identity``.
-
-.. code-block:: hy
+``(g (f x))``. Called without arguments, ``comp`` returns ``identity``.::
 
    => (setv example (comp str +))
    => (example 1 2 3)
@@ -85,9 +79,7 @@ complement
 Usage: ``(complement f)``
 
 Returns a new function that returns the same thing as ``f``, but logically
-inverted. So, ``((complement f) x)`` is equivalent to ``(not (f x))``.
-
-.. code-block:: hy
+inverted. So, ``((complement f) x)`` is equivalent to ``(not (f x))``.::
 
    => (setv inverse (complement identity))
    => (inverse True)
@@ -105,9 +97,7 @@ cons
 
 Usage: ``(cons a b)``
 
-Returns a fresh :ref:`cons cell <hycons>` with car *a* and cdr *b*.
-
-.. code-block:: hy
+Returns a fresh :ref:`cons cell <hycons>` with car *a* and cdr *b*.::
 
    => (setv a (cons 'hd 'tl))
 
@@ -125,9 +115,7 @@ cons?
 
 Usage: ``(cons? foo)``
 
-Checks whether *foo* is a :ref:`cons cell <hycons>`.
-
-.. code-block:: hy
+Checks whether *foo* is a :ref:`cons cell <hycons>`.::
 
    => (setv a (cons 'hd 'tl))
 
@@ -151,9 +139,7 @@ constantly
 Usage ``(constantly 42)``
 
 Create a new function that always returns the given value, regardless of
-the arguments given to it.
-
-.. code-block:: hy
+the arguments given to it.::
 
    => (setv answer (constantly 42))
    => (answer)
@@ -172,9 +158,7 @@ dec
 Usage: ``(dec x)``
 
 Returns one less than *x*. Equivalent to ``(- x 1)``. Raises ``TypeError``
-if ``(not (numeric? x))``.
-
-.. code-block:: hy
+if ``(not (numeric? x))``.::
 
    => (dec 3)
    2
@@ -196,9 +180,7 @@ disassemble
 Usage: ``(disassemble tree &optional [codegen false])``
 
 Dump the Python AST for given Hy *tree* to standard output. If *codegen*
-is ``True``, the function prints Python code instead.
-
-.. code-block:: hy
+is ``True``, the function prints Python code instead.::
 
    => (disassemble '(print "Hello World!"))
    Module(
@@ -216,9 +198,7 @@ empty?
 
 Usage: ``(empty? coll)``
 
-Returns ``True`` if *coll* is empty. Equivalent to ``(= 0 (len coll))``.
-
-.. code-block:: hy
+Returns ``True`` if *coll* is empty. Equivalent to ``(= 0 (len coll))``.::
 
    => (empty? [])
    True
@@ -238,17 +218,13 @@ eval
 ``eval`` evaluates a quoted expression and returns the value. The optional
 second and third arguments specify the dictionary of globals to use and the
 module name. The globals dictionary defaults to ``(local)`` and the module name
-defaults to the name of the current module.
-
-.. code-block:: clj
+defaults to the name of the current module.::
 
    => (eval '(print "Hello World"))
    "Hello World"
 
 If you want to evaluate a string, use ``read-str`` to convert it to a
-form first:
-
-.. code-block:: clj
+form first:::
 
    => (eval (read-str "(+ 1 1)"))
    2
@@ -264,9 +240,7 @@ every?
 Usage: ``(every? pred coll)``
 
 Returns ``True`` if ``(pred x)`` is logical true for every *x* in *coll*,
-otherwise ``False``. Return ``True`` if *coll* is empty.
-
-.. code-block:: hy
+otherwise ``False``. Return ``True`` if *coll* is empty.::
 
    => (every? even? [2 4 6])
    True
@@ -286,9 +260,7 @@ otherwise ``False``. Return ``True`` if *coll* is empty.
 exec
 ----
 
-Equivalent to Python 3's built-in function :py:func:`exec`.
-
-.. code-block:: clj
+Equivalent to Python 3's built-in function :py:func:`exec`.::
 
     => (exec "print(a + b)" {"a" 1} {"b" 2})
     3
@@ -301,9 +273,7 @@ float?
 
 Usage: ``(float? x)``
 
-Returns ``True`` if *x* is a float.
-
-.. code-block:: hy
+Returns ``True`` if *x* is a float.::
 
    => (float? 3.2)
    True
@@ -317,16 +287,12 @@ Returns ``True`` if *x* is a float.
 fraction
 --------
 
-Returns a Python object of type ``fractions.Fraction``.
-
-.. code-block:: hy
+Returns a Python object of type ``fractions.Fraction``.::
 
    => (fraction 1 2)
    Fraction(1, 2)
 
-Note that Hy has a built-in fraction literal that does the same thing:
-
-.. code-block:: hy
+Note that Hy has a built-in fraction literal that does the same thing:::
 
    => 1/2
    Fraction(1, 2)
@@ -340,9 +306,7 @@ even?
 Usage: ``(even? x)``
 
 Returns ``True`` if *x* is even. Raises ``TypeError`` if
-``(not (numeric? x))``.
-
-.. code-block:: hy
+``(not (numeric? x))``.::
 
    => (even? 2)
    True
@@ -361,9 +325,7 @@ identity
 
 Usage: ``(identity x)``
 
-Returns the argument supplied to the function.
-
-.. code-block:: hy
+Returns the argument supplied to the function.::
 
    => (identity 4)
    4
@@ -380,9 +342,7 @@ inc
 Usage: ``(inc x)``
 
 Returns one more than *x*. Equivalent to ``(+ x 1)``. Raises ``TypeError``
-if ``(not (numeric? x))``.
-
-.. code-block:: hy
+if ``(not (numeric? x))``.::
 
    => (inc 3)
    4
@@ -401,9 +361,7 @@ instance?
 
 Usage: ``(instance? class x)``
 
-Returns ``True`` if *x* is an instance of *class*.
-
-.. code-block:: hy
+Returns ``True`` if *x* is an instance of *class*.::
 
    => (instance? float 1.0)
    True
@@ -427,9 +385,7 @@ integer?
 Usage: ``(integer? x)``
 
 Returns `True` if *x* is an integer. For Python 2, this is
-either ``int`` or ``long``. For Python 3, this is ``int``.
-
-.. code-block:: hy
+either ``int`` or ``long``. For Python 3, this is ``int``.::
 
    => (integer? 3)
    True
@@ -448,9 +404,7 @@ interleave
 Usage: ``(interleave seq1 seq2 ...)``
 
 Returns an iterable of the first item in each of the sequences,
-then the second, etc.
-
-.. code-block:: hy
+then the second, etc.::
 
    => (list (interleave (range 5) (range 100 105)))
    [0, 100, 1, 101, 2, 102, 3, 103, 4, 104]
@@ -468,9 +422,7 @@ interpose
 
 Usage: ``(interpose item seq)``
 
-Returns an iterable of the elements of the sequence separated by the item.
-
-.. code-block:: hy
+Returns an iterable of the elements of the sequence separated by the item.::
 
    => (list (interpose "!" "abcd"))
    ['a', '!', 'b', '!', 'c', '!', 'd']
@@ -487,9 +439,7 @@ iterable?
 Usage: ``(iterable? x)``
 
 Returns ``True`` if *x* is iterable. Iterable objects return a new iterator
-when ``(iter x)`` is called. Contrast with :ref:`iterator?-fn`.
-
-.. code-block:: hy
+when ``(iter x)`` is called. Contrast with :ref:`iterator?-fn`.::
 
    => ;; works for strings
    => (iterable? (str "abcde"))
@@ -521,9 +471,7 @@ Usage: ``(iterator? x)``
 
 Returns ``True`` if *x* is an iterator. Iterators are objects that return
 themselves as an iterator when ``(iter x)`` is called. Contrast with
-:ref:`iterable?-fn`.
-
-.. code-block:: hy
+:ref:`iterable?-fn`.::
 
    => ;; doesn't work for a list
    => (iterator? [1 2 3 4 5])
@@ -552,9 +500,7 @@ juxt
 Usage: ``(juxt f &rest fs)``
 
 Return a function that applies each of the supplied functions to a
-single set of arguments and collects the results into a list.
-
-.. code-block:: hy
+single set of arguments and collects the results into a list.::
 
    => ((juxt min max sum) (range 1 101))
    [1, 100, 5050]
@@ -576,9 +522,7 @@ keyword
 Usage: ``(keyword "foo")``
 
 Create a keyword from the given value. Strings, numbers, and even
-objects with the `__name__` magic will work.
-
-.. code-block:: hy
+objects with the `__name__` magic will work.::
 
    => (keyword "foo")
    u'\ufdd0:foo'
@@ -595,9 +539,7 @@ keyword?
 
 Usage: ``(keyword? foo)``
 
-Check whether *foo* is a :ref:`keyword<HyKeyword>`.
-
-.. code-block:: hy
+Check whether *foo* is a :ref:`keyword<HyKeyword>`.::
 
    => (keyword? :foo)
    True
@@ -614,9 +556,7 @@ list*
 Usage: ``(list* head &rest tail)``
 
 Generates a chain of nested cons cells (a dotted list) containing the
-arguments. If the argument list only has one element, return it.
-
-.. code-block:: hy
+arguments. If the argument list only has one element, return it.::
 
     => (list* 1 2 3 4)
     <HyCons (
@@ -651,9 +591,7 @@ macroexpand
 
 Usage: ``(macroexpand form)``
 
-Returns the full macro expansion of *form*.
-
-.. code-block:: hy
+Returns the full macro expansion of *form*.::
 
     => (macroexpand '(-> (a b) (x y)))
     HyExpression([
@@ -682,9 +620,7 @@ macroexpand-1
 
 Usage: ``(macroexpand-1 form)``
 
-Returns the single step macro expansion of *form*.
-
-.. code-block:: hy
+Returns the single step macro expansion of *form*.::
 
     => (macroexpand-1 '(-> (a b) (-> (c d) (e f))))
     HyExpression([
@@ -707,9 +643,7 @@ mangle
 Usage: ``(mangle x)``
 
 Stringify the input and translate it according to :ref:`Hy's mangling rules
-<mangling>`.
-
-.. code-block:: hylang
+<mangling>`.::
 
     => (mangle "foo-bar")
     'foo_bar'
@@ -726,9 +660,7 @@ Usage: ``(merge-with f &rest maps)``
 Returns a map that consist of the rest of the maps joined onto first.
 If a key occurs in more than one map, the mapping(s) from the latter
 (left-to-right) will be combined with the mapping in the result by
-calling ``(f val-in-result val-in-latter)``.
-
-.. code-block:: hy
+calling ``(f val-in-result val-in-latter)``.::
 
     => (merge-with (fn [x y] (+ x y)) {"a" 10 "b" 20} {"a" 1 "c" 30})
     {u'a': 11L, u'c': 30L, u'b': 20L}
@@ -745,9 +677,7 @@ Usage: ``(name :keyword)``
 
 Convert the given value to a string. Keyword special character will be
 stripped. Strings will be used as is. Even objects with the `__name__`
-magic will work.
-
-.. code-block:: hy
+magic will work.::
 
    => (name :foo)
    u'foo'
@@ -760,9 +690,7 @@ neg?
 Usage: ``(neg? x)``
 
 Returns ``True`` if *x* is less than zero. Raises ``TypeError`` if
-``(not (numeric? x))``.
-
-.. code-block:: hy
+``(not (numeric? x))``.::
 
    => (neg? -2)
    True
@@ -780,9 +708,7 @@ none?
 
 Usage: ``(none? x)``
 
-Returns ``True`` if *x* is ``None``.
-
-.. code-block:: hy
+Returns ``True`` if *x* is ``None``.::
 
    => (none? None)
    True
@@ -808,9 +734,7 @@ Usage: ``(nth coll n &optional [default None])``
 
 Returns the *n*-th item in a collection, counting from 0. Return the
 default value, ``None``, if out of bounds (unless specified otherwise).
-Raises ``ValueError`` if *n* is negative.
-
-.. code-block:: hy
+Raises ``ValueError`` if *n* is negative.::
 
    => (nth [1 2 4 7] 1)
    2
@@ -841,9 +765,7 @@ numeric?
 Usage: ``(numeric? x)``
 
 Returns ``True`` if *x* is a numeric, as defined in Python's
-``numbers.Number`` class.
-
-.. code-block:: hy
+``numbers.Number`` class.::
 
    => (numeric? -2)
    True
@@ -863,9 +785,7 @@ odd?
 Usage: ``(odd? x)``
 
 Returns ``True`` if *x* is odd. Raises ``TypeError`` if
-``(not (numeric? x))``.
-
-.. code-block:: hy
+``(not (numeric? x))``.::
 
    => (odd? 13)
    True
@@ -883,25 +803,19 @@ partition
 
 Usage: ``(partition coll [n] [step] [fillvalue])``
 
-Chunks *coll* into *n*-tuples (pairs by default).
-
-.. code-block:: hy
+Chunks *coll* into *n*-tuples (pairs by default).::
 
     => (list (partition (range 10)))  ; n=2
     [(0, 1), (2, 3), (4, 5), (6, 7), (8, 9)]
 
-The *step* defaults to *n*, but can be more to skip elements, or less for a sliding window with overlap.
-
-.. code-block:: hy
+The *step* defaults to *n*, but can be more to skip elements, or less for a sliding window with overlap.::
 
     => (list (partition (range 10) 2 3))
     [(0, 1), (3, 4), (6, 7)]
     => (list (partition (range 5) 2 1))
     [(0, 1), (1, 2), (2, 3), (3, 4)]
 
-The remainder, if any, is not included unless a *fillvalue* is specified.
-
-.. code-block:: hy
+The remainder, if any, is not included unless a *fillvalue* is specified.::
 
     => (list (partition (range 10) 3))
     [(0, 1, 2), (3, 4, 5), (6, 7, 8)]
@@ -916,9 +830,7 @@ pos?
 Usage: ``(pos? x)``
 
 Returns ``True`` if *x* is greater than zero. Raises ``TypeError``
-if ``(not (numeric? x))``.
-
-.. code-block:: hy
+if ``(not (numeric? x))``.::
 
    => (pos? 3)
    True
@@ -937,9 +849,7 @@ second
 
 Usage: ``(second coll)``
 
-Returns the second member of *coll*. Equivalent to ``(get coll 1)``.
-
-.. code-block:: hy
+Returns the second member of *coll*. Equivalent to ``(get coll 1)``.::
 
    => (second [0 1 2])
    1
@@ -955,9 +865,7 @@ some
 Usage: ``(some pred coll)``
 
 Returns the first logically-true value of ``(pred x)`` for any ``x`` in
-*coll*, otherwise ``None``. Return ``None`` if *coll* is empty.
-
-.. code-block:: hy
+*coll*, otherwise ``None``. Return ``None`` if *coll* is empty.::
 
    => (some even? [2 4 6])
    True
@@ -982,9 +890,7 @@ string?
 
 Usage: ``(string? x)``
 
-Returns ``True`` if *x* is a string.
-
-.. code-block:: hy
+Returns ``True`` if *x* is a string.::
 
    => (string? "foo")
    True
@@ -999,9 +905,7 @@ symbol?
 
 Usage: ``(symbol? x)``
 
-Returns ``True`` if *x* is a symbol.
-
-.. code-block:: hy
+Returns ``True`` if *x* is a symbol.::
 
    => (symbol? 'foo)
    True
@@ -1016,9 +920,7 @@ zero?
 
 Usage: ``(zero? x)``
 
-Returns ``True`` if *x* is zero.
-
-.. code-block:: hy
+Returns ``True`` if *x* is zero.::
 
    => (zero? 3)
    False
@@ -1039,9 +941,7 @@ a list or similar container. They do this by returning a Python
 iterator.
 
 We can use the canonical infinite Fibonacci number generator
-as an example of how to use some of these functions.
-
-.. code-block:: hy
+as an example of how to use some of these functions.::
 
    (defn fib []
      (setv a 0)
@@ -1051,9 +951,7 @@ as an example of how to use some of these functions.
        (setv (, a b) (, b (+ a b)))))
 
 
-Note the ``(while True ...)`` loop. If we run this in the REPL,
-
-.. code-block:: hy
+Note the ``(while True ...)`` loop. If we run this in the REPL,::
 
    => (fib)
    <generator object fib at 0x101e642d0>
@@ -1062,26 +960,20 @@ Note the ``(while True ...)`` loop. If we run this in the REPL,
 Calling the function only returns an iterator, but does no
 work until we consume it. Trying something like this is not recommend as
 the infinite loop will run until it consumes all available RAM, or
-in this case until I killed it.
-
-.. code-block:: hy
+in this case until I killed it.::
 
    => (list (fib))
    [1]    91474 killed     hy
 
 
 To get the first 10 Fibonacci numbers, use :ref:`take-fn`. Note that
-:ref:`take-fn` also returns a generator, so I create a list from it.
-
-.. code-block:: hy
+:ref:`take-fn` also returns a generator, so I create a list from it.::
 
    => (list (take 10 (fib)))
    [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
 
 
-To get the Fibonacci number at index 9, (starting from 0):
-
-.. code-block:: hy
+To get the Fibonacci number at index 9, (starting from 0):::
 
    => (nth (fib) 9)
    34
@@ -1094,9 +986,7 @@ cycle
 
 Usage: ``(cycle coll)``
 
-Returns an infinite iterator of the members of coll.
-
-.. code-block:: clj
+Returns an infinite iterator of the members of coll.::
 
    => (list (take 7 (cycle [1 2 3])))
    [1, 2, 3, 1, 2, 3, 1]
@@ -1112,9 +1002,7 @@ distinct
 
 Usage: ``(distinct coll)``
 
-Returns an iterator containing only the unique members in *coll*.
-
-.. code-block:: hy
+Returns an iterator containing only the unique members in *coll*.::
 
    => (list (distinct [ 1 2 3 4 3 5 2 ]))
    [1, 2, 3, 4, 5]
@@ -1134,9 +1022,7 @@ drop
 Usage: ``(drop n coll)``
 
 Returns an iterator, skipping the first *n* members of *coll*.
-Raises ``ValueError`` if *n* is negative.
-
-.. code-block:: hy
+Raises ``ValueError`` if *n* is negative.::
 
    => (list (drop 2 [1 2 3 4 5]))
    [3, 4, 5]
@@ -1159,9 +1045,7 @@ drop-last
 Usage: ``(drop-last n coll)``
 
 Returns an iterator of all but the last *n* items in *coll*. Raises
-``ValueError`` if *n* is negative.
-
-.. code-block:: hy
+``ValueError`` if *n* is negative.::
 
    => (list (drop-last 5 (range 10 20)))
    [10, 11, 12, 13, 14]
@@ -1183,9 +1067,7 @@ drop-while
 
 Usage: ``(drop-while pred coll)``
 
-Returns an iterator, skipping members of *coll* until *pred* is ``False``.
-
-.. code-block:: hy
+Returns an iterator, skipping members of *coll* until *pred* is ``False``.::
 
    => (list (drop-while even? [2 4 7 8 9]))
    [7, 8, 9]
@@ -1206,9 +1088,7 @@ Usage: ``(filter pred coll)``
 
 Returns an iterator for all items in *coll* that pass the predicate *pred*.
 
-See also :ref:`remove-fn`.
-
-.. code-block:: hy
+See also :ref:`remove-fn`.::
 
    => (list (filter pos? [1 2 3 -4 5 -7]))
    [1, 2, 3, 5]
@@ -1226,9 +1106,7 @@ flatten
 Usage: ``(flatten coll)``
 
 Returns a single list of all the items in *coll*, by flattening all
-contained lists and/or tuples.
-
-.. code-block:: hy
+contained lists and/or tuples.::
 
    => (flatten [1 2 [3 4] 5])
    [1, 2, 3, 4, 5]
@@ -1244,9 +1122,7 @@ iterate
 
 Usage: ``(iterate fn x)``
 
-Returns an iterator of *x*, *fn(x)*, *fn(fn(x))*, etc.
-
-.. code-block:: hy
+Returns an iterator of *x*, *fn(x)*, *fn(fn(x))*, etc.::
 
    => (list (take 5 (iterate inc 5)))
    [5, 6, 7, 8, 9]
@@ -1264,9 +1140,7 @@ Usage: ``(read &optional [from-file eof])``
 
 Reads the next Hy expression from *from-file* (defaulting to ``sys.stdin``), and
 can take a single byte as EOF (defaults to an empty string). Raises ``EOFError``
-if *from-file* ends before a complete expression can be parsed.
-
-.. code-block:: hy
+if *from-file* ends before a complete expression can be parsed.::
 
     => (read)
     (+ 2 2)
@@ -1312,9 +1186,7 @@ read-str
 Usage: ``(read-str "string")``
 
 This is essentially a wrapper around `read` which reads expressions from a
-string:
-
-.. code-block:: hy
+string:::
 
     => (read-str "(print 1)")
     HyExpression([
@@ -1333,9 +1205,7 @@ Usage: ``(remove pred coll)``
 Returns an iterator from *coll* with elements that pass the
 predicate, *pred*, removed.
 
-See also :ref:`filter-fn`.
-
-.. code-block:: hy
+See also :ref:`filter-fn`.::
 
    => (list (remove odd? [1 2 3 4 5 6 7]))
    [2, 4, 6]
@@ -1355,9 +1225,7 @@ repeat
 
 Usage: ``(repeat x)``
 
-Returns an iterator (infinite) of ``x``.
-
-.. code-block:: hy
+Returns an iterator (infinite) of ``x``.::
 
    => (list (take 6 (repeat "s")))
    [u's', u's', u's', u's', u's', u's']
@@ -1370,9 +1238,7 @@ repeatedly
 
 Usage: ``(repeatedly fn)``
 
-Returns an iterator by calling *fn* repeatedly.
-
-.. code-block:: hy
+Returns an iterator by calling *fn* repeatedly.::
 
    => (import [random [randint]])
 
@@ -1388,9 +1254,7 @@ take
 Usage: ``(take n coll)``
 
 Returns an iterator containing the first *n* members of *coll*.
-Raises ``ValueError`` if *n* is negative.
-
-.. code-block:: hy
+Raises ``ValueError`` if *n* is negative.::
 
    => (list (take 3 [1 2 3 4 5]))
    [1, 2, 3]
@@ -1408,9 +1272,7 @@ take-nth
 
 Usage: ``(take-nth n coll)``
 
-Returns an iterator containing every *n*-th member of *coll*.
-
-.. code-block:: hy
+Returns an iterator containing every *n*-th member of *coll*.::
 
    => (list (take-nth 2 [1 2 3 4 5 6 7]))
    [1, 3, 5, 7]
@@ -1432,9 +1294,7 @@ take-while
 
 Usage: ``(take-while pred coll)``
 
-Returns an iterator from *coll* as long as *pred* returns ``True``.
-
-.. code-block:: hy
+Returns an iterator from *coll* as long as *pred* returns ``True``.::
 
    => (list (take-while pos? [ 1 2 3 -4 5]))
    [1, 2, 3]
@@ -1454,9 +1314,7 @@ Usage: ``(unmangle x)``
 
 Stringify the input and return a string that would :ref:`mangle <mangling>` to
 it. Note that this isn't a one-to-one operation, and nor is ``mangle``, so
-``mangle`` and ``unmangle`` don't always round-trip.
-
-.. code-block:: hylang
+``mangle`` and ``unmangle`` don't always round-trip.::
 
     => (unmangle "foo_bar")
     'foo-bar'
@@ -1464,11 +1322,46 @@ it. Note that this isn't a one-to-one operation, and nor is ``mangle``, so
 Included itertools
 ==================
 
-count cycle repeat accumulate chain compress drop-while remove group-by islice *map take-while tee zip-longest product permutations combinations multicombinations
----------
-
 All of Python's `itertools <https://docs.python.org/3/library/itertools.html>`_
-are available. Some of their names have been changed:
+are available.
+
+  - ``count``
+
+  - ``cycle``
+
+  - ``repeat``
+
+  - ``accumulate``
+
+  - ``chain``
+
+  - ``compress``
+
+  - ``drop-while``
+
+  - ``remove``
+
+  - ``group-by``
+
+  - ``islice``
+
+  - ``*map``
+
+  - ``take-while``
+
+  - ``tee``
+
+  - ``zip-longest``
+
+  - ``product``
+
+  - ``permutations``
+
+  - ``combinations``
+
+  - ``multicombinations``
+
+Note that some of their names have been changed:
 
   - ``starmap`` has been changed to ``*map``
 
@@ -1477,8 +1370,7 @@ are available. Some of their names have been changed:
   - ``groupby`` has been changed to ``group-by``
 
   - ``takewhile`` has been changed to ``take-while``
-  
-  - ``dropwhile`` has been changed to ``drop-while``
-  
-  - ``filterfalse`` has been changed to ``remove``
 
+  - ``dropwhile`` has been changed to ``drop-while``
+
+  - ``filterfalse`` has been changed to ``remove``

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -340,7 +340,9 @@ As example, the Hy::
 
     (print (if True True False))
 
-Will turn into::
+Will turn into
+
+.. code-block:: python
 
     if True:
         _temp_name_here = True
@@ -383,9 +385,7 @@ for a more complete description.) ``nif`` is an example, something like a numeri
 where based on the expression, one of the 3 forms is called depending on if the
 expression is positive, zero or negative.
 
-A first pass might be something like:
-
-.. code-block:: hy
+A first pass might be something like:::
 
    (defmacro nif [expr pos-form zero-form neg-form]
      `(do
@@ -399,9 +399,7 @@ conflict with other code. But of course, while well-intentioned,
 this is no guarantee.
 
 The method :ref:`gensym` is designed to generate a new, unique symbol for just
-such an occasion. A much better version of ``nif`` would be:
-
-.. code-block:: hy
+such an occasion. A much better version of ``nif`` would be:::
 
    (defmacro nif [expr pos-form zero-form neg-form]
      (setv g (gensym))
@@ -413,16 +411,12 @@ such an occasion. A much better version of ``nif`` would be:
 
 This is an easy case, since there is only one symbol. But if there is
 a need for several gensym's there is a second macro :ref:`with-gensyms` that
-basically expands to a ``setv`` form:
-
-.. code-block:: hy
+basically expands to a ``setv`` form:::
 
    (with-gensyms [a b c]
      ...)
 
-expands to:
-
-.. code-block:: hy
+expands to:::
 
    (do
      (setv a (gensym)
@@ -430,9 +424,7 @@ expands to:
            c (gensym))
      ...)
 
-so our re-written ``nif`` would look like:
-
-.. code-block:: hy
+so our re-written ``nif`` would look like:::
 
    (defmacro nif [expr pos-form zero-form neg-form]
      (with-gensyms [g]
@@ -445,9 +437,7 @@ Finally, though we can make a new macro that does all this for us. :ref:`defmacr
 will take all symbols that begin with ``g!`` and automatically call ``gensym`` with the
 remainder of the symbol. So ``g!a`` would become ``(gensym "a")``.
 
-Our final version of ``nif``, built with ``defmacro/g!`` becomes:
-
-.. code-block:: hy
+Our final version of ``nif``, built with ``defmacro/g!`` becomes:::
 
    (defmacro/g! nif [expr pos-form zero-form neg-form]
      `(do

--- a/docs/language/interop.rst
+++ b/docs/language/interop.rst
@@ -19,14 +19,14 @@ Using Python from Hy
 
 Using Python from Hy is nice and easy, you just have to :ref:`import` it.
 
-If you have the following in ``greetings.py`` in Python::
+If you have the following in ``greetings.py`` in Python
+
+.. code-block:: python
 
     def greet(name):
         print("hello," name)
 
-You can use it in Hy:
-
-.. code-block:: clj
+You can use it in Hy:::
 
     (import greetings)
     (.greet greetings "foo") ; prints "hello, foo"
@@ -43,9 +43,7 @@ with somebody else, who doesn't like Hy (!), and only uses Python.
 In any case, you need to know how to use Hy from Python. Fear not, for it is
 easy.
 
-If you save the following in ``greetings.hy``:
-
-.. code-block:: clj
+If you save the following in ``greetings.hy``:::
 
     (setv *this-will-be-in-caps-and-underscores* "See?")
     (defn greet [name] (print "hello from hy," name))

--- a/docs/language/syntax.rst
+++ b/docs/language/syntax.rst
@@ -11,17 +11,13 @@ numeric literals
 ----------------
 
 In addition to regular numbers, standard notation from Python 3 for non-base 10
-integers is used. ``0x`` for Hex, ``0o`` for Octal, ``0b`` for Binary.
-
-.. code-block:: clj
+integers is used. ``0x`` for Hex, ``0o`` for Octal, ``0b`` for Binary.::
     
     (print 0x80 0b11101 0o102 30)
 
 Underscores and commas can appear anywhere in a numeric literal except the very
 beginning. They have no effect on the value of the literal, but they're useful
-for visually separating digits.
-
-.. code-block:: clj
+for visually separating digits.::
 
     (print 10,000,000,000 10_000_000_000)
 
@@ -139,9 +135,7 @@ This completely removes the form so it doesn't evaluate to anything,
 not even None.
 It's often more useful than linewise comments for commenting out a
 form, because it respects code structure even when part of another
-form is on the same line. For example:
-
-.. code-block:: clj
+form is on the same line. For example:::
 
    => (print "Hy" "cruel" "World!")
    Hy cruel World!

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -54,9 +54,7 @@ Layout & Indentation
 + Avoid trailing spaces. They suck!
 
 + Indentation shall be 2 spaces (no hard tabs), except when matching
-  the indentation of the previous line.
-
-  .. code-block:: clj
+  the indentation of the previous line.::
 
      ;; Good (and preferred)
      (defn fib [n]
@@ -82,9 +80,7 @@ Layout & Indentation
 
 
 + Parentheses must *never* be left alone, sad and lonesome on their own
-  line.
-
-  .. code-block:: clj
+  line.::
 
     ;; Good (and preferred)
     (defn fib [n]
@@ -103,9 +99,7 @@ Layout & Indentation
 
 + Inline comments shall be two spaces from the end of the code; they
   must always have a space between the comment character and the start
-  of the comment. Also, try to not comment the obvious.
-
-.. code-block:: clj
+  of the comment. Also, try to not comment the obvious.::
 
    ;; Good
    (setv ind (dec x))  ; indexing starts from 0
@@ -123,9 +117,7 @@ Coding Style
 + Do not use s-expression syntax where vector syntax is intended.
   For instance, the fact that the former of these two examples works
   is just because the compiler isn't overly strict. In reality, the
-  correct syntax in places such as this is the latter.
-
-  .. code-block:: clj
+  correct syntax in places such as this is the latter.::
 
      ;; Bad (and evil)
      (defn foo (x) (print x))
@@ -139,9 +131,7 @@ Coding Style
 + Use the threading macro or the threading tail macros when encountering
   deeply nested s-expressions. However, be judicious when using them. Do
   use them when clarity and readability improves; do not construct
-  convoluted, hard to understand expressions.
-
-  .. code-block:: clj
+  convoluted, hard to understand expressions.::
 
      ;; Preferred
      (setv *names*
@@ -159,9 +149,7 @@ Coding Style
 
 
 + Clojure-style dot notation is preferred over the direct call of
-  the object's method, though both will continue to be supported.
-
-  .. code-block:: clj
+  the object's method, though both will continue to be supported.::
 
      ;; Good
      (with [fd (open "/etc/passwd")]

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -35,9 +35,7 @@ Basic intro to Lisp for Pythonistas
 
 Okay, maybe you've never used Lisp before, but you've used Python!
 
-A "hello world" program in Hy is actually super simple. Let's try it:
-
-.. code-block:: clj
+A "hello world" program in Hy is actually super simple. Let's try it:::
 
    (print "hello world")
 
@@ -46,24 +44,18 @@ version of::
 
   print("hello world")
 
-To add up some super simple math, we could do:
-
-.. code-block:: clj
+To add up some super simple math, we could do:::
 
    (+ 1 3)
 
-Which would return 4 and would be the equivalent of:
-
-.. code-block:: clj
+Which would return 4 and would be the equivalent of:::
 
    1 + 3
 
 What you'll notice is that the first item in the list is the function
 being called and the rest of the arguments are the arguments being
 passed in.  In fact, in Hy (as with most Lisps) we can pass in
-multiple arguments to the plus operator:
-
-.. code-block:: clj
+multiple arguments to the plus operator:::
 
    (+ 1 3 55)
 
@@ -75,9 +67,7 @@ is a great way to start learning Lisp.  The main thing that's obvious
 about Lisp is that there's a lot of parentheses.  This might seem
 confusing at first, but it isn't so hard.  Let's look at some simple
 math that's wrapped in a bunch of parentheses that we could enter into
-the Hy interpreter:
-
-.. code-block:: clj
+the Hy interpreter:::
 
    (setv result (- (/ (+ 1 3 88) 2) 8))
 
@@ -99,9 +89,7 @@ exercise first in Python::
   # simplified to...
   result = 38.0
 
-Now let's try the same thing in Hy:
-
-.. code-block:: clj
+Now let's try the same thing in Hy:::
 
    (setv result (- (/ (+ 1 3 88) 2) 8))
    ; simplified to...
@@ -123,7 +111,9 @@ imagine the entire same structure as above but with square brackets
 instead, any you'll be able to see the structure above as both a
 program and a data structure.)  This is easier to understand with more
 examples, so let's write a simple Python program, test it, and then
-show the equivalent Hy program::
+show the equivalent Hy program
+
+.. code-block:: python
 
   def simple_conversation():
       print("Hello!  I'd like to get to know you.  Tell me about yourself!")
@@ -133,16 +123,16 @@ show the equivalent Hy program::
 
   simple_conversation()
 
-If we ran this program, it might go like::
+If we ran this program, it might go like
+
+.. code-block:: none
 
   Hello!  I'd like to get to know you.  Tell me about yourself!
   What is your name? Gary
   What is your age? 38
   Hello Gary!  I see you are 38 years old.
 
-Now let's look at the equivalent Hy program:
-
-.. code-block:: clj
+Now let's look at the equivalent Hy program:::
 
    (defn simple-conversation []
       (print "Hello!  I'd like to get to know you.  Tell me about yourself!")
@@ -221,9 +211,7 @@ Hy syntax rather than Python syntax::
   {"dog" "bark" "cat" "meow"}
 
 If you are familiar with other Lisps, you may be interested that Hy
-supports the Common Lisp method of quoting:
-
-.. code-block:: clj
+supports the Common Lisp method of quoting:::
 
    => '(1 2 3)
    (1 2 3)
@@ -238,16 +226,12 @@ What's this?  Yes indeed, this is precisely the same as::
   " fooooo   ".strip()
 
 That's right---Lisp with dot notation!  If we have this string
-assigned as a variable, we can also do the following:
-
-.. code-block:: clj
+assigned as a variable, we can also do the following:::
 
    (setv this-string " fooooo   ")
    (this-string.strip)
 
-What about conditionals?:
-
-.. code-block:: clj
+What about conditionals?:::
 
    (if (try-some-thing)
      (print "this is if true")
@@ -259,7 +243,9 @@ is if false (ie. ``else``).
 
 If you need to do more complex conditionals, you'll find that you
 don't have ``elif`` available in Hy.  Instead, you should use something
-called ``cond``.  In Python, you might do something like::
+called ``cond``.  In Python, you might do something like
+
+.. code-block:: python
 
   somevar = 33
   if somevar > 50:
@@ -269,9 +255,7 @@ called ``cond``.  In Python, you might do something like::
   else:
       print("That variable is jussssst right!")
 
-In Hy, you would do:
-
-.. code-block:: clj
+In Hy, you would do:::
 
    (setv somevar 33)
    (cond
@@ -289,9 +273,7 @@ notice that the ``else`` is implemented at the end simply by checking
 for ``True`` -- that's because ``True`` will always be true, so if we get
 this far, we'll always run that one!
 
-You might notice above that if you have code like:
-
-.. code-block:: clj
+You might notice above that if you have code like:::
 
    (if some-condition
      (body-if-true)
@@ -300,9 +282,7 @@ You might notice above that if you have code like:
 But wait!  What if you want to execute more than one statement in the
 body of one of these?
 
-You can do the following:
-
-.. code-block:: clj
+You can do the following:::
 
    (if (try-some-thing)
      (do
@@ -314,39 +294,33 @@ You can see that we used ``do`` to wrap multiple statements.  If you're
 familiar with other Lisps, this is the equivalent of ``progn``
 elsewhere.
 
-Comments start with semicolons:
-
-.. code-block:: clj
+Comments start with semicolons:::
 
   (print "this will run")
   ; (print "but this will not")
   (+ 1 2 3)  ; we'll execute the addition, but not this comment!
 
-Hashbang (``#!``) syntax is supported:
-
-.. code-block:: clj
+Hashbang (``#!``) syntax is supported:::
 
    #! /usr/bin/env hy
    (print "Make me executable, and run me!")
 
 Looping is not hard but has a kind of special structure.  In Python,
-we might do::
+we might do
+
+.. code-block:: python
 
   for i in range(10):
       print("'i' is now at " + str(i))
 
-The equivalent in Hy would be:
-
-.. code-block:: clj
+The equivalent in Hy would be:::
 
   (for [i (range 10)]
     (print (+ "'i' is now at " (str i))))
 
 
 You can also import and make use of various Python libraries.  For
-example:
-
-.. code-block:: clj
+example:::
 
    (import os)
 
@@ -354,14 +328,14 @@ example:
      (os.mkdir "/tmp/somedir/anotherdir")
      (print "Hey, that path isn't there!"))
 
-Python's context managers (``with`` statements) are used like this:
-
-.. code-block:: clj
+Python's context managers (``with`` statements) are used like this:::
 
      (with [f (open "/tmp/data.in")]
        (print (.read f)))
 
-which is equivalent to::
+which is equivalent to
+
+.. code-block:: python
 
   with open("/tmp/data.in") as f:
       print(f.read())
@@ -373,9 +347,7 @@ And yes, we do have List comprehensions!  In Python you might do::
     for num in range(100)
     if num % 2 == 1]
 
-In Hy, you could do these like:
-
-.. code-block:: clj
+In Hy, you could do these like:::
 
   (setv odds-squared
     (list-comp
@@ -383,8 +355,7 @@ In Hy, you could do these like:
       (num (range 100))
       (= (% num 2) 1)))
 
-
-.. code-block:: clj
+::
 
   ; And, an example stolen shamelessly from a Clojure page:
   ; Let's list all the blocks of a Chessboard:
@@ -405,7 +376,9 @@ In Hy, you could do these like:
 
 
 Python has support for various fancy argument and keyword arguments.
-In Python we might see::
+In Python we might see
+
+.. code-block:: python
 
   >>> def optional_arg(pos1, pos2, keyword1=None, keyword2=42):
   ...   return [pos1, pos2, keyword1, keyword2]
@@ -444,9 +417,7 @@ similar to `*args` and `**kwargs` in Python::
   [1, 2, 4, 3]
 
 There's also a dictionary-style keyword arguments construction that
-looks like:
-
-.. code-block:: clj
+looks like:::
 
   (defn another-style [&key {"key1" "val1" "key2" "val2"}]
     [key1 key2])
@@ -454,22 +425,24 @@ looks like:
 The difference here is that since it's a dictionary, you can't rely on
 any specific ordering to the arguments.
 
-Hy also supports ``*args`` and ``**kwargs`` in parameter lists.  In Python::
+Hy also supports ``*args`` and ``**kwargs`` in parameter lists.  In Python
+
+.. code-block:: python
 
   def some_func(foo, bar, *args, **kwargs):
     import pprint
     pprint.pprint((foo, bar, args, kwargs))
 
-The Hy equivalent:
-
-.. code-block:: clj
+The Hy equivalent:::
 
   (defn some-func [foo bar &rest args &kwargs kwargs]
     (import pprint)
     (pprint.pprint (, foo bar args kwargs)))
 
 Finally, of course we need classes!  In Python, we might have a class
-like::
+like
+
+.. code-block:: python
 
   class FooBar(object):
       """
@@ -490,9 +463,7 @@ And we might use it like::
   print(bar.get_x())
 
 
-In Hy:
-
-.. code-block:: clj
+In Hy:::
 
   (defclass FooBar [object]
     "Yet Another Example Class"
@@ -504,30 +475,26 @@ In Hy:
       "Return our copy of x"
       self.x))
       
-And we can use it like:
-
-.. code-block:: clj
+And we can use it like:::
 
   (setv bar (FooBar 1))
   (print (bar.get-x))
   
-Or using the leading dot syntax!
-
-.. code-block:: clj
+Or using the leading dot syntax!::
 
   (print (.get-x (FooBar 1)))
       
 
-You can also do class-level attributes.  In Python::
+You can also do class-level attributes.  In Python
+
+.. code-block:: python
 
   class Customer(models.Model):
       name = models.CharField(max_length=255)
       address = models.TextField()
       notes = models.TextField()
 
-In Hy:
-
-.. code-block:: clj
+In Hy:::
 
   (defclass Customer [models.Model]
     [name (models.CharField :max-length 255})
@@ -540,9 +507,7 @@ Macros
 One really powerful feature of Hy are macros. They are small functions that are
 used to generate code (or data). When program written in Hy is started, the
 macros are executed and their output is placed in the program source. After this,
-the program starts executing normally. Very simple example:
-
-.. code-block:: clj
+the program starts executing normally. Very simple example:::
 
   => (defmacro hello [person]
   ...  `(print "Hello there," ~person))
@@ -552,15 +517,11 @@ the program starts executing normally. Very simple example:
 The thing to notice here is that hello macro doesn't output anything on
 screen. Instead it creates piece of code that is then executed and prints on
 screen. This macro writes a piece of program that looks like this (provided that
-we used "Tuukka" as parameter):
-
-.. code-block:: clj
+we used "Tuukka" as parameter):::
 
   (print "Hello there," "Tuukka")
 
-We can also manipulate code with macros:
-
-.. code-block:: clj
+We can also manipulate code with macros:::
 
   => (defmacro rev [code]
   ...  (setv op (last code) params (list (butlast code)))
@@ -569,18 +530,14 @@ We can also manipulate code with macros:
   6
 
 The code that was generated with this macro just switched around some of the
-elements, so by the time program started executing, it actually reads:
-
-.. code-block:: clj
+elements, so by the time program started executing, it actually reads:::
 
   (+ 1 2 3)
 
 Sometimes it's nice to be able to call a one-parameter macro without
 parentheses. Tag macros allow this. The name of a tag macro is typically
 one character long, but since Hy operates well with Unicode, we aren't running
-out of characters that soon:
-
-.. code-block:: clj
+out of characters that soon:::
 
   => (deftag ↻ [code]
   ...  (setv op (last code) params (list (butlast code)))
@@ -598,9 +555,7 @@ translates to a Python ``import`` statement that's executed at
 run-time, and macros are expanded at compile-time, that is,
 during the translate from Hy to Python. Instead, use ``require``,
 which imports the module and makes macros available at
-compile-time. ``require`` uses the same syntax as ``import``.
-
-.. code-block:: clj
+compile-time. ``require`` uses the same syntax as ``import``.::
 
    => (require tutorial.macros)
    => (tutorial.macros.rev (1 2 3 +))
@@ -614,9 +569,7 @@ Using Hy from Python
 
 You can use Hy modules in Python!
 
-If you save the following in ``greetings.hy``:
-
-.. code-block:: clj
+If you save the following in ``greetings.hy``:::
 
     (defn greet [name] (print "hello from hy," name))
 
@@ -633,14 +586,14 @@ Using Python from Hy
 
 You can also use any Python module in Hy!
 
-If you save the following in ``greetings.py`` in Python::
+If you save the following in ``greetings.py`` in Python
+
+.. code-block:: python
 
     def greet(name):
         print("hello, %s" % (name))
 
-You can use it in Hy (see :ref:`import`):
-
-.. code-block:: clj
+You can use it in Hy (see :ref:`import`):::
 
     (import greetings)
     (.greet greetings "foo")
@@ -658,17 +611,13 @@ to avoid deep nesting of expressions.
 The threading macro inserts each expression into the next expression's first
 argument place.
 
-Let's take the classic:
-
-.. code-block:: clj
+Let's take the classic:::
 
     (require [hy.contrib.loop [loop]])
 
     (loop (print (eval (read))))
 
-Rather than write it like that, we can write it as follows:
-
-.. code-block:: clj
+Rather than write it like that, we can write it as follows:::
 
     (require [hy.contrib.loop [loop]])
 
@@ -676,17 +625,13 @@ Rather than write it like that, we can write it as follows:
 
 Now, using `python-sh <http://amoffat.github.com/sh/>`_, we can show
 how the threading macro (because of python-sh's setup) can be used like
-a pipe:
-
-.. code-block:: clj
+a pipe:::
 
     => (import [sh [cat grep wc]])
     => (-> (cat "/usr/share/dict/words") (grep "-E" "^hy") (wc "-l"))
     210
 
-Which, of course, expands out to:
-
-.. code-block:: clj
+Which, of course, expands out to:::
 
     (wc (grep (cat "/usr/share/dict/words") "-E" "^hy") "-l")
 


### PR DESCRIPTION
Fixes a few warning with documentation formatting.

Change code blocks to `hylang`, now that Pygments has support for Hy. The `hy` specifier is used for a different language. This eliminates a lot of lexing errors and should mean more code blocks have syntax highlighting.

We're still not 100% problem free as it seems like repl output doesn't lex nicely:

```
hy/docs/contrib/walk.rst:48: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/contrib/walk.rst:128: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/extra/anaphoric.rst:246: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:124: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:246: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:340: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:469: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:510: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:876: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:903: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:914: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/api.rst:1781: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/core.rst:557: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/core.rst:717: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/language/core.rst:799: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
hy/docs/tutorial.rst:583: WARNING: Could not lex literal_block as "hylang". Highlighting skipped.
```