### PR TITLE
Fix help message in REPL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -93,3 +93,4 @@
 * Andrew R. M. <nixy@nixy.moe>
 * Tristan de Cacqueray <tdecacqu@redhat.com>
 * Sören Tempel <soeren@soeren-tempel.net>
+* Noah Snelson <noah.snelson@protonmail.com>

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -59,9 +59,19 @@ class HyQuitter(object):
             pass
         raise SystemExit(code)
 
+class HyHelper(object):
+    def __repr__(self):
+        return ("Use (help) for interactive help, or (help object) for help "
+                "about object.")
+
+    def __call__(self, *args, **kwds):
+        import pydoc
+        return pydoc.help(*args, **kwds)
+
 
 builtins.quit = HyQuitter('quit')
 builtins.exit = HyQuitter('exit')
+builtins.help = HyHelper()
 
 @contextmanager
 def extend_linecache(add_cmdline_cache):


### PR DESCRIPTION
Currently when in the hy REPL, when the user types ```help```, the REPL responds with the default builtins.help message ```Type help() for interactive help, or help(object) for help about object.``` This is inconsistent with the syntax of Hy and other REPL features, as ```quit``` and ```exit``` both display the proper syntax in their respective REPL messages.

This fix adds a ```HyHelper``` class for ```help``` similar to the ```HyQuitter``` class used to override the ```quit``` and ```exit``` builtins. Besides the corrected prompt using Lisp-like syntax, after executing ```(help)``` the user is still dropped into the default PyDoc help environment with normal Python syntax and links to documentation.