### PR TITLE
Revamp the setup script's install command

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright 2020 the authors.
+Portions of setup.py, copyright 2016 Jason R Coombs <jaraco@jaraco.com>.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
Previously, the Hy files would be bytecode compiled before the
compiler's dependencies were installed. In additon, the revamped
version properly propogates the optimization level and generally is a
bit cleaner.

Fixes #1864.

This solution wasn't nearly as bad I thought. (Please forgive minor formatting issues atm, literally typed this whole thing out on a phone.)