### PR TITLE
Add a let macro to make hy code a little more idiomatic

### DIFF
--- a/hy/contrib/let.hy
+++ b/hy/contrib/let.hy
@@ -1,0 +1,9 @@
+;; Copyright 2018 the authors.
+;; This file is part of Hy, which is free software licensed under the Expat
+;; license. See the LICENSE.
+
+(defmacro let [args &rest body]
+  "Define a local scope with a set of lexical bindings
+
+This simply wraps a call to setv in a function."
+  `((fn [] (setv ~@args) ~@body)))

--- a/tests/native_tests/contrib/let.hy
+++ b/tests/native_tests/contrib/let.hy
@@ -1,0 +1,19 @@
+;; Copyright 2018 the authors.
+;; This file is part of Hy, which is free software licensed under the Expat
+;; license. See the LICENSE.
+
+(require [hy.contrib.let [let]])
+
+(defn test-let []
+  (assert (= (let [x 1 y (* 2 x)] (+ x y)) 3))
+  (assert (= (let [x 3 y
+                   (let [y (* 2 x)]
+                     (let [x (* 3 y)] x))]
+               (assert (= x 3))
+               y) 18))
+  (try
+    (let [a x])
+    (except [e NameError]
+     (assert True))
+   (else
+    (assert False))))


### PR DESCRIPTION
The macro itself is very small, hardly noticeable. And yes, there will be some runtime overhead. Also, python scoping rules do not allow (simple) assignment to variables in a closure. Definitions in a "higher up" `let` will be protected for this reason. This might be surprising.

Overall, however, it feels so much better. A proper `let` makes code so much cleaner.
