### PR TITLE
Report objects when raising type error

### DIFF
--- a/hy/models.py
+++ b/hy/models.py
@@ -40,7 +40,7 @@ class HyObject(object):
                 if not hasattr(self, attr) and hasattr(other, attr):
                     setattr(self, attr, getattr(other, attr))
         else:
-            raise TypeError("Can't replace a non Hy object '{0}' with a Hy object '{1}'".format(other, self))
+            raise TypeError("Can't replace a non Hy object '{}' with a Hy object '{}'".format(repr(other), repr(self)))
 
         return self
 

--- a/hy/models.py
+++ b/hy/models.py
@@ -40,7 +40,7 @@ class HyObject(object):
                 if not hasattr(self, attr) and hasattr(other, attr):
                     setattr(self, attr, getattr(other, attr))
         else:
-            raise TypeError("Can't replace a non Hy object '{0}' with a Hy object '{1}'".format(self, other))
+            raise TypeError("Can't replace a non Hy object '{0}' with a Hy object '{1}'".format(other, self))
 
         return self
 

--- a/hy/models.py
+++ b/hy/models.py
@@ -40,7 +40,7 @@ class HyObject(object):
                 if not hasattr(self, attr) and hasattr(other, attr):
                     setattr(self, attr, getattr(other, attr))
         else:
-            raise TypeError("Can't replace a non Hy object with a Hy object")
+            raise TypeError("Can't replace a non Hy object '{0}' with a Hy object '{1}'".format(self, other))
 
         return self
 


### PR DESCRIPTION
Improves error reporting just a tiny bit by including offending objects and thus making debugging easier