### PR TITLE
Get  Travis and Python 3.7 working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
   - pypy
   - pypy3
 install:

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1625,11 +1625,6 @@
 (defn test-disassemble []
   "NATIVE: Test the disassemble function"
   (assert (= (disassemble '(do (leaky) (leaky) (macros))) (cond
-    [PY37 "Module(
-    body=[Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),
-        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),
-        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[]))],
-    docstring=None)"]
     [PY35 "Module(
     body=[Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),
         Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),


### PR DESCRIPTION
Closes #1627.

We need to both stop testing the old Python 3.7 on Travis, and fix our code to work on the latest Python 3.7.