### PR TITLE
Fix `sys.modules` for failed imports in Python 2.7

### DIFF
--- a/tests/resources/fails.hy
+++ b/tests/resources/fails.hy
@@ -1,0 +1,5 @@
+"This module produces an error when imported."
+(defmacro a-macro [x]
+  (+ x 1))
+
+(print (a-macro 'blah))


### PR DESCRIPTION
Newly imported modules with compile and/or run-time errors were not being removed from `sys.modules`.  This commit modifies the Python 2.7 loader so that it follows Python's failed-initial-import logic and fixes the issue.