### PR TITLE
 Look for o!-syms in (flatten args) of defmacro!

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -88,3 +88,4 @@
 * Yoan Tournade <yoan@ytotech.com>
 * Simon Gomizelj <simon@vodik.xyz>
 * Yigong Wang <wang@yigo.ng>
+* Oskar Kvist <oskar.kvist@gmail.com>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -54,6 +54,7 @@ New Features
 * `while` and `for` are allowed to have empty bodies
 * `for` supports the various new clause types offered by `lfor`
 * Added a new module ``hy.model_patterns``
+* `defmacro!` now allows optional args
 
 Bug Fixes
 ------------------------------

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -206,7 +206,12 @@ the second form, the second result is inserted into the third form, and so on."
   "Like `defmacro/g!`, with automatic once-only evaluation for 'o!' params.
 
 Such 'o!' params are available within `body` as the equivalent 'g!' symbol."
-  (setv os (lfor s args :if (.startswith s "o!") s)
+  (defn extract-o!-sym [arg]
+    (cond [(and (symbol? arg) (.startswith arg "o!"))
+           arg]
+          [(and (instance? list arg) (.startswith (first arg) "o!"))
+           (first arg)]))
+  (setv os (list (filter identity (map extract-o!-sym args)))
         gs (lfor s os (HySymbol (+ "g!" (cut s 2)))))
   `(defmacro/g! ~name ~args
      `(do (setv ~@(interleave ~gs ~os))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -257,7 +257,14 @@
   ;; test that o! is evaluated once only
   (setv foo 40)
   (foo! (+= foo 1))
-  (assert (= 41 foo)))
+  (assert (= 41 foo))
+  ;; test &optional args
+  (defmacro! bar! [o!a &optional [o!b 1]] `(do ~g!a ~g!a ~g!b ~g!b))
+  ;; test that o!s are evaluated once only
+  (bar! (+= foo 1) (+= foo 1))
+  (assert (= 43 foo))
+  ;; test that the optional arg works
+  (assert (= (bar! 2) 1)))
 
 
 (defn test-if-not []


### PR DESCRIPTION
Being able to have o!-symbols in lists nested in the arglist of `defmacro!` seems like a good idea to me. Otherwise one couldn't do things like

    (defmacro! if-let [[sym o!expr] then else]
      `(if ~g!expr (let [~sym ~g!expr] ~then) ~else))

If this is not allowed, `defmacro!` is pretty useless for writing `if-let` in particular; at least I *think* so.

The tests didn't pass before I started. :P