### PR TITLE
Don't install get_version.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,6 @@ setup(
         'hy.core': ['*.hy', '__pycache__/*'],
         'hy.extra': ['*.hy', '__pycache__/*'],
     },
-    data_files=[
-        ('get_version', ['get_version.py'])
-    ],
     author="Paul Tagliamonte",
     author_email="tag@pault.ag",
     long_description=long_description,


### PR DESCRIPTION
This file is not used at runtime, and the way it was installed violated FHS.

Fixes #1355.

This reverts commit 7361b37a7580bb5caaf7696b7bff5954042fd52b.