### PR TITLE
 Use `X` as the mangle delimiter on Python 3 

### DIFF
--- a/docs/language/syntax.rst
+++ b/docs/language/syntax.rst
@@ -99,7 +99,7 @@ Python-legal names. The rules are:
 
 - Convert all hyphens (``-``) to underscores (``_``). Thus, ``foo-bar`` becomes
   ``foo_bar``.
-- If the name ends with ``?``, remove it and prepend ``is``. Thus, ``tasty?``
+- If the name ends with ``?``, remove it and prepend ``is_``. Thus, ``tasty?``
   becomes ``is_tasty``.
 - If the name still isn't Python-legal, make the following changes. A name
   could be Python-illegal because it contains a character that's never legal in

--- a/docs/language/syntax.rst
+++ b/docs/language/syntax.rst
@@ -107,13 +107,13 @@ Python-legal names. The rules are:
   it's equal to a Python reserved word.
 
   - Prepend ``hyx_`` to the name.
-  - Replace each illegal character with ``ΔfooΔ`` (or on Python 2, ``XfooX``),
-    where ``foo`` is the the Unicode character name in lowercase, with spaces
-    replaced by underscores and hyphens replaced by ``H``. Replace ``Δ`` itself
-    (or on Python 2, ``X``) the same way. If the character doesn't have a name,
-    use ``U`` followed by its code point in lowercase hexadecimal.
+  - Replace each illegal character with ``XfooX``, where ``foo`` is the Unicode
+    character name in lowercase, with spaces replaced by underscores and
+    hyphens replaced by ``H``. Replace ``X`` itself the same way. If the
+    character doesn't have a name, use ``U`` followed by its code point in
+    lowercase hexadecimal.
 
-  Thus, ``green☘`` becomes ``hyx_greenΔshamrockΔ`` and ``if`` becomes
+  Thus, ``green☘`` becomes ``hyx_greenXshamrockX`` and ``if`` becomes
   ``hyx_if``.
 
 - Finally, any added ``hyx_`` or ``is_`` is added after any leading

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -23,7 +23,7 @@ pg = ParserGenerator(
     cache_id="hy_parser"
 )
 
-mangle_delim = 'Δ' if PY3 else 'X'
+mangle_delim = 'X'
 
 def unicode_to_ucs4iter(ustr):
     # Covert a unicode string to an iterable object,

--- a/tests/native_tests/mangling.hy
+++ b/tests/native_tests/mangling.hy
@@ -40,70 +40,49 @@
 
   (setv # "no comment")
   (assert (= # "no comment"))
-  (if PY3
-    (assert (= hyx_Δnumber_signΔ "no comment"))
-    (assert (= hyx_Xnumber_signX "no comment")))
+  (assert (= hyx_Xnumber_signX "no comment"))
 
   (setv $ "dosh")
   (assert (= $ "dosh"))
-  (if PY3
-    (assert (= hyx_Δdollar_signΔ "dosh"))
-    (assert (= hyx_Xdollar_signX "dosh"))))
+  (assert (= hyx_Xdollar_signX "dosh")))
 
 
 (defn test-basic-multilingual-plane []
   (setv ♥ "love"
         ⚘ab "flower")
   (assert (= (+ ⚘ab ♥) "flowerlove"))
-  (if PY3
-    (assert (= (+ hyx_ΔflowerΔab hyx_Δblack_heart_suitΔ) "flowerlove"))
-    (assert (= (+ hyx_XflowerXab hyx_Xblack_heart_suitX) "flowerlove")))
+  (assert (= (+ hyx_XflowerXab hyx_Xblack_heart_suitX) "flowerlove"))
   (setv ⚘-⚘ "doubleflower")
   (assert (= ⚘-⚘ "doubleflower"))
-  (if PY3
-    (assert (= hyx_ΔflowerΔ_ΔflowerΔ "doubleflower"))
-    (assert (= hyx_XflowerX_XflowerX "doubleflower")))
+  (assert (= hyx_XflowerX_XflowerX "doubleflower"))
   (setv ⚘? "mystery")
   (assert (= ⚘? "mystery"))
-  (if PY3
-    (assert (= hyx_is_ΔflowerΔ "mystery"))
-    (assert (= hyx_is_XflowerX "mystery"))))
+  (assert (= hyx_is_XflowerX "mystery")))
 
 
 (defn test-higher-unicode []
   (setv 😂 "emoji")
   (assert (= 😂 "emoji"))
   (if PY3
-    (assert (= hyx_Δface_with_tears_of_joyΔ "emoji"))
+    (assert (= hyx_Xface_with_tears_of_joyX "emoji"))
     (assert (= hyx_XU1f602X "emoji"))))
 
 
 (defn test-nameless-unicode []
   (setv  "private use")
   (assert (=  "private use"))
-  (if PY3
-    (assert (= hyx_ΔUe000Δ "private use"))
-    (assert (= hyx_XUe000X "private use"))))
+  (assert (= hyx_XUe000X "private use")))
 
 
 (defn test-charname-with-hyphen []
   (setv a<b "little")
   (assert (= a<b "little"))
-  (if PY3
-    (assert (= hyx_aΔlessHthan_signΔb "little"))
-    (assert (= hyx_aXlessHthan_signXb "little"))))
+  (assert (= hyx_aXlessHthan_signXb "little")))
 
 
 (defn test-delimiters []
-  (setv Δ✈ "Delta Air Lines")
-  (assert (= Δ✈ "Delta Air Lines"))
-  (if PY3
-    (assert (= hyx_Δgreek_capital_letter_deltaΔΔairplaneΔ "Delta Air Lines"))
-    (assert (= hyx_Xgreek_capital_letter_deltaXXairplaneX "Delta Air Lines")))
   (setv X☠ "treasure")
-  (if PY3
-    (assert (= hyx_XΔskull_and_crossbonesΔ "treasure"))
-    (assert (= hyx_Xlatin_capital_letter_xXXskull_and_crossbonesX "treasure"))))
+  (assert (= hyx_Xlatin_capital_letter_xXXskull_and_crossbonesX "treasure")))
 
 
 (defmacro m---x [form]
@@ -142,9 +121,7 @@
 (defn test-operator []
   (setv + 3)
   (assert (= + 3))
-  (if PY3
-    (assert (= hyx_Δplus_signΔ 3))
-    (assert (= hyx_Xplus_signX 3))))
+  (assert (= hyx_Xplus_signX 3)))
 
 
 (defn test-keyword-args []
@@ -152,20 +129,14 @@
   (defn f [a a-b foo? ☘]
     [a a-b foo? ☘])
   (assert (= (f :foo? 3 :☘ 4 :a 1 :a-b 2) [1 2 3 4]))
-  (if PY3
-    (assert (= (f :is_foo 3 :hyx_ΔshamrockΔ 4 :a 1 :a_b 2) [1 2 3 4]))
-    (assert (= (f :is_foo 3 :hyx_XshamrockX 4 :a 1 :a_b 2) [1 2 3 4])))
+  (assert (= (f :is_foo 3 :hyx_XshamrockX 4 :a 1 :a_b 2) [1 2 3 4]))
 
   (defn g [&kwargs x]
     x)
-  (setv sk (.format "hyx_{0}shamrock{0}" (if PY3 "Δ" "X")))
   (assert (= (g :foo? 3 :☘ 4 :a 1 :a-b 2)
-    {"a" 1  "a_b" 2  "is_foo" 3  sk 4}))
-  (if PY3
-    (assert (= (g :is_foo 3 :hyx_ΔshamrockΔ 4 :a 1 :a_b 2)
-      {"a" 1  "a_b" 2  "is_foo" 3  sk 4}))
-    (assert (= (g :is_foo 3 :hyx_XshamrockX 4 :a 1 :a_b 2)
-      {"a" 1  "a_b" 2  "is_foo" 3  sk 4}))))
+    {"a" 1  "a_b" 2  "is_foo" 3  "hyx_XshamrockX" 4}))
+  (assert (= (g :is_foo 3 :hyx_XshamrockX 4 :a 1 :a_b 2)
+    {"a" 1  "a_b" 2  "is_foo" 3  "hyx_XshamrockX" 4})))
 
 
 (defn test-late-mangling []
@@ -184,6 +155,6 @@
   (for [[a b] [
       ["---ab-cd?" "___is_ab_cd"]
       ["if" "hyx_if"]
-      ["⚘-⚘" (if PY3 "hyx_ΔflowerΔ_ΔflowerΔ" "hyx_XflowerX_XflowerX")]]]
+      ["⚘-⚘" "hyx_XflowerX_XflowerX"]]]
     (assert (= (mangle a) b))
     (assert (= (unmangle b) a))))

--- a/tests/native_tests/mangling.hy
+++ b/tests/native_tests/mangling.hy
@@ -134,9 +134,9 @@
   (defn g [&kwargs x]
     x)
   (assert (= (g :foo? 3 :☘ 4 :a 1 :a-b 2)
-    {"a" 1  "a_b" 2  "is_foo" 3  "hyx_XshamrockX" 4}))
+             {"a" 1  "a_b" 2  "is_foo" 3  "hyx_XshamrockX" 4}))
   (assert (= (g :is_foo 3 :hyx_XshamrockX 4 :a 1 :a_b 2)
-    {"a" 1  "a_b" 2  "is_foo" 3  "hyx_XshamrockX" 4})))
+             {"a" 1  "a_b" 2  "is_foo" 3  "hyx_XshamrockX" 4})))
 
 
 (defn test-late-mangling []
@@ -146,15 +146,14 @@
   (assert (= sym "foo?"))
   (assert (!= sym "is_foo"))
   (setv out (eval `(do
-    (setv ~sym 10)
-    [foo? is_foo])))
+                     (setv ~sym 10)
+                     [foo? is_foo])))
   (assert (= out [10 10])))
 
 
 (defn test-functions []
-  (for [[a b] [
-      ["---ab-cd?" "___is_ab_cd"]
-      ["if" "hyx_if"]
-      ["⚘-⚘" "hyx_XflowerX_XflowerX"]]]
+  (for [[a b] [["---ab-cd?" "___is_ab_cd"]
+               ["if" "hyx_if"]
+               ["⚘-⚘" "hyx_XflowerX_XflowerX"]]]
     (assert (= (mangle a) b))
     (assert (= (unmangle b) a))))


### PR DESCRIPTION
Mentioned in #1535.