### PR TITLE
Drop clint for colors in favor of colorama

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -31,6 +31,11 @@ Bug Fixes
 * `hy2py` can now handle format strings.
 * Fixed crashes from inaccessible history files.
 
+Misc. Improvements
+------------------------------
+* Drop the use of the long-abandoned `clint <https://github.com/kennethreitz/clint>`_ library
+  for colors. `colorama <https://github.com/tartley/colorama>`_ is now used instead.
+
 0.17.0
 ==============================
 

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -44,9 +44,9 @@ If this is causing issues,
 it can be turned off globally by setting ``hy.models.PRETTY`` to ``False``,
 or temporarily by using the ``hy.models.pretty`` context manager.
 
-Hy also attempts to color pretty reprs using ``clint.textui.colored``.
-This module has a flag to disable coloring,
-and a method ``clean`` to strip colored strings of their color tags.
+Hy also attempts to color pretty reprs and errors using ``colorama``. These can
+be turned off globally by setting ``hy.models.COLORED`` and ``hy.errors.COLORED``,
+respectively, to ``False``.
 
 .. _hysequence:
 

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -4,6 +4,9 @@
 
 from __future__ import print_function
 
+import colorama
+colorama.init()
+
 import argparse
 import code
 import ast

--- a/hy/errors.py
+++ b/hy/errors.py
@@ -9,14 +9,13 @@ import traceback
 import pkgutil
 
 from functools import reduce
+from colorama import Fore
 from contextlib import contextmanager
 from hy import _initialize_env_var
 
-from clint.textui import colored
-
 _hy_filter_internal_errors = _initialize_env_var('HY_FILTER_INTERNAL_ERRORS',
                                                  True)
-_hy_colored_errors = _initialize_env_var('HY_COLORED_ERRORS', False)
+COLORED = _initialize_env_var('HY_COLORED_ERRORS', False)
 
 
 class HyError(Exception):
@@ -108,15 +107,12 @@ class HyLanguageError(HyError):
         """Provide an exception message that includes SyntaxError-like source
         line information when available.
         """
-        global _hy_colored_errors
-
         # Syntax errors are special and annotate the traceback (instead of what
         # we would do in the message that follows the traceback).
         if isinstance(self, SyntaxError):
             return super(HyLanguageError, self).__str__()
-
         # When there isn't extra source information, use the normal message.
-        if not isinstance(self, SyntaxError) and not self.text:
+        elif not self.text:
             return super(HyLanguageError, self).__str__()
 
         # Re-purpose Python's builtin syntax error formatting.
@@ -142,15 +138,14 @@ class HyLanguageError(HyError):
             output[arrow_idx] = '{}{}^\n'.format(output[arrow_idx].rstrip('\n'),
                                                  '-' * (self.arrow_offset - 1))
 
-        if _hy_colored_errors:
-            from clint.textui import colored
-            output[msg_idx:] = [colored.yellow(o) for o in output[msg_idx:]]
+        if COLORED:
+            output[msg_idx:] = [Fore.YELLOW + o + Fore.RESET for o in output[msg_idx:]]
             if arrow_idx:
-                output[arrow_idx] = colored.green(output[arrow_idx])
+                output[arrow_idx] = Fore.GREEN + output[arrow_idx] + Fore.RESET
             for idx, line in enumerate(output[::msg_idx]):
                 if line.strip().startswith(
                         'File "{}", line'.format(self.filename)):
-                    output[idx] = colored.red(line)
+                    output[idx] = Fore.RED + line + Fore.RESET
 
         # This resulting string will come after a "<class-name>:" prompt, so
         # put it down a line.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     'rply>=0.7.7',
     'astor>=0.8',
     'funcparserlib>=0.3.6',
-    'clint>=0.4']
+    'colorama']
 if os.name == 'nt':
     install_requires.append('pyreadline>=2.1')
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,9 +4,10 @@
 
 import copy
 import hy
-from clint.textui.colored import clean
 from hy.models import (wrap_value, replace_hy_obj, HyString, HyInteger, HyList,
                        HyDict, HySet, HyExpression, HyComplex, HyFloat, pretty)
+
+hy.models.COLORED = False
 
 
 def test_wrap_int():
@@ -182,13 +183,13 @@ def test_compound_model_repr():
             assert eval(repr(model([1, 2, 3]))) == model([1, 2, 3])
         for k, v in PRETTY_STRINGS.items():
             # `str` should be pretty, even under `pretty(False)`.
-            assert clean(str(hy.read_str(k))) == v
+            assert str(hy.read_str(k)) == v
         for k in PRETTY_STRINGS.keys():
             assert eval(repr(hy.read_str(k))) == hy.read_str(k)
     with pretty(True):
         for model in HY_LIST_MODELS:
-            assert eval(clean(repr(model()))).__class__ is model
-            assert eval(clean(repr(model([1, 2])))) == model([1, 2])
-            assert eval(clean(repr(model([1, 2, 3])))) == model([1, 2, 3])
+            assert eval(repr(model())).__class__ is model
+            assert eval(repr(model([1, 2]))) == model([1, 2])
+            assert eval(repr(model([1, 2, 3]))) == model([1, 2, 3])
         for k, v in PRETTY_STRINGS.items():
-            assert clean(repr(hy.read_str(k))) == v
+            assert repr(hy.read_str(k)) == v


### PR DESCRIPTION
Closes #1820. Not particularly exciting, though I think in some aspects the code actually ends up a tad cleaner than before.

Reason for using colorama: all clint was really used for was color, and colorama is a popular, well-supported, and battle-tested library for handling this.