### PR TITLE
Make importing a dotted name a syntax error, per Python

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -67,6 +67,7 @@ Bug Fixes
 * `NaN` can no longer create an infinite loop during macro-expansion
 * Fixed a bug that caused `try` to drop expressions
 * Fixed a bug where the compiler didn't properly compile `unquote-splice`
+* Trying to import a dotted name is now a syntax error, as in Python
 
 Misc. Improvements
 ----------------------------

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1176,10 +1176,12 @@ class HyASTCompiler(object):
 
         return operand
 
+    _symn = some(lambda x: isinstance(x, HySymbol) and "." not in x)
+
     @special(["import", "require"], [many(
         SYM |
-        brackets(SYM, sym(":as"), SYM) |
-        brackets(SYM, brackets(many(SYM + maybe(sym(":as") + SYM)))))])
+        brackets(SYM, sym(":as"), _symn) |
+        brackets(SYM, brackets(many(_symn + maybe(sym(":as") + _symn)))))])
     def compile_import_or_require(self, expr, root, entries):
         """
         TODO for `require`: keep track of what we've imported in this run and

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -283,6 +283,13 @@ def test_ast_require():
     cant_compile("(require [tests.resources.tlib [* *]])")
 
 
+def test_ast_import_require_dotted():
+    """As in Python, it should be a compile-type error to attempt to
+import a dotted name."""
+    cant_compile("(import [spam [foo.bar]])")
+    cant_compile("(require [spam [foo.bar]])")
+
+
 def test_ast_no_pointless_imports():
     def contains_import_from(code):
         return any([isinstance(node, ast.ImportFrom)


### PR DESCRIPTION
Closes #1629.