### PR TITLE
Add `returns` to function ast generation

### DIFF
--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -2012,6 +2012,7 @@ class HyASTCompiler(object):
                     args=args,
                     body=body.stmts,
                     decorator_list=[],
+                    returns=None,
                     docstring=(None if docstring is None else
                         str_type(docstring)))
 


### PR DESCRIPTION
The `returns` entry was added as part of PEP 3107 to store a functions annotation for its return value, which there currently is no support for in Hy.

That said, we should try and always emit the same AST that Python would, so lets emit it anyways.