### PR TITLE
Contrib/iterable unpacking let

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,16 +3,17 @@
 Unreleased
 ==============================
 
+New Features
+------------------------------
+* `let` macro now supports extended iterable unpacking syntax
+* New contrib module `pprint`, a Hy equivalent of `python.pprint`.
+
 Bug Fixes
 ------------------------------
 * Fixed a bug that made `hy.eval` from Python fail on `require`.
 * Fixed a bug that prevented pickling of keyword objects.
 * Fixed a compiler crash from `setv` with an odd number of arguments in
   `defclass`.
-
-New Features
-------------------------------
-* New contrib module `pprint`, a Hy equivalent of `python.pprint`.
 
 0.19.0 (released 2020-07-16)
 ==============================

--- a/docs/contrib/walk.rst
+++ b/docs/contrib/walk.rst
@@ -238,10 +238,35 @@ if you must avoid this hoisting.
 
 The ``let`` macro takes two parameters: a list defining *variables*
 and the *body* which gets executed. *variables* is a vector of
-variable and value pairs.
+variable and value pairs. ``let`` can also define variables using
+Python's `extended iterable unpacking`_ syntax to destructure iterables.
+
+.. code-block:: hy
+
+   => (let [[head #* tail] (, 0 1 2)]
+   ...  [head tail])
+   [0 [1 2]]
+
+Do note, however, that let can not destructure into a mutable data type,
+such as ``dicts`` or ``classes``. As such, the following will both raise
+macro expansion errors:
+
+.. code-block:: hy
+
+   ;; Unpack into a dictionary
+   => (let [x (dict)
+   ...      (, a (get x "y")) [1 2]]
+   ...  [a x])
+
+   ;; Unpack into a class
+   => (let [x (SimpleNamespace)
+   ...      [a x.y] [1 2]]
+   ...  [a x])
+
+.. _extended iterable unpacking: https://www.python.org/dev/peps/pep-3132/#specification
 
 Like the ``let*`` of many other Lisps, ``let`` executes the variable
-assignments one-by-one, in the order written::
+assignments one-by-one, in the order written:
 
 .. code-block:: hy
 

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -345,3 +345,28 @@
         x (+ x x)]
     (assert (= x "foobarfoobar"))
     (assert (= y "barfoobar"))))
+
+(defn test-let-unpacking []
+  (let [[a b] [1 2]
+        [lhead #* ltail] (range 3)
+        (, thead #* ttail) (range 3)
+        [nhead #* (, c #* nrest)] [0 1 2]]
+    (assert (= a 1))
+    (assert (= b 2))
+    (assert (= lhead 0))
+    (assert (= ltail [1 2]))
+    (assert (= thead 0))
+    (assert (= ttail [1 2]))
+    (assert (= nhead 0))
+    (assert (= c 1))
+    (assert (= nrest [2]))))
+
+(defn test-let-unpacking-rebind []
+  (let [[a b] [:foo :bar]
+        [a #* c] (range 3)
+        [head #* tail] [a b c]]
+    (assert (= a 0))
+    (assert (= b :bar))
+    (assert (= c [1 2]))
+    (assert (= head 0))
+    (assert (= tail [:bar [1 2]]))))


### PR DESCRIPTION
Fixes: #1858

Iterable unpacking assignment is crucial to a lot of python idioms and a feature I believe necessary for a `let` macro to have in order for it to become the go to assignment form. This implements it by delegating unpacking forms to `setv`, replacing the bindings with `gensym`'ed names that are then added to the `let` macro's dict in the same manner as regular name binds. It doesn't allow for the kind of mutable unpacking assignment that python allows like `hello['world'], b = [1, 2]` or `point.x, point.y = [1, 2]` which would make the macro a lot more complicated than it needs to be (as well as just being bad syntax imo). 

An example of the resulting python code:
```
(let [[head #* tail] [1 2 3 4]]
  [head tail])
```
becomes
```python
_hyx_letXUffffX177 = {}
[_hyx_headXUffffX178, *_hyx_tailXUffffX179] = [1, 2, 3, 4]
_hyx_letXUffffX177['head'] = _hyx_headXUffffX178
_hyx_letXUffffX177['tail'] = _hyx_tailXUffffX179
[_hyx_letXUffffX177['head'], _hyx_letXUffffX177['tail']]
```
