### PR TITLE
Fix `defclass`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -27,6 +27,7 @@ Bug Fixes
 ------------------------------
 * Fix `(return)` so it works correctly to exit a Python 2 generator
 * Fixed a case where `->` and `->>` duplicated an argument
+* Fixed bugs that caused `defclass` to drop statements or crash
 
 Misc. Improvements
 ----------------------------

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -20,10 +20,8 @@ import hy.inspect
 
 import traceback
 import importlib
-import codecs
 import ast
 import sys
-import keyword
 import copy
 
 from collections import defaultdict

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2036,7 +2036,10 @@ class HyASTCompiler(object):
     def compile_class_expression(self, expressions):
         def rewire_init(expr):
             new_args = []
-            if expr[0] == HySymbol("setv"):
+            if (isinstance(expr, HyExpression)
+                and len(expr) > 1
+                and isinstance(expr[0], HySymbol)
+                and expr[0] == HySymbol("setv")):
                 pairs = expr[1:]
                 while len(pairs) > 0:
                     k, v = (pairs.pop(0), pairs.pop(0))

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2072,12 +2072,7 @@ class HyASTCompiler(object):
 
         # grab the doc string, if there is one
         if expressions and isinstance(expressions[0], HyString):
-            docstring = expressions.pop(0)
-            symb = HySymbol("__doc__")
-            symb.start_line = docstring.start_line
-            symb.start_column = docstring.start_column
-            body += self._compile_assign(symb, docstring)
-            body += body.expr_as_stmt()
+            body += self.compile(expressions.pop(0)).expr_as_stmt()
 
         if expressions and isinstance(expressions[0], HyList) \
            and not isinstance(expressions[0], HyExpression):
@@ -2088,7 +2083,8 @@ class HyASTCompiler(object):
             body += self.compile(rewire_init(expr))
 
         for expression in expressions:
-            body += self.compile(rewire_init(macroexpand(expression, self)))
+            e = self.compile(rewire_init(macroexpand(expression, self)))
+            body += e + e.expr_as_stmt()
 
         if not body.stmts:
             body += asty.Pass(expressions)

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2071,8 +2071,12 @@ class HyASTCompiler(object):
         body = Result()
 
         # grab the doc string, if there is one
+        docstring = None
         if expressions and isinstance(expressions[0], HyString):
-            body += self.compile(expressions.pop(0)).expr_as_stmt()
+            docstring = expressions.pop(0)
+            if not PY37:
+                body += self.compile(docstring).expr_as_stmt()
+                docstring = None
 
         if expressions and isinstance(expressions[0], HyList) \
            and not isinstance(expressions[0], HyExpression):
@@ -2097,7 +2101,8 @@ class HyASTCompiler(object):
             starargs=None,
             kwargs=None,
             bases=bases_expr,
-            body=body.stmts)
+            body=body.stmts,
+            docstring=(None if docstring is None else str_type(docstring)))
 
     @builds("dispatch-tag-macro")
     @checkargs(exact=2)

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -212,6 +212,9 @@ def test_ast_good_defclass():
     "Make sure AST can compile valid defclass"
     can_compile("(defclass a)")
     can_compile("(defclass a [])")
+    can_compile("(defclass a [] None 42)")
+    can_compile("(defclass a [] None \"test\")")
+    can_compile("(defclass a [] None (print \"foo\"))")
 
 
 @pytest.mark.skipif(not PY3, reason="Python 3 supports class keywords")

--- a/tests/native_tests/defclass.hy
+++ b/tests/native_tests/defclass.hy
@@ -127,3 +127,14 @@
   (setv b (B))
   (assert (= a.x 1))
   (assert (= b.x 2)))
+
+(defn test-class-sideeffects []
+  "NATIVE: test that defclass runs all expressions"
+  (defn set-sentinel []
+    (setv set-sentinel.set True))
+  (setv set-sentinel.set False)
+
+  (defclass A []
+    (set-sentinel))
+
+  (assert set-sentinel.set))


### PR DESCRIPTION
Okay, so back to square one, and this one I think is a much better fix. Address a few issues all at once.

- Fixes #1533. The problem there was in the \_\_init__ return suppression.
- Tweaks class construction so we emit a list of statements.
- Remove `__doc__` attribute setting. Python looks at the first ast.Expr statement in its body, we don't need to really handle it specially.

Now the only problem I have, and could use some help, is with `force_stmt`. I duplicated the function because `expr_as_stmt` drops statments. For example, consider I get back:

    Result(imports=[], stmts=[FunctionDef(name='foo', args=arguments(args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]), body=[Pass()], decorator_list=[])], expr=None, contains_yield=False)
	
Its already a statement but `expr_as_stmt` returns `Result()`.

So I tried putting that second condition I put in the `force_stmt` variant inside `expr_as_stmt`, and every statement suddenly was duplicated. For example, that new test I added looked like this:

	def test_class_sideeffects():
		"""NATIVE: test that defclass runs all expressions"""

		def set_sentinal():
			set_sentinal.set = True

		def set_sentinal():
			set_sentinal.set = True
		set_sentinal.set = False
		set_sentinal.set = False


		class A:
			set_sentinal()


		class A:
			set_sentinal()
		assert set_sentinal.set

So I suspect that this is an issue you guys solved differently, but I can't seem to dig into it. And I'm kinda short on time anyways (I shouldn't be hacking on Hy right now either....)

**EDIT** rewrote the test, updated it here too
