### PR TITLE
Fix missing import in `doc` macro expansion

### DIFF
--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -6,8 +6,6 @@
 ;;; These macros form the hy language
 ;;; They are automatically required in every module, except inside hy.core
 
-(import [importlib [import-module]])
-
 (import [hy.models [HyList HySymbol]])
 
 (defmacro as-> [head name &rest rest]
@@ -248,6 +246,7 @@ Such 'o!' params are available within `body` as the equivalent 'g!' symbol."
    Use ``#doc foo`` instead for help with tag macro ``#foo``.
    Use ``(help foo)`` instead for help with runtime objects."
   `(try
+     (import [importlib [import-module]])
      (help (. (import-module "hy")
               macros
               _hy_macros
@@ -265,6 +264,7 @@ Such 'o!' params are available within `body` as the equivalent 'g!' symbol."
 
    Gets help for a tag macro function available in this module."
   `(try
+     (import [importlib [import-module]])
      (help (. (import-module "hy")
               macros
               _hy_tag

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -682,3 +682,10 @@ result['y in globals'] = 'y' in globals()")
 (defn test-comment []
   (assert-none (comment <h1>This is merely a comment.</h1>
                         <p> Move along. (Nothing to see here.)</p>)))
+
+(defn test-doc [capsys]
+  (doc doc)
+  (setv out_err (.readouterr capsys))
+  (assert (.startswith (.strip (first out_err))
+            "Help on function (doc) in module hy.core.macros:"))
+  (assert (empty? (second out_err))))


### PR DESCRIPTION
The doc macro expands without importing `importlib.import_module`, so, if the expansion namespace doesn't have `import_module` present, `doc` will fail.  This PR corrects that and introduces a missing test for the `doc` macro.
