### PR TITLE
unquote/unpacking improvements

### DIFF
--- a/hy/models.py
+++ b/hy/models.py
@@ -226,11 +226,8 @@ class HyList(HyObject, list):
     """
 
     def replace(self, other):
-        for x in self:
-            replace_hy_obj(x, other)
-
-        HyObject.replace(self, other)
-        return self
+        self[:] = [replace_hy_obj(x, other) for x in self]
+        return HyObject.replace(self, other)
 
     def __add__(self, other):
         return self.__class__(super(HyList, self).__add__(other))
@@ -387,11 +384,11 @@ class HyCons(HyObject):
 
     def replace(self, other):
         if self.car is not None:
-            replace_hy_obj(self.car, other)
+            self.car = replace_hy_obj(self.car, other)
         if self.cdr is not None:
-            replace_hy_obj(self.cdr, other)
+            self.cdr = replace_hy_obj(self.cdr, other)
 
-        HyObject.replace(self, other)
+        return HyObject.replace(self, other)
 
     def __repr__(self):
         if PRETTY:

--- a/hy/models.py
+++ b/hy/models.py
@@ -3,6 +3,7 @@
 # license. See the LICENSE.
 
 from __future__ import unicode_literals
+import collections
 from contextlib import contextmanager
 from math import isnan, isinf
 from hy._compat import PY3, str_type, bytes_type, long_type, string_types
@@ -62,9 +63,11 @@ def wrap_value(x):
 
     wrapper = _wrappers.get(type(x))
     if wrapper is None:
+        if (not isinstance(x, HyObject)
+            and isinstance(x, collections.Iterable)):
+            return wrap_value(list(x))
         return x
-    else:
-        return wrapper(x)
+    return wrapper(x)
 
 
 def replace_hy_obj(obj, other):

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -98,3 +98,12 @@
       [1 2 3]
       [4 5 6])
     [4 5 6])))
+
+(defn test-unquote-with-generators []
+  (defn values []
+    (yield '1)
+    (yield '2)
+    (yield '3))
+
+  (assert (= (eval `[~@(values)]) [1 2 3]))
+  (assert (= (eval `[~(values)]) [[1 2 3]])))


### PR DESCRIPTION
A pile of changes dealing with some ugly corner cases in the language

Fixes #1519

The problem here is calling `replace` can trigger a call to `replace_hy_obj`, which will try to also wrap values inside a `HyObject`.

However, this means when we try to recursively replace inside a nested object, like a `HyList`, we should try and capture these new wrapped objects.

Hy still works if we don't, but it results in the object getting rewrapped multiple times during a compile.

But with that change in place, `wrap_value` should now only be called once per expression. This opens the door to safely wrap iterables. So instead of crashing when trying to wrap an iterable, first expand it and then try to wrap the resulting list.
    
This allows `unquote` to work with iterators and generators, which previously didn't work unless you used `unquote-splice` or explicitly expanded a list first.

And lastly, use PEP 448 for better unquoted expressions (inspired by @gilch's comment in #1542)
    
With Python 3.5, we can have an arbitrary number of unpackings. We can use this to emit cleaner expressions.
