### PR TITLE
Fix build status badge

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Welcome to Hy's documentation!
 :List: `hylang-discuss <https://groups.google.com/forum/#!forum/hylang-discuss>`_
 :IRC: ``#hy`` on Freenode
 :Build status:
-    .. image:: https://secure.travis-ci.org/hylang/hy.png
+    .. image:: https://secure.travis-ci.org/hylang/hy.png?branch=master
         :alt: Travis CI
         :target: http://travis-ci.org/hylang/hy
 


### PR DESCRIPTION
I'm not sure why this is currently red, maybe it references the latest build from here: https://travis-ci.org/hylang/hy/builds. 

The image url with the explicit branch is probably the better choice.