### PR TITLE
Fix a few minor spelling mistakes

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -665,7 +665,7 @@ requires.
         TypeError: compare() missing 1 required keyword-only argument: 'keyfn'
 
 &kwargs
-    Like ``&rest``, but for keyword arugments.
+    Like ``&rest``, but for keyword arguments.
     The following parameter will contain 0 or more keyword arguments.
 
     The following code examples defines a function that will print all keyword

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -725,7 +725,7 @@ Separate sentences with a single space.
     (setv ind (dec x));typing words for fun
 
     ;; Comment about the whole foofunction call.
-    ;; These can also span mulitple lines.
+    ;; These can also span multiple lines.
     (foofunction ;; Form comment about (get-arg1). Not a margin comment!
                  (get-arg1)
                  ;; Form comment about arg2. The indent matches.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -338,6 +338,6 @@ Next steps
 You now know enough to be dangerous with Hy. You may now smile villainously and
 sneak off to your Hydeaway to do unspeakable things.
 
-Refer to Python's documention for the details of Python semantics, and the rest
-of this manual for Hy-specific features. Like Hy itself, the manual is
+Refer to Python's documentation for the details of Python semantics, and the
+rest of this manual for Hy-specific features. Like Hy itself, the manual is
 incomplete, but :ref:`contributions <hacking>` are always welcome.


### PR DESCRIPTION
- `documention` -> `documentation`
- `mulitple` -> `multiple`
- `arugments` -> `arguments`