### PR TITLE
Point out appropriate help forums

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,1 +1,7 @@
-If you're reporting a bug, make sure you can reproduce it with the very latest, bleeding-edge version of Hy from the `master` branch on GitHub. Bugs in stable versions of Hy are fixed on `master` before the fix makes it into a new stable release. You can delete this text after reading it.
+Hy's issue list is for bugs, complaints, and feature requests.
+
+For help with Hy, ask on our IRC channel (may take up to a day), Stack Overflow with the `[hy]` tag, or on our mailing list.
+
+If you're reporting a bug, make sure you can reproduce it with the very latest, bleeding-edge version of Hy from the `master` branch on GitHub. Bugs in stable versions of Hy are fixed on `master` before the fix makes it into a new stable release.
+
+You can delete this text after reading it.


### PR DESCRIPTION
I occasionally see issues like #1667, #1666, #1595, etc. that probably shouldn't be on our issue list.

I considered adding a RTFM--sometimes these questions are about simple things that are clearly spelled out in the manual, but it can be hard to search it for special characters. (It might be easier to clone and grep the repo just to find the right docs sometimes.)

Does anyone still check the mailing list? I pretty much never use it. I am watching the `[hy]` tag on Stack Overflow, and would usually get around to checking our IRC channel via Matrix within about a day.

Also helps a little with #1357.

If anyone feels they can word this more politely without losing clarity for someone in a hurry, feel free to push changes.

I'd call this a doc fix, so one approval will suffice.