### PR TITLE
Add a macro for punning keyword arguments

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -12,6 +12,7 @@ New Features
 * Keyword objects (not just literal keywords) can be called, as
   shorthand for `(get obj :key)`, and they accept a default value
   as a second argument.
+* Added a new core macro `pun`.
 
 Bug Fixes
 ------------------------------

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -1325,6 +1325,20 @@ print
 .. note:: ``print`` always returns ``None``.
 
 
+pun
+---
+
+The ``pun`` macro provides a shorthand for setting a keyword argument equal to
+a variable of the same name. Any argument that's a literal keyword beginning
+with a caret (``^``) is replaced, such that ``:^foo`` becomes ``:foo foo``, and
+the result is an expression of all the arguments. For example, the following::
+
+    (pun dict :^monitor :^verbose :^cv-folds)
+
+expands to::
+
+    (dict  :monitor monitor  :verbose verbose  :cv-folds cv-folds)
+
 quasiquote
 ----------
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -6,7 +6,7 @@
 ;;; These macros form the hy language
 ;;; They are automatically required in every module, except inside hy.core
 
-(import [hy.models [HyList HySymbol]])
+(import [hy.models [HyList HySymbol HyKeyword HyExpression]])
 
 (defmacro as-> [head name &rest rest]
   "Beginning with `head`, expand a sequence of assignments `rest` to `name`.
@@ -276,3 +276,10 @@ Such 'o!' params are available within `body` as the equivalent 'g!' symbol."
                 _hy_tag
                 [None]
                 ['~symbol])))))
+
+
+(defmacro pun [&rest body]
+  (HyExpression (reduce + (gfor x body
+    (if (and (keyword? x) (.startswith x.name "^"))
+      [(HyKeyword (cut x.name 1)) (HySymbol (cut x.name 1))]
+      [x])))))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -2,7 +2,8 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy.errors [HyTypeError]])
+(import [tests.resources [kwtest]]
+        [hy.errors [HyTypeError]])
 
 (defmacro rev [&rest body]
   "Execute the `body` statements in reverse"
@@ -329,3 +330,9 @@
     (except [e SystemExit]
       (assert (= (str e) "42"))))
   (setv --name-- oldname))
+
+(defn test-pun []
+  (setv foo 15)
+  (assert (= (pun kwtest :^foo) {"foo" 15}))
+  (setv ^⁂ 16)
+  (assert (= (pun kwtest :^^⁂) {"hyx_Xcircumflex_accentXXasterismX" 16})))


### PR DESCRIPTION
Closes #1119.

Replaces  #1685.