### PR TITLE
Pre-Python 3.4 cleanup (including Python 2)

### DIFF
--- a/hy/__main__.py
+++ b/hy/__main__.py
@@ -11,5 +11,5 @@ import sys
 
 if len(sys.argv) > 1:
     sys.argv.pop(0)
-    imp.load_source("__main__", sys.argv[0])
+    hy.importer._import_from_path('__main__', sys.argv[0])
     sys.exit(0)  # right?

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -157,3 +157,11 @@ runpy = importlib.import_module('runpy')
 
 _runpy_get_code_from_file = runpy._get_code_from_file
 runpy._get_code_from_file = _get_code_from_file
+
+
+def _import_from_path(name, path):
+    """A helper function that imports a module from the given path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,6 @@ install_requires = [
 if os.name == 'nt':
     install_requires.append('pyreadline>=2.1')
 
-ver = sys.version_info[0]
-
 setup(
     name=PKG,
     version=__version__,
@@ -49,11 +47,11 @@ setup(
     entry_points={
         'console_scripts': [
             'hy = hy.cmdline:hy_main',
-            'hy%d = hy.cmdline:hy_main' % ver,
+            'hy3 = hy.cmdline:hy_main',
             'hyc = hy.cmdline:hyc_main',
-            'hyc%d = hy.cmdline:hyc_main' % ver,
+            'hyc3 = hy.cmdline:hyc_main',
             'hy2py = hy.cmdline:hy2py_main',
-            'hy2py%d = hy.cmdline:hy2py_main' % ver,
+            'hy2py3 = hy.cmdline:hy2py_main',
         ]
     },
     packages=find_packages(exclude=['tests*']),

--- a/tests/importer/test_pyc.py
+++ b/tests/importer/test_pyc.py
@@ -3,10 +3,11 @@
 # license. See the LICENSE.
 
 import os
-import imp
+import importlib.util
+import py_compile
 import tempfile
 
-import py_compile
+import hy.importer
 
 
 def test_pyc():
@@ -16,10 +17,11 @@ def test_pyc():
         f.flush()
 
         cfile = py_compile.compile(f.name)
-
         assert os.path.exists(cfile)
 
-        mod = imp.load_compiled('pyc', cfile)
-        os.remove(cfile)
+        try:
+            mod = hy.importer._import_from_path('pyc', cfile)
+        finally:
+            os.remove(cfile)
 
         assert mod.pyctest('Foo') == 'XFooY'

--- a/tests/test_hy2py.py
+++ b/tests/test_hy2py.py
@@ -6,6 +6,7 @@
 import math, itertools
 from hy import mangle
 from hy._compat import PY36
+import hy.importer
 
 
 def test_direct_import():
@@ -19,7 +20,8 @@ def test_hy2py_import(tmpdir):
         ["hy2py", "tests/resources/pydemo.hy"]).decode("UTF-8")
     path = tmpdir.join("pydemo.py")
     path.write(python_code)
-    assert_stuff(import_from_path("pydemo", path))
+    # Note: explicit "str" is needed for 3.5.
+    assert_stuff(hy.importer._import_from_path("pydemo", str(path)))
 
 
 def assert_stuff(m):
@@ -116,15 +118,3 @@ def assert_stuff(m):
     assert (m.C2.attr1, m.C2.attr2) == (5, 6)
 
     assert m.closed == ["v2", "v1"]
-
-
-def import_from_path(name, path):
-    if PY36:
-        import importlib.util
-        spec = importlib.util.spec_from_file_location(name, path)
-        m = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(m)
-    else:
-        import imp
-        m = imp.load_source(name, str(path))
-    return m


### PR DESCRIPTION
- We can just hardcode the `*3` scripts, no Python 2 left.
- Remove remaining uses of `imp`. The previous code incorrectly assumed the functions used (`spec_from_file_location` and `module_from_spec`) were unavailable prior to Python 3.6, whereas they were added in 3.4 and 3.5, respectively. (The former *was* modified to take path-like objects in 3.6, which is where the confusion may have come from).