### PR TITLE
added documentation for defclass docstring

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -415,14 +415,16 @@ They can be used to assign multiple variables at once:
 defclass
 --------
 
-New classes are declared with ``defclass``. It can takes two optional parameters:
-a vector defining a possible super classes and another vector containing
-attributes of the new class as two item vectors.
+New classes are declared with ``defclass``. It can take three optional parameters in the following order:
+a list defining (a) possible super class(es), a string (:term:`py:docstring`) and another list containing
+attributes of the new class along with their corresponding values.
 
 .. code-block:: clj
 
     (defclass class-name [super-class-1 super-class-2]
-      [attribute value]
+      "docstring"
+      [attribute1 value1
+       attribute2 value2]
 
       (defn method [self] (print "hello!")))
 

--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -239,7 +239,7 @@ as the user enters *k*.
 
 
 comment
-----
+-------
 
 The ``comment`` macro ignores its body and always expands to ``None``.
 Unlike linewise comments, the body of the ``comment`` macro must


### PR DESCRIPTION
#1527 
The following works with bar.__doc__ returning "bar":
   
    (defclass bar [] "bar" [attr "value"]) 

while the following does not:

    (defclass bar [] [attr "value"] "bar")

(bar.\_\_doc__ evaluates to bar.\_\_doc__ itself.)

This seems to be the intended python-ic behaviour, if I am not wrong.