### PR TITLE
Fix unit tests when run with PYTHONDONTWRITEBYTECODE

### DIFF
--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -10,6 +10,7 @@ import os
 import ast
 import tempfile
 from fractions import Fraction
+import pytest
 
 
 def test_basics():
@@ -50,6 +51,8 @@ def test_import_error_reporting():
     assert _import_error_test() is not None
 
 
+@pytest.mark.skipif(os.environ.get('PYTHONDONTWRITEBYTECODE'),
+                    reason="Bytecode generation is suppressed")
 def test_import_autocompiles():
     "Test that (import) byte-compiles the module."
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -24,10 +24,12 @@ def hr(s=""):
 
 
 def run_cmd(cmd, stdin_data=None, expect=0, dontwritebytecode=False):
-    env = None
+    env = dict(os.environ)
     if dontwritebytecode:
-        env = dict(os.environ)
         env["PYTHONDONTWRITEBYTECODE"] = "1"
+    else:
+        env.pop("PYTHONDONTWRITEBYTECODE", None)
+
     cmd = shlex.split(cmd)
     cmd[0] = os.path.join(hy_dir, cmd[0])
     p = subprocess.Popen(cmd,


### PR DESCRIPTION
When set, it will conflict with any tests that generate bytecode because they don't expect it to be set.

Fixable by sanitize the environment before forking, but we can't do anything about import tests.

This is a pipenv default, and possibly a sane flag to set while doing Hy development, so lets not let it be a hazard for developers to trip over.