### PR TITLE
Fix and add tests for ``smacrolet``.

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,7 @@ Bug Fixes
 ------------------------------
 * Fixed a bug where AST nodes from macro expansion did not properly
   receive source location info.
+* Fixed bug in `smacrolet` by replacing `module-name` argument with `&name`.
 
 New Features
 ------------------------------

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -269,7 +269,7 @@ Arguments without a header are under None.
         ;; recursive base case--it's an atom. Put it back.
         (self.handle-base))))
 
-(defmacro smacrolet [bindings &optional module-name &rest body]
+(defmacro smacrolet [bindings &rest body]
   "
 symbol macro let.
 
@@ -284,7 +284,7 @@ The bindings pairs the target symbol and the expansion form for that symbol.
             (if (in '. k)
                 (macro-error k "binding target may not contain a dot"))))
   (setv bindings (dict (partition bindings))
-        body (macroexpand-all body (or module-name (calling-module-name))))
+        body (macroexpand-all body &name))
   (symbolexpand `(do ~@body)
                 (fn [symbol]
                   (.get bindings symbol symbol))))

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -65,6 +65,30 @@
   (assert (= (last (macroexpand-all '(require-macro)))
              '(setv blah 1))))
 
+(defn test-smacrolet []
+  (setv form '(do
+                (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                (* b (foo 7)))
+        form1 (macroexpand
+                '(smacrolet [b c]
+                   (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                   (* b (foo 7))))
+        form2 (macroexpand
+                '(smacrolet [a c]
+                   (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                   (* b (foo 7))))
+        form3 (macroexpand
+                '(smacrolet [foo bar]
+                   (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                   (* b (foo 7)))))
+  (assert (= form1 '(do
+                      (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                      (* c (foo 7)))))
+  (assert (= form2 form))
+  (assert (= form3 '(do
+                      (setv bar (fn [a &optional [b 1]] (* b (inc a))))
+                      (* b (bar 7))))))
+
 (defn test-let-basic []
   (assert (zero? (let [a 0] a)))
   (setv a "a"


### PR DESCRIPTION
Current implementation of ``smacrolet`` from ``hy.contrib.walk`` has a simple fault: it has an ``&optional`` argument before ``&rest``, hence when the optional ``module-name`` isn't provided, it throws an error.

```hy
hy 0.19.0+36.g14b17afd using CPython(default) 3.9.1 on Linux
=> (require [hy.contrib.walk [smacrolet]])
import hy.macros
hy.macros.require('hy.contrib.walk', None, assignments=[['smacrolet',
    'smacrolet']], prefix='')
None

=> (smacrolet [a b] (+ a ((fn [a] (inc a)) 1)))
Traceback (most recent call last):
  File "stdin-dad2257d93a1a88c4c55229a701f11d0767b0201", line 1, in <module>
    (smacrolet [a b] (+ a ((fn [a] (inc a)) 1)))
  File "/usr/lib/python3.9/contextlib.py", line 135, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/peter/Programming/hy/hy-source/hy/hy/contrib/walk.hy", line 287, in smacrolet
    body (macroexpand-all body (or module-name (calling-module-name))))
  File "/home/peter/Programming/hy/hy-source/hy/hy/contrib/walk.hy", line 46, in macroexpand_all
    (import-module module-name))
  File "/usr/lib/python3.9/importlib/__init__.py", line 118, in import_module
    if name.startswith('.'):
hy.errors.HyMacroExpansionError: 
  File "<stdin>", line 1
    (smacrolet [a b] (+ a ((fn [a] (inc a)) 1)))
    ^------------------------------------------^
expanding macro smacrolet
  AttributeError: 'HyExpression' object has no attribute 'startswith'


=> (smacrolet [a b] "hy.cmdline" (+ a ((fn [a] (inc a)) 1)))
from hy.core.language import inc
b + (lambda a: inc(a))(1) ; <- substitution happened correctly

Traceback (most recent call last):
  File "stdin-9c555ba1a2470d5f1adc4306d886f6b9c53c2a8e", line 1, in <module>
    (smacrolet [a b] "hy.cmdline" (+ a ((fn [a] (inc a)) 1)))
NameError: name 'b' is not defined

```

It seems that the easy fix is to remove the ``module-name`` argument and replace it's use with ``&name`` within the macro.