### PR TITLE
Allow Hy to run when installed in read only filesystem

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,3 +90,4 @@
 * Yigong Wang <wang@yigo.ng>
 * Oskar Kvist <oskar.kvist@gmail.com>
 * Brandon T. Willard <brandonwillard@gmail.com>
+* Andrew R. M. <nixy@nixy.moe>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -12,6 +12,11 @@ New Features
 * Format strings with embedded Hy code (e.g., `f"The sum is {(+ x y)}"`)
   are now supported, even on Pythons earlier than 3.6.
 
+Bug Fixes
+------------------------------
+* Fixed a crash caused by errors creating temp files during bytecode
+  compilation
+
 0.16.0
 ==============================
 

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -467,9 +467,10 @@ else:
         if cfile is None:
             cfile = cache_from_source(filename)
 
-        f = tempfile.NamedTemporaryFile('wb', dir=os.path.split(cfile)[0],
-                                        delete=False)
+        f = None
         try:
+            f = tempfile.NamedTemporaryFile('wb', dir=os.path.split(cfile)[0],
+                                            delete=False)
             f.write('\0\0\0\0')
             f.write(struct.pack('<I', timestamp))
             f.write(marshal.dumps(codeobject))
@@ -489,7 +490,8 @@ else:
             os.rename(f.name, cfile)
         except OSError:
             try:
-                os.unlink(f.name)
+                if f is not None:
+                    os.unlink(f.name)
             except OSError:
                 pass
 


### PR DESCRIPTION
The `dir` parameter removed by this commit caused hy to try to create a
temporary file where it is installed. This caused problems for the NixOS
package as it would be installed in the Nix store which is a read-only
filesystem.

I ran the tests and most of them passed. I rolled back my branch to master and ran them again and it appears the tests that failed were also failing on master. I've used hy with these changes and am fairly confident that they don't cause any issues.

Information on the issues facing the NixOS package can be found here: https://github.com/NixOS/nixpkgs/pull/57882