### PR TITLE
Remove obsolete shields in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@ Hy
 ==
 
 [![Build Status](https://img.shields.io/travis/hylang/hy/master.svg)](https://travis-ci.org/hylang/hy)
-[![Downloads](https://img.shields.io/pypi/dm/hy.svg)](https://pypi.python.org/pypi/hy)
 [![Version](https://img.shields.io/pypi/v/hy.svg)](https://pypi.python.org/pypi/hy)
-[![Coverage Status](https://img.shields.io/coveralls/hylang/hy/master.svg)](https://coveralls.io/r/hylang/hy)
 
 <a href="https://xkcd.com/224/"><img title="We lost the documentation on quantum mechanics. You'll have to decode the regexes yourself." alt="XKCD #224" src="https://raw.github.com/hylang/shyte/18f6925e08684b0e1f52b2cc2c803989cd62cd91/imgs/xkcd.png"></a>
 


### PR DESCRIPTION
PyPI shields are "no longer available", and we haven't updated Coveralls since Jaunary 2016.