### PR TITLE
Fix bug in let's handle-dot.

### DIFF
--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -136,12 +136,14 @@ Arguments without a header are under None.
                                     :quote-level (+ self.quote-level x))))
 
   (defn handle-dot [self]
-    `(. ~@(walk (fn [form]
+    `(. ~(self.expand-symbols (first (self.tail)))
+        ~@(walk (fn [form]
                   (if (symbol? form)
                       form  ; don't expand attrs
                       (self.expand-symbols form)))
                 identity
-                (self.tail))))
+                (cut (self.tail)
+                     1))))
 
   (defn head [self]
     (first self.form))

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -227,7 +227,12 @@
   (setv foo (fn [])
         foo.a 42)
   (let [a 1
-        b []]
+        b []
+        bar (fn [])]
+       (setv bar.a 13)
+       (assert (= bar.a 13))
+       (setv (. bar a) 14)
+       (assert (= bar.a 14))
        (assert (= a 1))
        (assert (= b []))
        ;; method syntax not affected


### PR DESCRIPTION
Fixes #1602. The first element after the `.` should be expanded normally, even if it's a symbol.