### PR TITLE
Fix misplaced `#@` tag macro

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -96,3 +96,4 @@
 * Noah Snelson <noah.snelson@protonmail.com>
 * Adam Porter <adam@alphapapa.net>
 * Gábor Lipták <gliptak@gmail.com>
+* Raymund MARTINEZ <zhaqenl@protonmail.com>

--- a/docs/whyhy.rst
+++ b/docs/whyhy.rst
@@ -105,7 +105,7 @@ in Hy::
     (import cherrypy)
 
     (defclass HelloWorld []
-      (#@ cherrypy.expose (defn index [self]
+      #@(cherrypy.expose (defn index [self]
         "Hello World!")))
 
     (cherrypy.quickstart (HelloWorld))


### PR DESCRIPTION
Under the [Hy versus other Lisps](https://docs.hylang.org/en/stable/whyhy.html#hy-versus-other-lisps) section, and inside the definition of the `HelloWorld` class, the `#@` tag macro is misplaced inside the parenthesis.