### PR TITLE
Prettify hy command helping message

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -253,10 +253,11 @@ def run_icommand(source, **kwargs):
 
 USAGE = "%(prog)s [-h | -i cmd | -c cmd | -m module | file | -] [arg] ..."
 VERSION = "%(prog)s " + hy.__version__
-EPILOG = """  file         program read from script
-  module       module to execute as main
-  -            program read from stdin
-  [arg] ...    arguments passed to program in sys.argv[1:]
+EPILOG = """
+  file                  program read from script
+  module                module to execute as main
+  -                     program read from stdin
+  [arg] ...             arguments passed to program in sys.argv[1:]
 """
 
 
@@ -270,9 +271,8 @@ def cmdline_handler(scriptname, argv):
                         help="program passed in as a string")
     parser.add_argument("-m", dest="mod",
                         help="module to run, passed in as a string")
-    parser.add_argument(
-        "-i", dest="icommand",
-        help="program passed in as a string, then stay in REPL")
+    parser.add_argument("-i", dest="icommand",
+                        help="program passed in as a string, then stay in REPL")
     parser.add_argument("--spy", action="store_true",
                         help="print equivalent Python code before executing")
     parser.add_argument("--repl-output-fn",


### PR DESCRIPTION
Previously the `hy -h` helping message looks like this:

```
usage: hy [-h | -i cmd | -c cmd | -m module | file | -] [arg] ...

optional arguments:
  -h, --help            show this help message and exit
  -c COMMAND            program passed in as a string
  -m MOD                module to run, passed in as a string
  -i ICOMMAND           program passed in as a string, then stay in REPL
  --spy                 print equivalent Python code before executing
  --repl-output-fn REPL_OUTPUT_FN
                        function for printing REPL output (e.g., hy.contrib
                        .hy-repr.hy-repr)
  -v, --version         show program's version number and exit
  --show-tracebacks     show complete tracebacks for Hy exceptions

  file         program read from script
  module       module to execute as main
  -            program read from stdin
  [arg] ...    arguments passed to program in sys.argv[1:]
```

Note the lower section is not aligned with the `optional arguments` section. This commit updates the `EPILOG` section.

```
usage: hy [-h | -i cmd | -c cmd | -m module | file | -] [arg] ...

optional arguments:
  -h, --help            show this help message and exit
  -c COMMAND            program passed in as a string
  -m MOD                module to run, passed in as a string
  -i ICOMMAND           program passed in as a string, then stay in REPL
  --spy                 print equivalent Python code before executing
  --repl-output-fn REPL_OUTPUT_FN
                        function for printing REPL output (e.g., hy.contrib
                        .hy-repr.hy-repr)
  -v, --version         show program's version number and exit
  --show-tracebacks     show complete tracebacks for Hy exceptions

  file                  program read from script
  module                module to execute as main
  -                     program read from stdin
  [arg] ...             arguments passed to program in sys.argv[1:]
```