### PR TITLE
Include fastentrypoints in the MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include AUTHORS
 include LICENSE
 include NEWS.rst
 include README.md
+include fastentrypoints.py


### PR DESCRIPTION
Fixes #1861.

This is a packaging bug that affected 0.17.0, but it's not worth backporting, because I'll be making a 0.18.0 in the next few days, anyway.