### PR TITLE
fix botsbuildbots for #1582

### DIFF
--- a/hy/contrib/botsbuildbots.hy
+++ b/hy/contrib/botsbuildbots.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(defn Botsbuildbots () (Botsbuildbots))
+(defn Botsbuildbots [] (Botsbuildbots))
 
 (defmacro Botsbuildbots []
   "Build bots, repeatedly.^W^W^WPrint the AUTHORS, forever."


### PR DESCRIPTION
The change in #1582 is preventing Hy from installing.

Closes #1599

#1601 would make this moot, but fixing it is the more conservative change. Pick one or the other. This `botsbuildsbots` doesn't do anything important. It's just one of our Easter eggs.