### PR TITLE
Avoid a crash when we can't access a history file

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,7 @@ Bug Fixes
 * Statements in the second argument of `assert` are now executed.
 * Fixed the expression of a while loop that contains statements being compiled twice.
 * `hy2py` can now handle format strings.
+* Fixed crashes from inaccessible history files.
 
 0.17.0
 ==============================

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -123,7 +123,7 @@ def completion(completer=None):
         try:
             readline.read_history_file(history)
         except IOError:
-            open(history, 'a').close()
+            pass
 
         readline.parse_and_bind(readline_bind)
 
@@ -131,4 +131,7 @@ def completion(completer=None):
         yield
     finally:
         if docomplete:
-            readline.write_history_file(history)
+            try:
+                readline.write_history_file(history)
+            except IOError:
+                pass


### PR DESCRIPTION
Fixes #1812.