### PR TITLE
Adjust Python version check for `cache_from_source`.

### DIFF
--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -21,6 +21,7 @@ except ImportError:
 import sys, keyword
 
 PY3 = sys.version_info[0] >= 3
+PY34 = sys.version_info >= (3, 4)
 PY35 = sys.version_info >= (3, 5)
 PY36 = sys.version_info >= (3, 6)
 PY37 = sys.version_info >= (3, 7)

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -20,7 +20,7 @@ import inspect
 import os
 import __future__
 
-from hy._compat import PY3, PY37, MAGIC, builtins, long_type, wr_long
+from hy._compat import PY3, PY34, PY37, MAGIC, builtins, long_type, wr_long
 from hy._compat import string_types
 
 
@@ -275,7 +275,7 @@ def is_package(module_name):
 
 
 def get_bytecode_path(source_path):
-    if PY3:
+    if PY34:
         import importlib.util
         return importlib.util.cache_from_source(source_path)
     elif hasattr(imp, "cache_from_source"):


### PR DESCRIPTION
Python 3.3 will fail when Hy tries to use `importlib.util.cache_from_source`,
because it was actually introduced in Python 3.4.

https://docs.python.org/3/library/importlib.html#importlib.util.cache_from_source