### PR TITLE
Add `__setstate__` and `__getstate__` to HyKeyword

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,6 +6,10 @@ Unreleased
 Bug Fixes
 ------------------------------
 * Fixed a bug that made `hy.eval` from Python fail on `require`.
+* Fixed a bug that prevented pickling of keyword objects.
+
+New Features
+------------------------------
 * New contrib module `pprint`, a Hy equivalent of `python.pprint`.
 
 0.19.0

--- a/hy/models.py
+++ b/hy/models.py
@@ -50,12 +50,12 @@ class HyObject(object):
     `abc` starting at the first column would have `start_column` 1 and
     `end_column` 3.
     """
-    __properties__ = ["module", "start_line", "end_line", "start_column",
-                      "end_column"]
+    properties = ["module", "start_line", "end_line", "start_column",
+                  "end_column"]
 
     def replace(self, other, recursive=False):
         if isinstance(other, HyObject):
-            for attr in self.__properties__:
+            for attr in self.properties:
                 if not hasattr(self, attr) and hasattr(other, attr):
                     setattr(self, attr, getattr(other, attr))
         else:

--- a/hy/models.py
+++ b/hy/models.py
@@ -176,6 +176,15 @@ class HyKeyword(HyObject):
                 raise
             return default
 
+    # __getstate__ and __setstate__ are required for Pickle protocol
+    # 0, because we have __slots__.
+    def __getstate__(self):
+        return {k: getattr(self, k)
+            for k in self.properties + self.__slots__
+            if hasattr(self, k)}
+    def __setstate__(self, state):
+        for k, v in state.items():
+            setattr(self, k, v)
 
 def strip_digit_separators(number):
     # Don't strip a _ or , if it's the first character, as _42 and

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -7,6 +7,7 @@
         [sys :as systest]
         re
         [operator [or_]]
+        pickle
         [hy.errors [HyLanguageError]]
         pytest)
 (import sys)
@@ -1140,6 +1141,12 @@
   (assert (!= : ":"))
   (assert (= (name ':) "")))
 
+(defn test-pickling-keyword []
+  ; https://github.com/hylang/hy/issues/1754
+  (setv x :test-keyword)
+  (for [protocol (range 0 (+ pickle.HIGHEST-PROTOCOL 1))]
+    (assert (= x
+      (pickle.loads (pickle.dumps x :protocol protocol))))))
 
 (defn test-nested-if []
   "NATIVE: test nested if"


### PR DESCRIPTION
Fixes #1754.

Replaces #1923, because @brandonwillard vetoed removing `__slots__`.

Pickling `Result` with pickle protocol 0 will still fail, but this class is only for internal use and we have no intention of pickling it, so that's not a problem.