### PR TITLE
Simplify import statements

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -35,7 +35,12 @@ Other Breaking Changes
   made into its own object type.
 * `HySymbol` no longer inherits from `HyString`.
 * `(except)` is no longer allowed. Use `(except [])` instead.
-* `(import [foo])` is no longer allowed. Use `(import foo)` instead.
+* The `import` and `require` expressions have been reworked. They now takes
+  arguments as expressions instead of lists
+
+  * `(import [foo])` is no longer allowed. Use `(import foo)` instead.
+  * `(import [foo :as bar])` is no longer allowed. Use `(import foo :as bar)`.
+  * `(import [foo [bar]])` is no longer allowed. Use `(import foo [bar])`.
 
 New Features
 ------------------------------

--- a/docs/contrib/hy_repr.rst
+++ b/docs/contrib/hy_repr.rst
@@ -7,7 +7,7 @@ Hy representations
 ``hy.contrib.hy-repr`` is a module containing two functions.
 To import them, say::
 
-  (import [hy.contrib.hy-repr [hy-repr hy-repr-register]])
+  (import hy.contrib.hy-repr [hy-repr hy-repr-register])
 
 To make the Hy REPL use it for output, invoke Hy like so::
 

--- a/docs/contrib/loop.rst
+++ b/docs/contrib/loop.rst
@@ -45,7 +45,7 @@ Example:
 
 .. code-block:: hy
 
-    (require [hy.contrib.loop [loop]])
+    (require hy.contrib.loop [loop])
 
     (defn factorial [n]
       (loop [[i n] [acc 1]]

--- a/docs/contrib/multi.rst
+++ b/docs/contrib/multi.rst
@@ -12,7 +12,7 @@ with the arity overloaded one. Inspired by Clojures take on ``defn``.
 
 .. code-block:: clj
 
-    => (require [hy.contrib.multi [defn]])
+    => (require hy.contrib.multi [defn])
     => (defn fun
     ...  ([a] "a")
     ...  ([a b] "a b")
@@ -43,7 +43,7 @@ on the code by `Adam Bard`_.
 
 .. code-block:: clj
 
-    => (require [hy.contrib.multi [defmulti defmethod default-method]])
+    => (require hy.contrib.multi [defmulti defmethod default-method])
     => (defmulti area [shape]
     ...  "calculate area of a shape"
     ...  (:type shape))
@@ -91,7 +91,7 @@ different implementations can narrow them down.
 
 .. code-block:: clj
 
-    => (require [hy.contrib.multi [defmulti defmethod]])
+    => (require hy.contrib.multi [defmulti defmethod])
     => (defmulti fun [&rest args]
     ...  (len args))
 

--- a/docs/contrib/profile.rst
+++ b/docs/contrib/profile.rst
@@ -27,7 +27,7 @@ Example:
 
 .. code-block:: hy
 
-   (require [hy.contrib.profile [profile/calls]])
+   (require hy.contrib.profile [profile/calls])
    (profile/calls (print "hey there"))
 
 
@@ -42,7 +42,7 @@ Example:
 
 .. code-block:: hy
 
-    (require [hy.contrib.profile [profile/cpu]])
+    (require hy.contrib.profile [profile/cpu])
     (profile/cpu (print "hey there"))
 
 .. code-block:: bash

--- a/docs/contrib/sequences.rst
+++ b/docs/contrib/sequences.rst
@@ -15,8 +15,8 @@ so:
 
 .. code-block:: hy
 
-   (require [hy.contrib.sequences [defseq seq]])
-   (import [hy.contrib.sequences [Sequence end-sequence]])
+   (require hy.contrib.sequences [defseq seq])
+   (import hy.contrib.sequences [Sequence end-sequence])
 
 The simplest sequence can be defined as ``(seq [n] n)``. This defines a sequence
 that starts as ``[0 1 2 3 ...]`` and continues forever. In order to define a

--- a/docs/contrib/walk.rst
+++ b/docs/contrib/walk.rst
@@ -22,7 +22,7 @@ Example:
 
 .. code-block:: hy
 
-    => (import [hy.contrib.walk [walk]])
+    => (import hy.contrib.walk [walk])
     => (setv a '(a b c d e f))
     => (walk ord identity a)
     HyExpression([
@@ -47,7 +47,7 @@ each sub-form, uses ``f`` 's return value in place of the original.
 
 .. code-block:: hy
 
-    => (import [hy.contrib.walk [postwalk]])
+    => (import hy.contrib.walk [postwalk])
     => (setv trail '([1 2 3] [4 [5 6 [7]]]))
     => (defn walking [x]
     ...  (print "Walking:" x :sep "\n")
@@ -127,7 +127,7 @@ each sub-form, uses ``f`` 's return value in place of the original.
 
 .. code-block:: hy
 
-    => (import [hy.contrib.walk [prewalk]])
+    => (import hy.contrib.walk [prewalk])
     => (setv trail '([1 2 3] [4 [5 6 [7]]]))
     => (defn walking [x]
     ...  (print "Walking:" x :sep "\n")

--- a/docs/extra/anaphoric.rst
+++ b/docs/extra/anaphoric.rst
@@ -15,7 +15,7 @@ concise and easy to read.
 
 To use these macros you need to require the ``hy.extra.anaphoric`` module like so:
 
-``(require [hy.extra.anaphoric [*]])``
+``(require hy.extra.anaphoric [*])``
 
 .. _ap-if:
 

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -152,7 +152,7 @@ point per form via the name instead of always the first or last argument.
   'Sir Joseph Cooke Verco'
 
   ;; more convoluted example to load web page and retrieve data from it
-  => (import [urllib.request [urlopen]])
+  => (import urllib.request [urlopen])
   => (as-> (urlopen "http://docs.hylang.org/en/stable/") it
   ...      (.read it)
   ...      (.decode it "utf-8")
@@ -1100,12 +1100,12 @@ that ``import`` can be used.
     ;; Import from a module
     ;;
     ;; Python: from os.path import exists, isdir, isfile
-    (import [os.path [exists isdir isfile]])
+    (import os.path [exists isdir isfile])
 
     ;; Import with an alias
     ;;
     ;; Python: import sys as systest
-    (import [sys :as systest])
+    (import sys :as systest)
 
     ;; You can list as many imports as you like of different types.
     ;;
@@ -1113,16 +1113,16 @@ that ``import`` can be used.
     ;; from tests.resources import kwtest, function_with_a_dash
     ;; from os.path import exists, isdir as is_dir, isfile as is_file
     ;; import sys as systest
-    (import [tests.resources [kwtest function-with-a-dash]]
-            [os.path [exists
-                      isdir :as dir?
-                      isfile :as file?]]
-            [sys :as systest])
+    (import tests.resources [kwtest function-with-a-dash])
+            os.path [exists
+                     isdir :as dir?
+                     isfile :as file?]
+            sys :as systest)
 
     ;; Import all module functions into current namespace
     ;;
     ;; Python: from sys import *
-    (import [sys [*]])
+    (import sys [*])
 
 
 fn
@@ -1349,16 +1349,16 @@ The following are all equivalent ways to call a macro named ``foo`` in the modul
     (require mymodule)
     (mymodule.foo 1)
 
-    (require [mymodule :as M])
+    (require mymodule :as M)
     (M.foo 1)
 
-    (require [mymodule [foo]])
+    (require mymodule [foo])
     (foo 1)
 
-    (require [mymodule [*]])
+    (require mymodule [*])
     (foo 1)
 
-    (require [mymodule [foo :as bar]])
+    (require mymodule [foo :as bar])
     (bar 1)
 
 Macros that call macros
@@ -1381,7 +1381,7 @@ And then, in your main program, you write:
 
 .. code-block:: clj
 
-    (require [mymodule [foo]])
+    (require mymodule [foo])
 
     (print (mymodule.foo 3))
 
@@ -1389,8 +1389,8 @@ Running this raises ``NameError: name 'repexpr' is not defined``, even though
 writing ``(print (foo 3))`` in ``mymodule`` works fine. The trouble is that your
 main program doesn't have the macro ``repexpr`` available, since it wasn't
 imported (and imported under exactly that name, as opposed to a qualified name).
-You could do ``(require [mymodule [*]])`` or ``(require [mymodule [foo
-repexpr]])``, but a less error-prone approach is to change the definition of
+You could do ``(require mymodule [*])`` or ``(require mymodule [foo
+repexpr])``, but a less error-prone approach is to change the definition of
 ``foo`` to require whatever sub-macros it needs:
 
 .. code-block:: clj
@@ -1400,8 +1400,8 @@ repexpr]])``, but a less error-prone approach is to change the definition of
         (require mymodule)
         (mymodule.repexpr ~n (input "Gimme some input: "))))
 
-It's wise to use ``(require mymodule)`` here rather than ``(require [mymodule
-[repexpr]])`` to avoid accidentally shadowing a function named ``repexpr`` in
+It's wise to use ``(require mymodule)`` here rather than ``(require mymodule
+[repexpr])`` to avoid accidentally shadowing a function named ``repexpr`` in
 the main program.
 
 Qualified macro names

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -1296,7 +1296,7 @@ Returns an iterator by calling *fn* repeatedly.
 
 .. code-block:: hy
 
-   => (import [random [randint]])
+   => (import random [randint])
 
    => (list (take 5 (repeatedly (fn [] (randint 0 10)))))
    [6, 2, 0, 6, 7]

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -651,7 +651,7 @@ Let's take the classic:
 
 .. code-block:: clj
 
-    (require [hy.contrib.loop [loop]])
+    (require hy.contrib.loop [loop])
 
     (loop (print (eval (read))))
 
@@ -659,7 +659,7 @@ Rather than write it like that, we can write it as follows:
 
 .. code-block:: clj
 
-    (require [hy.contrib.loop [loop]])
+    (require hy.contrib.loop [loop])
 
     (-> (read) (eval) (print) (loop))
 
@@ -669,7 +669,7 @@ a pipe:
 
 .. code-block:: clj
 
-    => (import [sh [cat grep wc]])
+    => (import [sh cat grep wc])
     => (-> (cat "/usr/share/dict/words") (grep "-E" "^hy") (wc "-l"))
     210
 

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -158,7 +158,7 @@ def ideas_macro(ETname):
     return HyExpression([HySymbol('print'),
                          HyString(r"""
 
-    => (import [sh [figlet]])
+    => (import sh [figlet])
     => (figlet "Hi, Hy!")
      _   _ _     _   _       _
     | | | (_)   | | | |_   _| |
@@ -173,7 +173,7 @@ def ideas_macro(ETname):
 
 
 ;;; this one plays with command line bits
-(import [sh [cat grep]])
+(import sh [cat grep])
 (-> (cat "/usr/share/dict/words") (grep "-E" "bro$"))
 
 

--- a/hy/contrib/botsbuildbots.hy
+++ b/hy/contrib/botsbuildbots.hy
@@ -8,7 +8,7 @@
   "Build bots, repeatedly.^W^W^WPrint the AUTHORS, forever."
   `(try
     (do
-     (import [requests])
+     (import requests)
 
      (setv r (requests.get
               "https://raw.githubusercontent.com/hylang/hy/master/AUTHORS"))

--- a/hy/contrib/hy_repr.hy
+++ b/hy/contrib/hy_repr.hy
@@ -3,15 +3,15 @@
 ;; license. See the LICENSE.
 
 (import
-  [math [isnan]]
+  math [isnan]
   re
   datetime
   collections
-  [hy._compat [PY3 PY36 str-type bytes-type long-type]]
-  [hy.models [HyObject HyExpression HySymbol HyKeyword HyInteger HyFloat HyComplex HyList HyDict HySet HyString HyBytes]])
+  hy._compat [PY3 PY36 str-type bytes-type long-type]
+  hy.models [HyObject HyExpression HySymbol HyKeyword HyInteger HyFloat HyComplex HyList HyDict HySet HyString HyBytes])
 
 (try
-  (import [_collections_abc [dict-keys dict-values dict-items]])
+  (import _collections_abc [dict-keys dict-values dict-items])
   (except [ImportError]
     (defclass C)
     (setv [dict-keys dict-values dict-items] [C C C])))

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -6,7 +6,7 @@
 ;;; The loop/recur macro allows you to construct functions that use tail-call
 ;;; optimization to allow arbitrary levels of recursion.
 
-(import [hy.contrib.walk [prewalk]])
+(import hy.contrib.walk [prewalk])
 
 (defn --trampoline-- [f]
   "Wrap f function and make it tail-call optimized."
@@ -37,7 +37,7 @@
     (fn [x] (if (and (symbol? x) (= x "recur")) g!recur-fn x))
     body))
   `(do
-    (import [hy.contrib.loop [--trampoline--]])
+    (import hy.contrib.loop [--trampoline--])
     (with-decorator
       --trampoline--
       (defn ~g!recur-fn [~@signature] ~@new-body))

--- a/hy/contrib/multi.hy
+++ b/hy/contrib/multi.hy
@@ -3,8 +3,8 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [collections [defaultdict]]
-        [hy [HyExpression HyList HyString]])
+(import collections [defaultdict]
+        hy [HyExpression HyList HyString])
 
 (defclass MultiDispatch [object] [
 
@@ -56,17 +56,17 @@
   apply-decorator)
  
 (defmacro defmulti [name params &rest body]
-  `(do (import [hy.contrib.multi [multi-decorator]])
+  `(do (import hy.contrib.multi [multi-decorator])
        (with-decorator multi-decorator
          (defn ~name ~params ~@body))))
 
 (defmacro defmethod [name multi-key params &rest body]
-  `(do (import [hy.contrib.multi [method-decorator]])
+  `(do (import hy.contrib.multi [method-decorator])
        (with-decorator (method-decorator ~name ~multi-key)
          (defn ~name ~params ~@body))))
 
 (defmacro default-method [name params &rest body]
-  `(do (import [hy.contrib.multi [method-decorator]])
+  `(do (import hy.contrib.multi [method-decorator])
        (with-decorator (method-decorator ~name)
          (defn ~name ~params ~@body))))
 
@@ -85,7 +85,7 @@
      (if (= (type (first bodies)) HyString)
        (setv [comment bodies] (head-tail bodies)))
      (setv ret `(do))
-     (.append ret '(import [hy.contrib.multi [MultiDispatch]]))
+     (.append ret '(import hy.contrib.multi [MultiDispatch]))
      (for [body bodies]
        (setv [let-binds body] (head-tail body))
        (.append ret 

--- a/hy/contrib/profile.hy
+++ b/hy/contrib/profile.hy
@@ -8,8 +8,8 @@
 
 (defmacro profile/calls [&rest body]
   `(do
-     (import [pycallgraph [PyCallGraph]]
-             [pycallgraph.output [GraphvizOutput]])
+     (import pycallgraph [PyCallGraph]
+             pycallgraph.output [GraphvizOutput])
      (with* [(PyCallGraph :output (GraphvizOutput))]
            ~@body)))
 
@@ -20,8 +20,8 @@
      (import cProfile pstats)
 
      (if-python2
-       (import [StringIO [StringIO]])
-       (import [io [StringIO]]))
+       (import StringIO [StringIO])
+       (import io [StringIO])
 
      (setv ~g!hy-pr (.Profile cProfile))
      (.enable ~g!hy-pr)

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -3,11 +3,11 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy [HyExpression HyDict]]
-        [functools [partial]]
-        [collections [OrderedDict]]
-        [hy.macros [macroexpand :as mexpand]]
-        [hy.compiler [HyASTCompiler]])
+(import hy [HyExpression HyDict]
+        functools [partial]
+        collections [OrderedDict]
+        hy.macros [macroexpand :as mexpand]
+        hy.compiler [HyASTCompiler])
 
 (defn walk [inner outer form]
   "Traverses form, an arbitrary data structure. Applies inner to each

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -8,21 +8,21 @@
 
 (import itertools)
 (import functools)
-(import [fractions [Fraction :as fraction]])
+(import fractions [Fraction :as fraction])
 (import operator)  ; shadow not available yet
 (import sys)
 (if-python2
-  (import [StringIO [StringIO]])
-  (import [io [StringIO]]))
-(import [hy._compat [long-type]]) ; long for python2, int for python3
+  (import StringIO [StringIO])
+  (import io [StringIO]))
+(import hy._compat [long-type]) ; long for python2, int for python3
 (if-python2
-  (import [collections :as cabc])
-  (import [collections.abc :as cabc]))
-(import [hy.models [HySymbol HyKeyword]])
-(import [hy.lex [LexException PrematureEndOfInput tokenize]])
-(import [hy.lex.parser [mangle unmangle]])
-(import [hy.compiler [HyASTCompiler spoof-positions]])
-(import [hy.importer [hy-eval :as eval]])
+  (import collections :as cabc)
+  (import collections.abc :as cabc))
+(import hy.models [HySymbol HyKeyword])
+(import hy.lex [LexException PrematureEndOfInput tokenize])
+(import hy.lex.parser [mangle unmangle])
+(import hy.compiler [HyASTCompiler spoof-positions])
+(import hy.importer [hy-eval :as eval])
 
 (defn butlast [coll]
   "Return an iterator of all but the last item in `coll`."
@@ -207,7 +207,7 @@ Return series of accumulated sums (or other binary function results)."
   "Check if `s` is a symbol."
   (instance? HySymbol s))
 
-(import [threading [Lock]])
+(import threading [Lock])
 (setv _gensym_counter 1234)
 (setv _gensym_lock (Lock))
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -7,7 +7,7 @@
 ;;; They are automatically required in every module, except inside hy.core
 
 
-(import [hy.models [HyList HySymbol]])
+(import hy.models [HyList HySymbol])
 
 (defmacro as-> [head name &rest rest]
   "Beginning with `head`, expand a sequence of assignments `rest` to `name`.

--- a/hy/core/shadow.hy
+++ b/hy/core/shadow.hy
@@ -5,10 +5,10 @@
 ;;;; Hy shadow functions
 
 (import operator)
-(import [hy._compat [PY3 PY35]])
+(import hy._compat [PY3 PY35])
 
 (if PY3
-  (import [functools [reduce]]))
+  (import functools [reduce]))
 
 (defn + [&rest args]
   "Shadowed `+` operator adds `args`."

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -258,21 +258,25 @@ def test_ast_bad_yield():
 
 def test_ast_good_import_from():
     "Make sure AST can compile valid selective import"
-    can_compile("(import [x [y]])")
+    can_compile("(import x)")
+    can_compile("(import x y)")
+    can_compile("(import x :as y)")
+    can_compile("(import x [y])")
+    can_compile("(import x y :as z)")
+    can_compile("(import x [y :as z])")
 
 
 def test_ast_require():
     "Make sure AST respects (require) syntax"
     can_compile("(require tests.resources.tlib)")
-    can_compile("(require [tests.resources.tlib [qplah parald]])")
-    can_compile("(require [tests.resources.tlib [*]])")
-    can_compile("(require [tests.resources.tlib :as foobar])")
-    can_compile("(require [tests.resources.tlib [qplah :as quiz]])")
-    can_compile("(require [tests.resources.tlib [qplah :as quiz parald]])")
-    cant_compile("(require [tests.resources.tlib])")
-    cant_compile("(require [tests.resources.tlib [* qplah]])")
-    cant_compile("(require [tests.resources.tlib [qplah *]])")
-    cant_compile("(require [tests.resources.tlib [* *]])")
+    can_compile("(require tests.resources.tlib [qplah parald])")
+    can_compile("(require tests.resources.tlib [*])")
+    can_compile("(require tests.resources.tlib :as foobar)")
+    can_compile("(require tests.resources.tlib [qplah :as quiz])")
+    can_compile("(require tests.resources.tlib [qplah :as quiz parald])")
+    cant_compile("(require tests.resources.tlib [* qplah])")
+    cant_compile("(require tests.resources.tlib [qplah *])")
+    cant_compile("(require tests.resources.tlib [* *])")
 
 
 def test_ast_no_pointless_imports():

--- a/tests/native_tests/contrib/hy_repr.hy
+++ b/tests/native_tests/contrib/hy_repr.hy
@@ -3,9 +3,9 @@
 ;; license. See the LICENSE.
 
 (import
-  [hy._compat [PY3 PY36 PY37]]
-  [math [isnan]]
-  [hy.contrib.hy-repr [hy-repr hy-repr-register]])
+  hy._compat [PY3 PY36 PY37]
+  math [isnan]
+  hy.contrib.hy-repr [hy-repr hy-repr-register])
 
 (defn test-hy-repr-roundtrip-from-value []
   ; Test that a variety of values round-trip properly.
@@ -85,7 +85,7 @@
   (assert (= (hy-repr (.items {1 2})) "(dict-items [(, 1 2)])"))))
 
 (defn test-datetime []
-  (import [datetime :as D])
+  (import datetime :as D)
 
   (assert (= (hy-repr (D.datetime 2009 1 15 15 27 5 0))
     "(datetime.datetime 2009 1 15 15 27 5)"))

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(require [hy.contrib.loop [loop]])
+(require hy.contrib.loop [loop])
 (import sys)
 
 (defn tco-sum [x y]

--- a/tests/native_tests/contrib/multi.hy
+++ b/tests/native_tests/contrib/multi.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(require [hy.contrib.multi [defmulti defmethod default-method defn]])
+(require hy.contrib.multi [defmulti defmethod default-method defn])
 
 (defn test-different-signatures []
   "NATIVE: Test multimethods with different signatures"

--- a/tests/native_tests/contrib/sequences.hy
+++ b/tests/native_tests/contrib/sequences.hy
@@ -2,9 +2,9 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(require [hy.contrib.sequences [seq defseq]])
+(require hy.contrib.sequences [seq defseq])
 
-(import [hy.contrib.sequences [Sequence end-sequence]])
+(import hy.contrib.sequences [Sequence end-sequence])
 
 (defn test-infinite-sequence []
   "NATIVE: test creating infinite sequence"

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -2,8 +2,8 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy.contrib.walk [*]])
-(require [hy.contrib.walk [*]])
+(import hy.contrib.walk [*])
+(require hy.contrib.walk [*])
 
 (import pytest)
 

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy._compat [PY3]])
+(import hy._compat [PY3])
 
 ;;;; some simple helpers
 
@@ -269,7 +269,7 @@ result['y in globals'] = 'y' in globals()")
 
 (defn test-gensym []
   "NATIVE: testing the gensym function"
-  (import [hy.models [HySymbol]])
+  (import hy.models [HySymbol])
   (setv s1 (gensym))
   (assert (isinstance s1 HySymbol))
   (assert (= 0 (.find s1 "_;G|")))

--- a/tests/native_tests/extra/anaphoric.hy
+++ b/tests/native_tests/extra/anaphoric.hy
@@ -2,8 +2,8 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy.errors [HyMacroExpansionError]])
-(require [hy.extra.anaphoric [*]])
+(import hy.errors [HyMacroExpansionError])
+(require hy.extra.anaphoric [*])
 
 ;;;; some simple helpers
 

--- a/tests/native_tests/extra/reserved.hy
+++ b/tests/native_tests/extra/reserved.hy
@@ -2,7 +2,8 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy.extra.reserved [names]] [hy._compat [PY3]])
+(import hy.extra.reserved [names]
+        hy._compat [PY3])
 
 (defn test-reserved []
   (assert (is (type (names)) frozenset))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -2,16 +2,15 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [tests.resources [kwtest function-with-a-dash]]
-        [os.path [exists isdir isfile]]
-        [sys :as systest]
+(import tests.resources [kwtest function-with-a-dash]
+        os.path [exists isdir isfile]
+        sys
         re
-        [operator [or_]]
-        [hy.errors [HyTypeError]]
+        operator [or_]
+        hy.errors [HyTypeError]
         pytest)
-(import sys)
 
-(import [hy._compat [PY3 PY35 PY37]])
+(import hy._compat [PY3 PY35 PY37])
 
 (defn test-sys-argv []
   "NATIVE: test sys.argv"
@@ -898,6 +897,7 @@
 
 (defn test-importas []
   "NATIVE: test import as"
+  (import sys :as systest)
   (assert (!= (len systest.path) 0)))
 
 
@@ -1375,21 +1375,22 @@
   (import sys os)
 
   ;; from os.path import basename
-  (import [os.path [basename]])
+  (import os.path [basename])
   (assert (= (basename "/some/path") "path"))
 
   ;; import os.path as p
-  (import [os.path :as p])
+  (import os.path :as p)
   (assert (= p.basename basename))
 
   ;; from os.path import basename as bn
-  (import [os.path [basename :as bn]])
+  (import os.path [basename :as bn])
   (assert (= bn basename))
 
   ;; Multiple stuff to import
-  (import sys [os.path [dirname]]
-          [os.path :as op]
-          [os.path [dirname :as dn]])
+  (import sys
+          os.path :as op
+          os.path [dirname]
+          os.path [dirname :as dn])
   (assert (= (dirname "/some/path") "/some"))
   (assert (= op.dirname dirname))
   (assert (= dn dirname)))
@@ -1475,7 +1476,7 @@
   (try (parald 1 2 3 4)
        (except [NameError] True)
        (else (assert False)))
-  (require [tests.resources.tlib [qplah]])
+  (require tests.resources.tlib [qplah])
   (assert (= (qplah 1 2 3) [8 1 2 3]))
   (try (parald 1 2 3 4)
        (except [NameError] True)
@@ -1485,17 +1486,17 @@
   (try (parald 1 2 3 4)
        (except [NameError] True)
        (else (assert False)))
-  (require [tests.resources.tlib :as T])
+  (require tests.resources.tlib :as T)
   (assert (= (T.parald 1 2 3) [9 1 2 3]))
   (try (parald 1 2 3 4)
        (except [NameError] True)
        (else (assert False)))
-  (require [tests.resources.tlib [parald :as p]])
+  (require tests.resources.tlib [parald :as p])
   (assert (= (p 1 2 3) [9 1 2 3]))
   (try (parald 1 2 3 4)
        (except [NameError] True)
        (else (assert False)))
-  (require [tests.resources.tlib [*]])
+  (require tests.resources.tlib [*])
   (assert (= (parald 1 2 3) [9 1 2 3])))
 
 
@@ -1516,7 +1517,7 @@
                   (assert (= x [3 2 1]))
                   "success")
               (except [NameError] "failure"))))
-  (require [tests.native_tests.native_macros [rev]])
+  (require tests.native_tests.native_macros [rev])
   (assert (= "success"
              (try
               (do (setv x [])
@@ -1589,7 +1590,7 @@
 (defn test-macroexpand-with-named-import []
   ; https://github.com/hylang/hy/issues/1207
   (defmacro m-with-named-import []
-    (import [math [pow]])
+    (import math [pow])
     (pow 2 3))
   (assert (= (macroexpand '(m-with-named-import)) (** 2 3))))
 
@@ -1677,9 +1678,9 @@ macros()
 (defn test-read []
   "NATIVE: test that read takes something for stdin and reads"
   (if-python2
-    (import [StringIO [StringIO]])
-    (import [io [StringIO]]))
-  (import [hy.models [HyExpression]])
+    (import StringIO [StringIO])
+    (import io [StringIO]))
+  (import hy.models [HyExpression])
 
   (setv stdin-buffer (StringIO "(+ 2 2)\n(- 2 2)"))
   (assert (= (eval (read stdin-buffer)) 4))
@@ -1787,11 +1788,11 @@ macros()
   (assert (= (f3) "not a docstring")))
 
 (defn test-module-docstring []
-  (import [tests.resources.module-docstring-example :as m])
+  (import tests.resources.module-docstring-example :as m)
   (assert (= m.__doc__ "This is the module docstring."))
   (assert (= m.foo 5)))
 
 (defn test-relative-import []
   "Make sure relative imports work properly"
-  (import [..resources [tlib]])
+  (import ..resources [tlib])
   (assert (= tlib.SECRET-MESSAGE "Hello World")))

--- a/tests/native_tests/mangling.hy
+++ b/tests/native_tests/mangling.hy
@@ -3,7 +3,7 @@
 ;; license. See the LICENSE.
 
 
-(import [hy._compat [PY3]])
+(import hy._compat [PY3])
 
 
 (defn test-hyphen []

--- a/tests/native_tests/mathematics.hy
+++ b/tests/native_tests/mathematics.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy._compat [PY35]])
+(import hy._compat [PY35])
 
 (setv square (fn [x]
                (* x x)))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy.errors [HyTypeError]])
+(import hy.errors [HyTypeError])
 
 (defmacro rev [&rest body]
   "Execute the `body` statements in reverse"
@@ -138,8 +138,8 @@
 
 (defn test-gensym-in-macros []
   (import ast)
-  (import [astor.code-gen [to-source]])
-  (import [hy.importer [import_buffer_to_ast]])
+  (import astor.code-gen [to-source])
+  (import hy.importer [import_buffer_to_ast])
   (setv macro1 "(defmacro nif [expr pos zero neg]
       (setv g (gensym))
       `(do
@@ -164,8 +164,8 @@
 
 (defn test-with-gensym []
   (import ast)
-  (import [astor.code-gen [to-source]])
-  (import [hy.importer [import_buffer_to_ast]])
+  (import astor.code-gen [to-source])
+  (import hy.importer [import_buffer_to_ast])
   (setv macro1 "(defmacro nif [expr pos zero neg]
       (with-gensyms [a]
         `(do
@@ -188,8 +188,8 @@
 
 (defn test-defmacro-g! []
   (import ast)
-  (import [astor.code-gen [to-source]])
-  (import [hy.importer [import_buffer_to_ast]])
+  (import astor.code-gen [to-source])
+  (import hy.importer [import_buffer_to_ast])
   (setv macro1 "(defmacro/g! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
@@ -217,8 +217,8 @@
 (defn test-defmacro! []
   ;; defmacro! must do everything defmacro/g! can
   (import ast)
-  (import [astor.code-gen [to-source]])
-  (import [hy.importer [import_buffer_to_ast]])
+  (import astor.code-gen [to-source])
+  (import hy.importer [import_buffer_to_ast])
   (setv macro1 "(defmacro! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import pytest [hy._compat [PY35]])
+(import pytest hy._compat [PY35])
 
 (defmacro op-and-shadow-test [op &rest body]
   ; Creates two tests with the given `body`, one where all occurrences
@@ -12,7 +12,7 @@
   ;
   ; `op` can also be a list of operators, in which case two tests are
   ; created for each operator.
-  (import [hy [HySymbol HyString]] [hy.contrib.walk [prewalk]])
+  (import hy [HySymbol HyString] hy.contrib.walk [prewalk])
   (setv defns [])
   (for [o (if (coll? op) op [op])]
     (.append defns `(defn ~(HySymbol (+ "test_operator_" o "_real")) []

--- a/tests/native_tests/py35_only_tests.hy
+++ b/tests/native_tests/py35_only_tests.hy
@@ -5,7 +5,7 @@
 ;; Tests where the emitted code relies on Python ≥3.5.
 ;; conftest.py skips this file when running on Python <3.5.
 
-(import [asyncio [get-event-loop sleep]])
+(import asyncio [get-event-loop sleep])
 
 
 (defn test-unpacking-pep448-1star []

--- a/tests/native_tests/py36_only_tests.hy
+++ b/tests/native_tests/py36_only_tests.hy
@@ -5,7 +5,7 @@
 ;; Tests where the emitted code relies on Python ≥3.6.
 ;; conftest.py skips this file when running on Python <3.6.
 
-(import [asyncio [get-event-loop sleep]])
+(import asyncio [get-event-loop sleep])
 
 
 (defn run-coroutine [coro]

--- a/tests/native_tests/py3_only_tests.hy
+++ b/tests/native_tests/py3_only_tests.hy
@@ -71,7 +71,7 @@
         (yield 4))))
   (assert (= (list (yield-from-test)) [0 1 2 1 2 3 4])))
 
-(require [hy.contrib.walk [let]])
+(require hy.contrib.walk [let])
 
 (defn test-let-optional []
   (let [a 1

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy [HyExpression HySymbol HyString HyBytes HyDict]])
+(import hy [HyExpression HySymbol HyString HyBytes HyDict])
 
 
 (defn test-quote []

--- a/tests/native_tests/tag_macros.hy
+++ b/tests/native_tests/tag_macros.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [functools [wraps]])
+(import functools [wraps])
 
 
 (defn test-tag-macro []

--- a/tests/resources/pydemo.hy
+++ b/tests/resources/pydemo.hy
@@ -50,9 +50,8 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
 (del (get delstatement 1))
 
 (import math)
-(import [math [sqrt]])
-(import [math [sin :as sine]])
-(import [datetime [*]])
+(import math [sqrt sin :as sine])
+(import datetime [*])
 
 (setv if-block "")
 (if 0
@@ -139,7 +138,7 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
   [attr1 5  attr2 6]
   (setv attr3 7))
 
-(import [contextlib [closing]])
+(import contextlib [closing])
 (setv closed [])
 (defclass Closeable []
   [close (fn [self] (.append closed self.x))])


### PR DESCRIPTION
Removes an unnecessary level of indentation, and changes them from using lists to expressions. See for details #1612

Nice work with the pattern matching compiler, its really easy to make the change.