### PR TITLE
docs: fix simple typo, exteneded -> extended

### DIFF
--- a/docs/contrib/pprint.rst
+++ b/docs/contrib/pprint.rst
@@ -18,7 +18,7 @@ print objects using Hy syntax.
                       :pizza}}
 
 Hy ``pprint`` leverages ``hy-repr`` for much of it's pretty printing and
-therefor can be exteneded to work with arbitrary types using
+therefor can be extended to work with arbitrary types using
 ``hy-repr-register``. Like Python's ``pprint`` and ``hy-repr``, Hy ``pprint``
 attempts to maintain round-trippability of it's input where possible. Unlike
 Python, however, Hy does not have `string literal concatenation`_,


### PR DESCRIPTION
There is a small typo in docs/contrib/pprint.rst.

Should read `extended` rather than `exteneded`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md