### PR TITLE
Remove imp to avoid the deprecation message

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,3 +99,4 @@
 * Raymund MARTINEZ <zhaqenl@protonmail.com>
 * Zepeng Zhang <redraiment@gmail.com>
 * Joseph Egan <joseph.s.egan@gmail.com>
+* Xi Jin <xij@usc.edu>

--- a/conftest.py
+++ b/conftest.py
@@ -45,5 +45,5 @@ def pytest_collect_file(parent, path):
         and NATIVE_TESTS in path.dirname + os.sep
         and path.basename != "__init__.hy"):
 
-        pytest_mod = pytest.Module(path, parent)
+        pytest_mod = pytest.Module.from_parent(parent, fspath=path)
         return pytest_mod

--- a/conftest.py
+++ b/conftest.py
@@ -45,5 +45,8 @@ def pytest_collect_file(parent, path):
         and NATIVE_TESTS in path.dirname + os.sep
         and path.basename != "__init__.hy"):
 
-        pytest_mod = pytest.Module.from_parent(parent, fspath=path)
+        if hasattr(pytest.Module, "from_parent"):
+            pytest_mod = pytest.Module.from_parent(parent, fspath=path)
+        else:
+            pytest_mod = pytest.Module(path, parent)
         return pytest_mod

--- a/hy/__main__.py
+++ b/hy/__main__.py
@@ -1,5 +1,4 @@
 import hy  # NOQA
-import imp
 import sys
 
 # This just mocks the normalish behavior of the Python interp. Helpful to aid


### PR DESCRIPTION
Could we remove `imp` to avoid the deprecation message if we use `python -m hy`.

```
/usr/local/lib/python3.7/site-packages/hy/__main__.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```

Also, [since pytest 5.4, node construction is also deprecated in favor of `.from_parent`](https://docs.pytest.org/en/latest/deprecations.html#node-construction-changed-to-node-from-parent), old style will generate deprecation warning every time when we run `pytest`

```
conftest.py:48
  /.../conftest.py:48: PytestDeprecationWarning: direct construction of Module has been deprecated, please use Module.from_parent
    pytest_mod = pytest.Module(path, parent)
```