### PR TITLE
Fix a unit test bug on slim Python Docker images

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -31,6 +31,8 @@ Bug Fixes
 * Fixed the expression of a while loop that contains statements being compiled twice.
 * `hy2py` can now handle format strings.
 * Fixed crashes from inaccessible history files.
+* The unit tests no longer unintentionally import the internal Python module "test".
+  This allows them to pass when run inside the "slim" Python Docker images.
 
 0.17.0
 ==============================

--- a/tests/compilers/test_compiler.py
+++ b/tests/compilers/test_compiler.py
@@ -6,6 +6,7 @@ import ast
 
 from hy import compiler
 from hy.models import HyExpression, HyList, HySymbol, HyInteger
+import types
 
 
 def make_expression(*args):
@@ -25,7 +26,7 @@ def test_compiler_bare_names():
                         HySymbol("a"),
                         HySymbol("b"),
                         HySymbol("c"))
-    ret = compiler.HyASTCompiler('test').compile(e)
+    ret = compiler.HyASTCompiler(types.ModuleType('test')).compile(e)
 
     # We expect two statements and a final expr.
 
@@ -54,7 +55,7 @@ def test_compiler_yield_return():
                         HyExpression([HySymbol("+"),
                                       HyInteger(1),
                                       HyInteger(1)]))
-    ret = compiler.HyASTCompiler('test').compile_atom(e)
+    ret = compiler.HyASTCompiler(types.ModuleType('test')).compile_atom(e)
 
     assert len(ret.stmts) == 1
     stmt, = ret.stmts


### PR DESCRIPTION
If HyASTCompiler is given a string, it imports it and uses it as the execution environment. However, the unit tests gave HyASTCompiler the string 'test', assuming it would create a new test module, when in
reality it would import CPython's test module that is designed for internal use. Slim Docker images don't include this module, therefore the tests would fail to run.