### PR TITLE
Fix parse-args "Don't know how to wrap <class 'type'>: <class 'int'>" error

### DIFF
--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -401,7 +401,10 @@ constructor."
   (import argparse)
   (setv parser (argparse.ArgumentParser #** parser-args))
   (for [arg spec]
-    (eval `(.add-argument parser ~@arg)))
+    (parser.add-argument
+      #* (take-while (complement keyword?) arg)
+      #** (dfor [key value] (partition (drop-while (complement keyword?) arg) 2)
+                [(name key) value])))
   (.parse-args parser args))
 
 (setv EXPORTS


### PR DESCRIPTION
`(parse-args [["-f" :type int]] ["-f" "1"])` would raise an exception like below:

```
Traceback (most recent call last):
  File "stdin-70c552c2f85a6cd51869faa11b6b4d0fae374f37", line 1, in <module>
    (parse-args [["-f" :type int]] ["-f" "1"])
  File "/Users/redraiment/Library/Python/3.7/lib/python/site-packages/hy/core/language.hy", line 404, in parse_args
    (eval `(.add-argument parser ~@arg)))
hy.errors.HyWrapperError: Don't know how to wrap <class 'type'>: <class 'int'>
```