### PR TITLE
Add pytest plugin

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,6 +18,8 @@ Other Breaking Changes
 
 New Features
 ------------------------------
+* Added a first pytest plugin that teaches pytest how to collect Hy
+  modules
 * Added `mangle` and `unmangle` as core functions
 * `defclass` in Python 3 now supports specifying metaclasses and other
   keyword arguments

--- a/conftest.py
+++ b/conftest.py
@@ -1,15 +1,7 @@
-import pytest
-import hy
-import os
 from hy._compat import PY3, PY35, PY36
 
-NATIVE_TESTS = os.path.join("", "tests", "native_tests", "")
 
-def pytest_collect_file(parent, path):
-    if (path.ext == ".hy"
-            and NATIVE_TESTS in path.dirname + os.sep
-            and path.basename != "__init__.hy"
-            and not ("py3_only" in path.basename and not PY3)
-            and not ("py35_only" in path.basename and not PY35)
-            and not ("py36_only" in path.basename and not PY36)):
-        return pytest.Module(path, parent)
+def pytest_ignore_collect(path, config):
+    return (("py3_only" in path.basename and not PY3)
+            or ("py35_only" in path.basename and not PY35)
+            or ("py36_only" in path.basename and not PY36))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,4 +36,5 @@ Contents:
    language/index
    extra/index
    contrib/index
+   testing
    hacking

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,45 @@
+=======
+Testing
+=======
+
+The Hy package provides a very basic pytest plugin out of the box to
+help testing Hy code.
+
+A simple test function with just four lines of code::
+
+    # content of test_sample.hy
+    (defn func [x]
+      (+ x 1))
+
+    (def test-answer []
+      (assert (func 3) 5))
+
+You can now execute the test function::
+
+    $ pytest
+    =========================== test session starts ============================
+    platform linux -- Python 3.x.y, pytest-3.x.y, py-1.x.y, pluggy-0.x.y
+    rootdir: $REGENDOC_TMPDIR, inifile:
+    plugins: hy-x.y
+    collected 1 item
+
+    test_sample.hy F                                                     [100%]
+
+    ================================= FAILURES =================================
+    _______________________________ test_answer ________________________________
+
+	(defn test-answer []
+    >     (assert (= (func 3) 5)))
+    E     AssertionError
+
+    test_sample.hy:5: AssertionError
+    ========================= 1 failed in 0.12 seconds =========================
+
+This test returns a failure report because ``func(3)`` does not return ``5``.
+
+``pytest`` will run all files of the form test_*.hy or \*_test.hy in
+the current directory and its subdirectories. It will follow the
+`standard test discovery rules
+<https://docs.pytest.org/en/latest/goodpractices.html#test-discovery>`_,
+but that its customized with ``hy_files`` rather than with
+``python_files``.

--- a/hy/pytest_plugin.py
+++ b/hy/pytest_plugin.py
@@ -1,0 +1,21 @@
+import pytest
+import hy  # noqa
+
+
+def pytest_addoption(parser):
+    parser.addini("hy_files", type="args",
+                  default=['test_*.hy', '*_test.hy'],
+                  help="glob-style file patterns for Hy test module discovery")
+
+
+def pytest_collect_file(parent, path):
+    ext = path.ext
+    if ext == ".hy":
+        if not parent.session.isinitpath(path):
+            for pat in parent.config.getini('hy_files'):
+                if path.fnmatch(pat):
+                    break
+            else:
+                return
+        ihook = parent.session.gethookproxy(path)
+        return ihook.pytest_pycollect_makemodule(path=path, parent=parent)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,8 @@ ignore_errors = True
 [tool:pytest]
 # Be sure to include Hy test functions whose names end with "?",
 # which will be mangled to begin with "is_".
-python_functions=test_* is_test_*
+python_functions = test_* is_test_*
+hy_files = tests/native_tests/*.hy
 filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ setup(
             'hyc%d = hy.cmdline:hyc_main' % ver,
             'hy2py = hy.cmdline:hy2py_main',
             'hy2py%d = hy.cmdline:hy2py_main' % ver,
+        ],
+        'pytest11': [
+            'hy = hy.pytest_plugin'
         ]
     },
     packages=find_packages(exclude=['tests*']),

--- a/tests/pytest_plugin/conftest.py
+++ b/tests/pytest_plugin/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ['pytester']

--- a/tests/pytest_plugin/test_plugin.py
+++ b/tests/pytest_plugin/test_plugin.py
@@ -1,0 +1,37 @@
+def test_hy_test(testdir):
+    testdir.makefile(
+        "hy",
+        test_example="""
+            (defn test-func1 [])
+        """)
+
+    result = testdir.runpytest_subprocess()
+    assert result.ret == 0
+
+
+def test_hy_test_with_fixture(testdir):
+    testdir.makefile(
+        "hy",
+        test_example="""
+            (import [pytest [fixture]])
+
+            #@(fixture (defn foobar [] 42))
+
+            (defn test-func1 [foobar]
+              (assert (= foobar 42)))
+        """)
+
+    result = testdir.runpytest_subprocess()
+    assert result.ret == 0
+
+
+def test_hy_test_class(testdir):
+    testdir.makefile(
+        "hy",
+        test_example="""
+            (defclass Tests []
+              (defn test-func1 [self]))
+        """)
+
+    result = testdir.runpytest_subprocess()
+    assert result.ret == 0


### PR DESCRIPTION
Adds a Hy pytest plugin.

With this patch, pytest - though a special Hy plugin - will automatically pick up tests written in Hy. No need to have every project using Hy come up with their own testing solution.

Closes #1526

Now back to the importer...