### PR TITLE
Use io.StringIO everywhere

### DIFF
--- a/hy/contrib/profile.hy
+++ b/hy/contrib/profile.hy
@@ -18,10 +18,7 @@
   " Profile a bit of code "
   `(do
      (import cProfile pstats)
-
-     (if-python2
-       (import [StringIO [StringIO]])
-       (import [io [StringIO]]))
+     (import [io [StringIO]])
 
      (setv ~g!hy-pr (.Profile cProfile))
      (.enable ~g!hy-pr)

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -12,9 +12,7 @@
 (import [fractions [Fraction :as fraction]])
 (import operator)  ; shadow not available yet
 (import sys)
-(if-python2
-  (import [StringIO [StringIO]])
-  (import [io [StringIO]]))
+(import [io [StringIO]])
 (import [hy._compat [long-type]]) ; long for python2, int for python3
 (import [hy.models [HyCons HySymbol HyKeyword]])
 (import [hy.lex [LexException PrematureEndOfInput tokenize]])

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1660,9 +1660,7 @@ macros()
 
 (defn test-read []
   "NATIVE: test that read takes something for stdin and reads"
-  (if-python2
-    (import [StringIO [StringIO]])
-    (import [io [StringIO]]))
+  (import [io [StringIO]])
   (import [hy.models [HyExpression]])
 
   (setv stdin-buffer (StringIO "(+ 2 2)\n(- 2 2)"))


### PR DESCRIPTION
Small change that drops some compatibility code. Python 2.6 got a backport of the `io` module, and it contains a better `StringIO` implementation