### PR TITLE
get_version.py: Also write VERSIONFILE when HY_VERSION env is set

### DIFF
--- a/get_version.py
+++ b/get_version.py
@@ -5,19 +5,20 @@ import os, subprocess, runpy
 os.chdir(os.path.split(os.path.abspath(__file__))[0])
 VERSIONFILE = os.path.join("hy", "version.py")
 
-if "HY_VERSION" in os.environ:
-    __version__ = os.environ["HY_VERSION"]
-else:
-    try:
+try:
+    if "HY_VERSION" in os.environ:
+        __version__ = os.environ["HY_VERSION"]
+    else:
         __version__ = (subprocess.check_output
                        (["git", "describe", "--tags", "--dirty"])
                        .decode('ASCII').strip()
                        .replace('-', '+', 1).replace('-', '.'))
-        with open(VERSIONFILE, "wt") as o:
-            o.write("__version__ = {!r}\n".format(__version__))
 
-    except (subprocess.CalledProcessError, OSError):
-        if os.path.exists(VERSIONFILE):
-            __version__ = runpy.run_path(VERSIONFILE)['__version__']
-        else:
-            __version__ = "unknown"
+    with open(VERSIONFILE, "wt") as o:
+        o.write("__version__ = {!r}\n".format(__version__))
+
+except (subprocess.CalledProcessError, OSError):
+    if os.path.exists(VERSIONFILE):
+        __version__ = runpy.run_path(VERSIONFILE)['__version__']
+    else:
+        __version__ = "unknown"


### PR DESCRIPTION
Without this change, hy is not capable of figuring out the correct
version in the REPL if the version was set using the HY_VERSION
environment variable during build.

---

Seems like I missed this in #1821 (sorry!).