### PR TITLE
Guard against malformed `setv` in `_rewire_init`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,8 @@ Bug Fixes
 ------------------------------
 * Fixed a bug that made `hy.eval` from Python fail on `require`.
 * Fixed a bug that prevented pickling of keyword objects.
+* Fixed a compiler crash from `setv` with an odd number of arguments in
+  `defclass`.
 
 New Features
 ------------------------------

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1671,6 +1671,8 @@ class HyASTCompiler(object):
             else:
                 ann = None
 
+            if len(decls) < 2:
+                break
             k, v = (decls.pop(0), decls.pop(0))
             if ast_str(k) == "__init__" and isinstance(v, HyExpression):
                 v += HyExpression([HySymbol("None")])
@@ -1679,7 +1681,8 @@ class HyASTCompiler(object):
                 new_args.append(ann)
 
             new_args.extend((k, v))
-        return HyExpression([HySymbol("setv")] + new_args).replace(expr)
+        return (HyExpression([HySymbol("setv")] + new_args + decls)
+            .replace(expr))
 
     @special("dispatch-tag-macro", [STR, FORM])
     def compile_dispatch_tag_macro(self, expr, root, tag, arg):

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -234,6 +234,10 @@ def test_ast_bad_defclass():
     cant_compile("(defclass a None)")
     cant_compile("(defclass a None None)")
 
+    # https://github.com/hylang/hy/issues/1920
+    cant_compile("(defclass a [] (setv x))")
+    cant_compile("(defclass a [] (setv x 1  y))")
+
 
 def test_ast_good_lambda():
     "Make sure AST can compile valid lambda"


### PR DESCRIPTION
Fixes #1920.