### PR TITLE
Fix #1875: use function type for :type of parse-args rather than symbol

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -96,3 +96,4 @@
 * Noah Snelson <noah.snelson@protonmail.com>
 * Adam Porter <adam@alphapapa.net>
 * Gábor Lipták <gliptak@gmail.com>
+* Zepeng Zhang <redraiment@gmail.com>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,12 @@
 .. default-role:: code
 
+Unreleased
+==============================
+
+Other Breaking Changes
+------------------------------
+* Value type of `:type` in `parse-args` spec is now a `function` instead of `HySymbol`.
+
 0.18.0
 ==============================
 

--- a/docs/language/core.rst
+++ b/docs/language/core.rst
@@ -804,7 +804,7 @@ may be a list of keyword arguments to pass to the
 .. code-block:: hy
 
     => (parse-args [["strings" :nargs "+" :help "Strings"]
-                    ["-n" "--numbers" :action "append" :type 'int :help "Numbers"]]
+                    ["-n" "--numbers" :action "append" :type int :help "Numbers"]]
                    ["a" "b" "-n" "1" "-n" "2"]
                    :description "Parse strings and numbers from args")
     Namespace(numbers=[1, 2], strings=['a', 'b'])

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -401,7 +401,10 @@ constructor."
   (import argparse)
   (setv parser (argparse.ArgumentParser #** parser-args))
   (for [arg spec]
-    (eval `(.add-argument parser ~@arg)))
+    (parser.add-argument
+      #* (take-while (complement keyword?) arg)
+      #** (dfor [key value] (partition (drop-while (complement keyword?) arg) 2)
+            [(name key) value])))
   (.parse-args parser args))
 
 (setv EXPORTS

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -481,7 +481,7 @@ result['y in globals'] = 'y' in globals()")
 (defn test-parse-args []
   "NATIVE: testing the parse-args function"
   (setv parsed-args (parse-args [["strings" :nargs "+" :help "Strings"]
-                                 ["-n" "--numbers" :action "append" :type 'int :help "Numbers"]]
+                                 ["-n" "--numbers" :action "append" :type int :help "Numbers"]]
                                 ["a" "b" "-n" "1" "-n" "2"]
                                 :description "Parse strings and numbers from args"))
   (assert-equal parsed-args.strings ["a" "b"])

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -481,8 +481,8 @@ result['y in globals'] = 'y' in globals()")
 (defn test-parse-args []
   "NATIVE: testing the parse-args function"
   (setv parsed-args (parse-args [["strings" :nargs "+" :help "Strings"]
-                                 ["-n" "--numbers" :action "append" :type int :help "Numbers"]]
-                                ["a" "b" "-n" "1" "-n" "2"]
+                                 ["-n" :action "append" :type int :help "Numbers" "--numbers"]]
+                                ["a" "b" "-n" "1" "--numbers" "2"]
                                 :description "Parse strings and numbers from args"))
   (assert-equal parsed-args.strings ["a" "b"])
   (assert-equal parsed-args.numbers [1 2]))


### PR DESCRIPTION
Keep the behavior same with Python.