### PR TITLE
Fixes #1605: remove macros ap-pipe and ap-compose

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,6 +11,9 @@ Removals
 * `&key` is no longer special in lambda lists. Use `&optional` instead.
 * Tuple unpacking is no longer built into special forms for function
   definition (`fn` etc.)
+* Macros `ap-pipe` and `ap-compose` have been removed.
+  Anaphoric macros do not work well with point-free style programming,
+  in which case both threading macros and `comp` are more adequate.
 
 Other Breaking Changes
 ------------------------------

--- a/docs/extra/anaphoric.rst
+++ b/docs/extra/anaphoric.rst
@@ -197,38 +197,6 @@ first element instead. This exposes the element being iterated as
    45
 
 
-.. _ap-pipe:
-
-ap-pipe
-=========
-
-Usage ``(ap-pipe value form1 form2 ...)``
-
-Applies several forms in series to a value from left to right. The special variable ``ìt`` in each form is replaced by the result of the previous form.
-
-.. code-block:: hy
-
-   => (ap-pipe 3 (+ it 1) (/ 5 it))
-   1.25
-   => (ap-pipe [4 5 6 7] (list (rest it)) (len it))
-   3
-
-
-.. _ap-compose:
-
-ap-compose
-=========
-
-Usage ``(ap-compose form1 form2 ...)``
-
-Returns a function which applies several forms in series from left to right. The special variable ``ìt`` in each form is replaced by the result of the previous form.
-
-.. code-block:: hy
-
-   => (setv op (ap-compose (+ it 1) (* it 3)))
-   => (op 2)
-   9
-
 .. _#%
 
 #%

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -100,17 +100,6 @@
      acc))
 
 
-(defmacro ap-pipe [var &rest forms]
-  "Pushes a value through several forms.
-  (Anaphoric version of -> and ->>)"
-  (if (empty? forms) var
-      `(ap-pipe (do (setv it ~var) ~(first forms)) ~@(rest forms))))
-
-
-(defmacro ap-compose [&rest forms]
-  "Returns a function which is the composition of several forms."
-  `(fn [var] (ap-pipe var ~@forms)))
-
 (deftag % [expr]
   "Makes an expression into a function with an implicit `%` parameter list.
 

--- a/tests/native_tests/extra/anaphoric.hy
+++ b/tests/native_tests/extra/anaphoric.hy
@@ -89,16 +89,6 @@
                 "Hy on meth")
   (assert-equal (ap-reduce (+ acc it) [] 1) 1))
 
-(defn test-ap-pipe []
-  "NATIVE: testing anaphoric pipe"
-  (assert-equal (ap-pipe 2 (+ it 1) (* it 3)) 9)
-  (assert-equal (ap-pipe [4 5 6 7] (list (rest it)) (len it)) 3))
-
-(defn test-ap-compose []
-  "NATIVE: testing anaphoric compose"
-  (assert-equal ((ap-compose (+ it 1) (* it 3)) 2) 9)
-  (assert-equal ((ap-compose (list (rest it)) (len it)) [4 5 6 7]) 3))
-
 (defn test-tag-fn []
   "NATIVE: testing #%() forms"
   ;; test ordering


### PR DESCRIPTION
Anaphoric macros do not work well with point-free style programming, in
which case both threading macros and `comp` are more adequate.