### PR TITLE
Fix `defclass` validation

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -20,10 +20,8 @@ import hy.inspect
 
 import traceback
 import importlib
-import codecs
 import ast
 import sys
-import keyword
 import copy
 
 from collections import defaultdict

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2033,7 +2033,12 @@ class HyASTCompiler(object):
     def compile_class_expression(self, expressions):
         def rewire_init(expr):
             new_args = []
-            if expr[0] == HySymbol("setv"):
+            if not isinstance(expr, HyExpression):
+                raise HyTypeError(expr,
+                                  "`defclass` expects expressions, received `{}`".format(
+                                      type(expr).__name__))
+
+            if expr and expr[0] == HySymbol("setv"):
                 pairs = expr[1:]
                 while len(pairs) > 0:
                     k, v = (pairs.pop(0), pairs.pop(0))

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -219,6 +219,8 @@ def test_ast_bad_defclass():
     cant_compile("(defclass)")
     cant_compile("(defclass a None)")
     cant_compile("(defclass a None None)")
+    cant_compile("(defclass a [] None 42)")
+    cant_compile("(defclass a [] None \"test\")")
 
 
 def test_ast_good_lambda():


### PR DESCRIPTION
Mostly fixes the problem. This one however sneaks through:

```clj
(defclass Foo [] 'test)
```

Which would be a tricky case to fix. The problem is `defclass` sees it as `(quote test)` so its a valid expression.

Mostly fixes #1533 