### PR TITLE
Make (require [foo [*]]) pull in macros required by `foo`

### DIFF
--- a/hy/macros.py
+++ b/hy/macros.py
@@ -190,14 +190,9 @@ def require(source_module, target_module, assignments, prefix=""):
         prefix += "."
 
     if assignments == "ALL":
-        # Only add macros/tags created in/by the source module.
-        name_assigns = [(n, n) for n, f in source_macros.items()
-                        if inspect.getmodule(f) == source_module]
-        name_assigns += [(n, n) for n, f in source_tags.items()
-                         if inspect.getmodule(f) == source_module]
+        name_assigns = [(k, k) for k in
+            tuple(source_macros.keys()) + tuple(source_tags.keys())]
     else:
-        # If one specifically requests a macro/tag not created in the source
-        # module, I guess we allow it?
         name_assigns = assignments
 
     for name, alias in name_assigns:

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -378,10 +378,6 @@ in expansions."
 
   (require [tests.resources.macro-with-require [*]])
 
-  ;; Make sure our local version wasn't overwritten by a faulty `require` of the
-  ;; one in tests.resources.macro-with-require.
-  (assert (= nonlocal-test-macro (get __macros__ "nonlocal_test_macro")))
-
   (setv module-name-var "tests.native_tests.native_macros.test-macro-namespace-resolution")
   (assert (= (+ "This macro was created in tests.resources.macros, "
                 "expanded in tests.native_tests.native_macros.test-macro-namespace-resolution "
@@ -479,3 +475,11 @@ in expansions."
   ;; ensure that an imported module used the cached bytecode.  We'll simply have
   ;; to trust that the .pyc loading convention was followed.
   (test-requires-and-macros))
+
+
+(defn test-recursive-require-star []
+  "(require [foo [*]]) should pull in macros required by `foo`."
+  (require [tests.resources.macro-with-require [*]])
+
+  (test-macro)
+  (assert (= blah 1)))


### PR DESCRIPTION
This change makes it possible to do things like require a library full of macros. It also increases consistency with Python's usual import system.

I haven't edited NEWS, since this change is a return to 0.15 semantics.