### PR TITLE
Fix `mangle` for Pythons compiled with UCS-2

### DIFF
--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -25,6 +25,10 @@ PY35 = sys.version_info >= (3, 5)
 PY36 = sys.version_info >= (3, 6)
 PY37 = sys.version_info >= (3, 7)
 
+# The value of UCS4 indicates whether Unicode strings are stored as UCS-4.
+# It is always true on Pythons >= 3.3, which use USC-4 on all systems.
+UCS4 = sys.maxunicode == 0x10FFFF
+
 str_type     = str   if PY3 else unicode      # NOQA
 bytes_type   = bytes if PY3 else str          # NOQA
 long_type    = int   if PY3 else long         # NOQA


### PR DESCRIPTION
When `hy` python compiled with UCS-2, the unit tests failed because in the [mangle function](https://github.com/hylang/hy/blob/master/hy/lex/parser.py#L54), `😂` unicode represents as two 16bit int `0xD83D` `0xDE02` rather than one 32bit int `0x1F602`.

This problem only affects before Python version 3.3 ([PEP 393](https://www.python.org/dev/peps/pep-0393/) uses UCS-4 on all systems).

ref:
[1] https://docs.python.org/2/howto/unicode.html#the-unicode-type
[2] https://docs.python.org/3/library/sys.html#sys.maxunicode
