### PR TITLE
Reduce scope of symbol replacement for anaphoric macros

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,3 +98,4 @@
 * Gábor Lipták <gliptak@gmail.com>
 * Raymund MARTINEZ <zhaqenl@protonmail.com>
 * Zepeng Zhang <redraiment@gmail.com>
+* Joseph Egan <joseph.s.egan@gmail.com>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,6 +8,11 @@ Other Breaking Changes
 * `parse-args` is no longer implemented with `eval`; so e.g. you should
   now say `:type int` instead of `:type 'int`.
 
+Bug Fixes
+------------------------------
+* Improved support for nesting anaphoric macros by only applying
+  symbol replacement where absolutely necessary.
+
 0.18.0
 ==============================
 

--- a/docs/extra/anaphoric.rst
+++ b/docs/extra/anaphoric.rst
@@ -19,9 +19,11 @@ To use these macros you need to require the ``hy.extra.anaphoric`` module like s
 
 These macros are implemented by replacing any use of the designated
 anaphoric symbols (``it``, in most cases) with a gensym. Consequently,
-it's unwise to nest these macros, or to use an affected symbol as
-something other than a variable name, as in ``(print "My favorite
-Stephen King book is" 'it)``.
+it's unwise to nest these macros where symbol replacement is happening.
+Symbol replacement typically takes place in ``body`` or ``form``
+parameters, where the output of the expression may be returned. It is also
+recommended to avoid using an affected symbol as something other than a
+variable name, as in ``(print "My favorite Stephen King book is" 'it)``.
 
 .. _ap-if:
 

--- a/tests/native_tests/extra/anaphoric.hy
+++ b/tests/native_tests/extra/anaphoric.hy
@@ -13,17 +13,40 @@
   (setv it "orig")
   (setv out (ap-if (+ 1 1) (+ it 1) (+ it 10)))
   (assert (= out 3))
-  (assert (= it "orig")))
+  (assert (= it "orig"))
+
+  (ap-if
+    (->> [1 2 3 4 5]
+      (ap-filter (= (% it 2) 0))
+      (list))
+    (assert (= it [2 4]))))
+
 
 (defn test-ap-each []
   (setv res [])
   (assert (is (ap-each [1 2 3 4] (.append res it)) None))
-  (assert (= res [1 2 3 4])))
+  (assert (= res [1 2 3 4]))
+
+  (setv res [])
+  (ap-each
+    (->> [1 2 3 4]
+      (ap-map (+ 1 it))
+      (list))
+    (.append res it))
+  (assert (= res [2 3 4 5])))
 
 (defn test-ap-each-while []
   (setv res [])
   (ap-each-while [2 2 4 3 4 5 6] (even? it) (.append res it))
-  (assert (= res [2 2 4])))
+  (assert (= res [2 2 4]))
+
+  (setv res [])
+  (ap-each-while
+    (->> [2 2 4 3 4 5 6]
+      (ap-map (+ 1 it))
+      (list))
+    (odd? it) (.append res it))
+  (assert (= res [3 3 5])))
 
 (defn test-ap-map []
   (assert (= (list (ap-map (* it 3) [1 2 3]))
@@ -31,23 +54,51 @@
   (assert (= (list (ap-map (* it 3) []))
              []))
   (assert (= (do (setv v 1 f 1) (list (ap-map (it v f) [(fn [a b] (+ a b))])))
-             [2])))
+             [2]))
+
+  (assert (=
+    (->> [1 2 3]
+      (ap-filter (even? it))
+      (ap-map (* 3 it))
+      (list))
+    [6])))
 
 (defn test-ap-map-when []
   (assert (= (list (ap-map-when even? (* it 2) [1 2 3 4]))
-             [1 4 3 8])))
+             [1 4 3 8]))
+
+  (assert (=
+    (->> [1 2 3 4]
+      (ap-map (+ 1 it))
+      (ap-map-when even? (* 2 it))
+      (list))
+    [4 3 8 5])))
 
 (defn test-ap-filter []
   (assert (= (list (ap-filter (> it 2) [1 2 3 4]))
              [3 4]))
   (assert (= (list (ap-filter (even? it) [1 2 3 4]))
-             [2 4])))
+             [2 4]))
+
+  (assert (=
+    (->> [1 2 3 4]
+      (ap-map (+ 3 it))
+      (ap-filter (even? it))
+      (list))
+    [4 6])))
 
 (defn test-ap-reject []
   (assert (= (list (ap-reject (> it 2) [1 2 3 4]))
              [1 2]))
   (assert (= (list (ap-reject (even? it) [1 2 3 4]))
-             [1 3])))
+             [1 3]))
+
+  (assert (=
+    (->> [1 2 3 4]
+      (ap-map (+ 3 it))
+      (ap-reject (even? it))
+      (list))
+    [5 7])))
 
 (defn test-ap-dotimes []
   (assert (= (do (setv n []) (ap-dotimes 3 (.append n 3)) n)
@@ -59,17 +110,38 @@
   (setv n 5)
   (setv x "")
   (ap-dotimes n (+= x "."))
-  (assert (= x ".....")))
+  (assert (= x "....."))
+
+  (assert (=
+    (do
+      (setv n [])
+      (ap-dotimes
+        (ap-first (odd? it) [2 4 5 6 3 8])
+        (.append n it))
+      n)
+    [0 1 2 3 4])))
 
 (defn test-ap-first []
   (assert (= (ap-first (> it 5) (range 10)) 6))
   (assert (= (ap-first (even? it) [1 2 3 4]) 2))
-  (assert (= (ap-first (> it 10) (range 10)) None)))
+  (assert (= (ap-first (> it 10) (range 10)) None))
+
+  (assert (=
+    (->> [1 2 3 4]
+      (ap-map (+ 4 it))
+      (ap-first (even? it)))
+    6)))
 
 (defn test-ap-last []
   (assert (= (ap-last (> it 5) (range 10)) 9))
   (assert (= (ap-last (even? it) [1 2 3 4]) 4))
-  (assert (= (ap-last (> it 10) (range 10)) None)))
+  (assert (= (ap-last (> it 10) (range 10)) None))
+
+  (assert (=
+    (->> [1 2 3 4]
+      (ap-map (+ 4 it))
+      (ap-last (odd? it)))
+    7)))
 
 (defn test-ap-reduce []
   (assert (= (ap-reduce (* acc it) [1 2 3]) 6))
@@ -86,7 +158,13 @@
   (assert (=
     (ap-reduce (* acc it) (do (+= expr-evaluated 1) [4 5 6])))
     120)
-  (assert (= expr-evaluated 1)))
+  (assert (= expr-evaluated 1))
+
+  (assert (=
+    (->> [1 2 3]
+      (ap-map (+ 2 it))
+      (ap-reduce (* acc it)))
+    60)))
 
 (defn test-tag-fn []
   ;; test ordering


### PR DESCRIPTION
Resolves #1883
I would encourage reviewers to look at the commit history to see if there is any merit in the an earlier more verbose approach I took.
This is my first time committing lisp code, so any feedback would be kindly received! :)