### PR TITLE
Fix `hy.eval` from Python failing on `require`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -100,3 +100,4 @@
 * Zepeng Zhang <redraiment@gmail.com>
 * Joseph Egan <joseph.s.egan@gmail.com>
 * Xi Jin <xij@usc.edu>
+* Alexey Yurchenko <homonoidian@yandex.ru>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,12 @@
 .. default-role:: code
 
+Unreleased
+==============================
+
+Bug Fixes
+------------------------------
+* Fixed a bug that made `hy.eval` from Python fail on `require`.
+
 0.19.0
 ==============================
 

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -105,7 +105,7 @@ def _same_modules(source_module, target_module):
         try:
             if not inspect.ismodule(module):
                 loader = pkgutil.get_loader(module)
-                if loader:
+                if isinstance(loader, importlib.machinery.SourceFileLoader):
                     filename = loader.get_filename()
             else:
                 filename = inspect.getfile(module)

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -289,3 +289,9 @@ def test_docstring():
         assert mod.a == 1
     finally:
         sys.path.pop(0)
+
+
+def test_hy_python_require():
+    # https://github.com/hylang/hy/issues/1911
+    test = "(do (require [tests.resources.macros [test-macro]]) (test-macro) blah)"
+    assert hy.eval(hy.read_str(test)) == 1


### PR DESCRIPTION
A tiny brute-fix for #1911. I really don't know what's the root of the problem, though, but it seems to be dynamic typing letting odd stuff in and causing havoc!