### PR TITLE
get_version.py: Prefer VERSIONFILE over git-describe(1)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,3 +92,4 @@
 * Brandon T. Willard <brandonwillard@gmail.com>
 * Andrew R. M. <nixy@nixy.moe>
 * Tristan de Cacqueray <tdecacqu@redhat.com>
+* Sören Tempel <soeren@soeren-tempel.net>

--- a/get_version.py
+++ b/get_version.py
@@ -5,16 +5,19 @@ import os, subprocess, runpy
 os.chdir(os.path.split(os.path.abspath(__file__))[0])
 VERSIONFILE = os.path.join("hy", "version.py")
 
-try:
-    __version__ = (subprocess.check_output
-                   (["git", "describe", "--tags", "--dirty"])
-                   .decode('ASCII').strip()
-                   .replace('-', '+', 1).replace('-', '.'))
-    with open(VERSIONFILE, "wt") as o:
-        o.write("__version__ = {!r}\n".format(__version__))
+if "HY_VERSION" in os.environ:
+    __version__ = os.environ["HY_VERSION"]
+else:
+    try:
+        __version__ = (subprocess.check_output
+                       (["git", "describe", "--tags", "--dirty"])
+                       .decode('ASCII').strip()
+                       .replace('-', '+', 1).replace('-', '.'))
+        with open(VERSIONFILE, "wt") as o:
+            o.write("__version__ = {!r}\n".format(__version__))
 
-except (subprocess.CalledProcessError, OSError):
-    if os.path.exists(VERSIONFILE):
-        __version__ = runpy.run_path(VERSIONFILE)['__version__']
-    else:
-        __version__ = "unknown"
+    except (subprocess.CalledProcessError, OSError):
+        if os.path.exists(VERSIONFILE):
+            __version__ = runpy.run_path(VERSIONFILE)['__version__']
+        else:
+            __version__ = "unknown"


### PR DESCRIPTION
Noticed this while packaging hy for Alpine Linux. On Alpine package
builders git is installed by default and all packages are build in
subdirectories of the package git repository. This causes git_version.py
to output the version of the package repository since it doesn't consult
the VERSIONFILE first.

This commit reverse the logic checking for the VERSIONFILE first and
only falling back to git-describe if the version file doesn't exist. I personally
think that it is more logical to do it that way.