### PR TITLE
Cleanup sys.modules after a Hy specific import failure.

### DIFF
--- a/hy/importer.py
+++ b/hy/importer.py
@@ -116,6 +116,7 @@ def import_file_to_module(module_name, fpath, loader=None):
                 with open(fpath, 'rt') as fp:
                     e.source = fp.read()
                 e.filename = fpath
+            sys.modules.pop(module_name, None)
             raise
         except Exception:
             sys.modules.pop(module_name, None)

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -68,6 +68,37 @@ def test_import_autocompiles():
     os.remove(get_bytecode_path(f.name))
 
 
+def test_import_failure_retryable():
+    "Test that a failed import does not prevents from re trying"
+    module_name = "again"
+
+    f = open("again.hy", "wb")
+
+    def _import_test():
+        try:
+            import again
+        except HyTypeError:
+            return "Failed"
+        else:
+            return "Succeeded"
+
+    f.write(b'(import "sys")')
+    f.flush()
+
+    assert _import_test() == "Failed"
+
+    f.seek(0)
+    f.truncate()
+    f.write(b'(import sys)')
+    f.flush()
+
+    assert _import_test() == "Succeeded"
+
+    f.close()
+    os.remove(f.name)
+    os.remove(get_bytecode_path(f.name))
+
+
 def test_eval():
     def eval_str(s):
         return hy.eval(hy.read_str(s))


### PR DESCRIPTION
When there is a HyTypeError or a LexException, the None placeholder inserted in
sys.modules is not removed.  This prevents future import attempts because the
Python import machinery finds the None reference during the "fast path" of the
default importer.

This fixes #1523.