### PR TITLE
Allow `runpy` to consider non-standard Hy source extensions

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -19,7 +19,7 @@ import astor.code_gen
 import hy
 from hy.lex import LexException, PrematureEndOfInput, mangle
 from hy.compiler import HyTypeError, hy_compile
-from hy.importer import hy_eval, hy_parse
+from hy.importer import hy_eval, hy_parse, runhy
 from hy.completer import completion, Completer
 from hy.macros import macro, require
 from hy.models import HyExpression, HyString, HySymbol
@@ -352,7 +352,7 @@ def cmdline_handler(scriptname, argv):
 
             try:
                 sys.argv = options.args
-                runpy.run_path(filename, run_name='__main__')
+                runhy.run_path(filename, run_name='__main__')
                 return 0
             except FileNotFoundError as e:
                 print("hy: Can't open file '{0}': [Errno {1}] {2}".format(

--- a/tests/resources/no_extension
+++ b/tests/resources/no_extension
@@ -1,0 +1,2 @@
+#!/usr/bin/env hy
+(print "This Should Still Work")

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -382,3 +382,9 @@ def test_bin_hy_module_no_main():
 def test_bin_hy_sys_executable():
     output, _ = run_cmd("hy -c '(do (import sys) (print sys.executable))'")
     assert output.strip().endswith('/hy')
+
+
+def test_bin_hy_file_no_extension():
+    """Confirm that a file with no extension is processed as Hy source"""
+    output, _ = run_cmd("hy tests/resources/no_extension")
+    assert "This Should Still Work" in output


### PR DESCRIPTION
Adds Hy parsing of files with unrecognized source extensions to cmdline Hy.

~~The fallback is tried only after first attempting standard Python compilation.  If the attempt raises a `SyntaxError` (and the file is not clearly identified as Python source via its extension), then it tries Hy.
The reason for choosing the order Python-then-Hy is somewhat arbitrary, except for the impression that Python's parsing might be more efficient than Hy's and, thus, better as a first attempt.~~