### PR TITLE
Expand `require`d macros in `macroexpand-all`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,3 +89,4 @@
 * Simon Gomizelj <simon@vodik.xyz>
 * Yigong Wang <wang@yigo.ng>
 * Oskar Kvist <oskar.kvist@gmail.com>
+* Brandon T. Willard <brandonwillard@gmail.com>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -86,6 +86,7 @@ Misc. Improvements
 ----------------------------
 * `hy-repr` uses registered functions instead of methods.
 * `hy-repr` supports more standard types.
+* `macroexpand-all` will now expand macros introduced by a `require` in the body of a macro.
 
 0.14.0
 ==============================

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -43,7 +43,8 @@
 (defn macroexpand-all [form &optional module-name]
   "Recursively performs all possible macroexpansions in form."
   (setv module-name (or module-name (calling-module-name))
-        quote-level [0])  ; TODO: make nonlocal after dropping Python2
+        quote-level [0]
+        ast-compiler (HyASTCompiler module-name))  ; TODO: make nonlocal after dropping Python2
   (defn traverse [form]
     (walk expand identity form))
   (defn expand [form]
@@ -64,7 +65,10 @@
                      [True (traverse form)])]
               [(= (first form) 'quote) form]
               [(= (first form) 'quasiquote) (+quote)]
-              [True (traverse (mexpand form (HyASTCompiler module-name)))])
+              [(= (first form) (HySymbol "require"))
+               (ast-compiler.compile form)
+               (return)]
+              [True (traverse (mexpand form ast-compiler))])
         (if (coll? form)
             (traverse form)
             form)))
@@ -325,4 +329,3 @@ as can nested let forms.
                      expander)))
 
 ;; (defmacro macrolet [])
-

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -56,7 +56,15 @@
                 (do '(with [b 2])
                     `(with [c 3]
                        ~(with* [d 4] (do))
-                       ~@[(with* [e 5] (do))]))))))
+                       ~@[(with* [e 5] (do))])))))
+
+  (defmacro require-macro []
+    `(do
+       (require [tests.resources.macros [test-macro :as my-test-macro]])
+       (my-test-macro)))
+
+  (assert (= (last (macroexpand-all '(require-macro)))
+             '(setv blah 1))))
 
 (defn test-let-basic []
   (assert (zero? (let [a 0] a)))

--- a/tests/resources/macros.hy
+++ b/tests/resources/macros.hy
@@ -7,3 +7,6 @@
   (defn f [&rest args] (.join "" (+ (, "c") args)))
   (setv variable (HySymbol (->> "d" (f))))
   `(setv ~variable 5))
+
+(defmacro test-macro []
+  '(setv blah 1))


### PR DESCRIPTION
Minor change that allows `macroexpand-all` to expand `require`d macros.

See [this discussion for some context](https://github.com/algernon/adderall/pull/9#issuecomment-407560245).