### PR TITLE
Add async tests to `pydemo`

### DIFF
--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [tests.resources [kwtest function-with-a-dash]]
+(import [tests.resources [kwtest function-with-a-dash AsyncWithTest]]
         [os.path [exists isdir isfile]]
         [sys :as systest]
         re
@@ -1899,18 +1899,6 @@ macros()
         (await (sleep 0))
         42))
   (assert (= (run-coroutine coro-test) 21)))
-
-
-(defclass AsyncWithTest []
-  (defn --init-- [self val]
-    (setv self.val val)
-    None)
-
-  (defn/a --aenter-- [self]
-    self.val)
-
-  (defn/a --aexit-- [self tyle value traceback]
-    (setv self.val None)))
 
 
 (defn test-single-with/a []

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,6 +1,27 @@
+# Copyright 2020 the authors.
+# This file is part of Hy, which is free software licensed under the Expat
+# license. See the LICENSE.
+
+
 def kwtest(*args, **kwargs):
     return kwargs
 
 
 def function_with_a_dash():
     pass
+
+
+class AsyncWithTest:
+    def __init__(self, val):
+        self.val = val
+    async def __aenter__(self):
+        return self.val
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.val = None
+
+
+async def async_loop(items):
+    import asyncio
+    for x in items:
+        yield x
+        await asyncio.sleep(0)

--- a/tests/resources/pydemo.hy
+++ b/tests/resources/pydemo.hy
@@ -167,3 +167,16 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
           o.x = C()
       pys_accum.append(i)")
 (setv py-accum (py "''.join(map(str, pys_accum))"))
+
+(defn/a coro []
+  (import asyncio [tests.resources [AsyncWithTest async-loop]])
+  (await (asyncio.sleep 0))
+  (setv values ["a"])
+  (with/a [t (AsyncWithTest "b")]
+    (.append values t))
+  (for [:async item (async-loop ["c" "d"])]
+    (.append values item))
+  (.extend values (lfor
+    :async item (async-loop ["e" "f"])
+    item))
+  values)

--- a/tests/test_hy2py.py
+++ b/tests/test_hy2py.py
@@ -3,7 +3,7 @@
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.
 
-import math, itertools
+import math, itertools, asyncio
 from hy import mangle
 import hy.importer
 
@@ -125,3 +125,6 @@ def assert_stuff(m):
         assert type(a) is not type(b)
     assert m.pys_accum == [0, 1, 2, 3, 4]
     assert m.py_accum == "01234"
+
+    assert (asyncio.get_event_loop().run_until_complete(m.coro())
+        == list("abcdef"))


### PR DESCRIPTION
#1931 is a prerequisite, since these tests fail on Python 3.5.