### PR TITLE
Update .gitignore to exclude pytest cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /hy/version.py
 *.pyc
-*swp
+.*.sw?
 *hy*egg*
 *pyreadline*egg*
 .tox
@@ -9,3 +9,4 @@ dist
 .coverage
 build/
 /.cache
+/.pytest_cache


### PR DESCRIPTION
The `.pytest_cache/` folder appears after running `make test` locally.
This commit also updates vim temporary files exclusion rules.