### PR TITLE
Reuse Hy compiler instances

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,8 @@ Removals
 
 New Features
 ------------------------------
+* `eval` / `hy_eval` and `hy_compile` now accept an optional `compiler` argument
+  that enables the use of an existing `HyASTCompiler` instance.
 * Keyword objects (not just literal keywords) can be called, as
   shorthand for `(get obj :key)`, and they accept a default value
   as a second argument.

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -195,7 +195,9 @@ eval
 ``eval`` evaluates a quoted expression and returns the value. The optional
 second and third arguments specify the dictionary of globals to use and the
 module name. The globals dictionary defaults to ``(local)`` and the module name
-defaults to the name of the current module.
+defaults to the name of the current module.  An optional fourth keyword parameter,
+``compiler``, allows one to re-use an existing ``HyASTCompiler`` object for the
+compilation step.
 
 .. code-block:: clj
 
@@ -1403,4 +1405,3 @@ are available. Some of their names have been changed:
   - ``dropwhile`` has been changed to ``drop-while``
 
   - ``filterfalse`` has been changed to ``remove``
-


### PR DESCRIPTION
Every call to `hy_eval` and `hy_compile` will create a new `HyASTCompiler` instance, which incurs Hy standard library setup costs each time.  When calls to these functions occur more than once (e.g. by use of `HyREPL` and `eval-and-compile`), the aforementioned work is performed unnecessarily for the same module.  These changes avoid that unneeded and error-prone repetition.

- [x] #1698 