### PR TITLE
Update test_preprocessor_exceptions

### DIFF
--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -44,15 +44,12 @@ def test_preprocessor_expression():
     assert obj == macroexpand(obj, HyASTCompiler(""))
 
 
-@pytest.mark.xfail
 def test_preprocessor_exceptions():
     """ Test that macro expansion raises appropriate exceptions"""
-    try:
+    with pytest.raises(HyMacroExpansionError) as excinfo:
         macroexpand(tokenize('(defn)')[0], HyASTCompiler(__name__))
-        assert False
-    except HyMacroExpansionError as e:
-        assert "_hy_anon_fn_" not in str(e)
-        assert "TypeError" not in str(e)
+    assert "_hy_anon_fn_" not in excinfo.value.message
+    assert "TypeError" not in excinfo.value.message
 
 
 def test_macroexpand_nan():


### PR DESCRIPTION
This test has been passing since b023ebd0b5340a666df83e3fc0b72d7734636e04, so I removed the xfail. I also rewrote the test to use pytest.raises.