### PR TITLE
Add -E support for Hy REPL

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,6 +22,7 @@ New Features
 * Added `mangle` and `unmangle` as core functions
 * `defclass` in Python 3 now supports specifying metaclasses and other
   keyword arguments
+* Added a command-line option `-E` per CPython
 
 Bug Fixes
 ------------------------------

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -271,6 +271,8 @@ def cmdline_handler(scriptname, argv):
                         help="program passed in as a string")
     parser.add_argument("-m", dest="mod",
                         help="module to run, passed in as a string")
+    parser.add_argument("-E", action='store_true',
+                        help="ignore PYTHON* environment variables")
     parser.add_argument("-i", dest="icommand",
                         help="program passed in as a string, then stay in REPL")
     parser.add_argument("--spy", action="store_true",
@@ -309,6 +311,10 @@ def cmdline_handler(scriptname, argv):
 
     # reset sys.argv like Python
     sys.argv = options.args + module_args or [""]
+
+    if options.E:
+        # User did "hy -E ..."
+        _remove_python_envs()
 
     if options.command:
         # User did "hy -c ..."
@@ -436,3 +442,10 @@ def _print_for_windows(src):
             print(line)
         except:
             print(line.encode('utf-8'))
+
+# remove PYTHON* environment variables,
+# such as "PYTHONPATH"
+def _remove_python_envs():
+    for key in list(os.environ.keys()):
+        if key.startswith("PYTHON"):
+            os.environ.pop(key)

--- a/tests/resources/bin/printenv.hy
+++ b/tests/resources/bin/printenv.hy
@@ -1,0 +1,3 @@
+(import os)
+
+(print (. os environ))

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -168,6 +168,23 @@ def test_bin_hy_stdin_hy_repr():
     output, _ = run_cmd(hr("--spy"), '(+ [1] [2] (foof))')
     assert "[1]+[2]" in output.replace('L', '').replace(' ', '')
 
+def test_bin_hy_ignore_python_env():
+    os.environ.update({"PYTHONTEST": '0'})
+    output, _ = run_cmd("hy -c '(print (do (import os) (. os environ)))'")
+    assert "PYTHONTEST" in output
+    output, _ = run_cmd("hy -m tests.resources.bin.printenv")
+    assert "PYTHONTEST" in output
+    output, _ = run_cmd("hy tests/resources/bin/printenv.hy")
+    assert "PYTHONTEST" in output
+
+    output, _ = run_cmd("hy -E -c '(print (do (import os) (. os environ)))'")
+    assert "PYTHONTEST" not in output
+    os.environ.update({"PYTHONTEST": '0'})
+    output, _ = run_cmd("hy -E -m tests.resources.bin.printenv")
+    assert "PYTHONTEST" not in output
+    os.environ.update({"PYTHONTEST": '0'})
+    output, _ = run_cmd("hy -E tests/resources/bin/printenv.hy")
+    assert "PYTHONTEST" not in output
 
 def test_bin_hy_cmd():
     output, _ = run_cmd("hy -c \"(koan)\"")


### PR DESCRIPTION
This commit adds `-E` support for Hy. Similar to Python, hy will ignore
all PYTHON* environment variables, e.g. PYTHONPATH and PYTHONHOME,
that might be set.

This is an enhancement mentioned in https://github.com/hylang/hy/issues/1488