### PR TITLE
get_version is not needed in data_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,6 @@ setup(
         'hy.core': ['*.hy', '__pycache__/*'],
         'hy.extra': ['*.hy', '__pycache__/*'],
     },
-    data_files=[
-        ('get_version', ['get_version.py'])
-    ],
     author="Paul Tagliamonte",
     author_email="tag@pault.ag",
     long_description=long_description,


### PR DESCRIPTION
I wrote an RPM package for hy (which you can find [here](https://github.com/eklitzke/hy-rpm/)) and ran into a kind of weird thing during packaging. Right now `get_version` is specified in `data_files`, which means that it's installed into `/usr` or `/usr/local` by default when installing hy. However, this file isn't actually needed at all by hy: it's only used in the `setup.py` script and the `docs/conf.py` file, so it's really a build dependency and not an install dependency. In fact, the `setup.py` file creates `hy/version.py` which is installed the usual way, and contains the version which can be queried at runtime:
```
$ hy
hy 0.16.0+20.gb31863d using CPython(default) 3.7.2 on Linux
=> (import hy.version)
=> hy.version.--version--
'0.16.0+20.gb31863d'
```

This part of the `setup.py` file was added by @Kodiologist in commit 7361b37a7580bb5caaf7696b7bff5954042fd52b, but the commit comment isn't very illuminating and PR #1305 doesn't really have an explanation so it's not clear to me why it was added in the first place.