### PR TITLE
Walkable f-strings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,3 +104,4 @@
 * Allie Jo Casey <allie.jo.casey@gmail.com>
 * Joshua Munn <public@elysee-munn.family>
 * Peter Andreev <appa@gmx.co.uk>
+* Sunjay Cauligi <scauligi@eng.ucsd.edu>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,15 +3,21 @@
 Unreleased
 ==============================
 
+Breaking Changes
+------------------------------
+* f-strings are now parsed as a separate `HyFString` node,
+  which is a collection of `HyString` and `HyFComponent` nodes.
+
+New Features
+------------------------------
+* New contrib module `destructure` for Clojure-style destructuring.
+
 Bug Fixes
 ------------------------------
 * Fixed a bug where AST nodes from macro expansion did not properly
   receive source location info.
 * Fixed bug in `smacrolet` by replacing `module-name` argument with `&name`.
-
-New Features
-------------------------------
-* New contrib module `destructure` for Clojure-style destructuring.
+* Fixed expressions within f-strings being inaccessible to macros.
 
 0.20.0 (released 2021-01-25)
 ==============================

--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -15,7 +15,7 @@ def _initialize_env_var(env_var, default_val):
     return res
 
 
-from hy.models import HyExpression, HyInteger, HyKeyword, HyComplex, HyString, HyBytes, HySymbol, HyFloat, HyDict, HyList, HySet  # NOQA
+from hy.models import HyExpression, HyInteger, HyKeyword, HyComplex, HyString, HyFString, HyFComponent, HyBytes, HySymbol, HyFloat, HyDict, HyList, HySet  # NOQA
 
 
 import hy.importer  # NOQA

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -19,7 +19,6 @@ from hy.macros import require, load_macros, macroexpand, tag_macroexpand
 
 import hy.core
 
-import re
 import textwrap
 import pkgutil
 import traceback
@@ -1882,86 +1881,6 @@ class HyASTCompiler(object):
         node = asty.Bytes if type(string) is HyBytes else asty.Str
         f = bytes if type(string) is HyBytes else str
         return node(string, s=f(string))
-
-    def _format_string(self, string, rest, allow_recursion=True):
-        values = []
-        ret = Result()
-
-        while True:
-           # Look for the next replacement field, and get the
-           # plain text before it.
-           match = re.search(r'\{\{?|\}\}?', rest)
-           if match:
-              literal_chars = rest[: match.start()]
-              if match.group() == '}':
-                  raise self._syntax_error(string,
-                      "f-string: single '}' is not allowed")
-              if match.group() in ('{{', '}}'):
-                  # Doubled braces just add a single brace to the text.
-                  literal_chars += match.group()[0]
-              rest = rest[match.end() :]
-           else:
-              literal_chars = rest
-              rest = ""
-           if literal_chars:
-               values.append(asty.Str(string, s = literal_chars))
-           if not rest:
-               break
-           if match.group() != '{':
-               continue
-
-           # Look for the end of the replacement field, allowing
-           # one more level of matched braces, but no deeper, and only
-           # if we can recurse.
-           match = re.match(
-               r'(?: \{ [^{}]* \} | [^{}]+ )* \}'
-                   if allow_recursion
-                   else r'[^{}]* \}',
-               rest, re.VERBOSE)
-           if not match:
-              raise self._syntax_error(string, 'f-string: mismatched braces')
-           item = rest[: match.end() - 1]
-           rest = rest[match.end() :]
-
-           # Parse the first form.
-           try:
-               model, item = parse_one_thing(item)
-           except (ValueError, LexException) as e:
-               raise self._syntax_error(string, "f-string: " + str(e))
-
-           # Look for a conversion character.
-           item = item.lstrip()
-           conversion = None
-           if item.startswith('!'):
-               conversion = item[1]
-               item = item[2:].lstrip()
-
-           # Look for a format specifier.
-           format_spec = None
-           if item.startswith(':'):
-               if allow_recursion:
-                   ret += self._format_string(string,
-                       item[1:],
-                       allow_recursion=False)
-                   format_spec = ret.force_expr
-               else:
-                   format_spec = asty.JoinedStr(string, values=
-                       [asty.Str(string, s=item[1:])])
-           elif item:
-               raise self._syntax_error(string,
-                   "f-string: trailing junk in field")
-
-           # Now, having finished compiling any recursively included
-           # forms, we can compile the first form that we parsed.
-           ret += self.compile(model)
-
-           values.append(asty.FormattedValue(
-               string,
-               conversion = -1 if conversion is None else ord(conversion),
-               format_spec = format_spec,
-               value = ret.force_expr))
-
-        return ret + asty.JoinedStr(string, values = values)
 
     @builds_model(HyList, HySet)
     def compile_list(self, expression):

--- a/hy/contrib/hy_repr.hy
+++ b/hy/contrib/hy_repr.hy
@@ -7,7 +7,7 @@
   re
   datetime
   collections
-  [hy.models [HyObject HyExpression HySymbol HyKeyword HyInteger HyFloat HyComplex HyList HyDict HySet HyString HyBytes]])
+  [hy.models [HyObject HyExpression HySymbol HyKeyword HyInteger HyFloat HyComplex HyList HyDict HySet HyString HyFString HyFComponent HyBytes]])
 
 (try
   (import [_collections_abc [dict-keys dict-values dict-items]])

--- a/hy/model_patterns.py
+++ b/hy/model_patterns.py
@@ -4,7 +4,7 @@
 
 "Parser combinators for pattern-matching Hy model trees."
 
-from hy.models import HyExpression, HySymbol, HyKeyword, HyString, HyList
+from hy.models import HyExpression, HySymbol, HyKeyword, HyString, HyFString, HyList
 from funcparserlib.parser import (
     some, skip, many, finished, a, Parser, NoParseError, State)
 from functools import reduce
@@ -16,7 +16,7 @@ from math import isinf
 FORM = some(lambda _: True)
 SYM = some(lambda x: isinstance(x, HySymbol))
 KEYWORD = some(lambda x: isinstance(x, HyKeyword))
-STR = some(lambda x: isinstance(x, HyString))
+STR = some(lambda x: isinstance(x, HyString))  # matches literal strings only!
 
 def sym(wanted):
     "Parse and skip the given symbol or keyword."

--- a/tests/native_tests/extra/anaphoric.hy
+++ b/tests/native_tests/extra/anaphoric.hy
@@ -194,6 +194,9 @@
   (assert (= (#%(, %* %**) 1 2 :a 'b)
              (, (, 1 2)
                 (dict :a 'b))))
+  ;; test f-strings
+  ;; https://github.com/hylang/hy/issues/1938
+  (assert (= (#% f"->{(- %2 %1)}" 4 7) "->3"))
   ;; test other expression types
   (assert (= (#% %* 1 2 3)
              (, 1 2 3)))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1316,7 +1316,7 @@ cee\"} dee" "ey bee\ncee dee"))
   ; Quoting shouldn't evaluate the f-string immediately
   ; https://github.com/hylang/hy/issues/1844
   (setv quoted 'f"hello {world}")
-  (assert quoted.is-format)
+  (assert (isinstance quoted HyFString))
   (with [(pytest.raises NameError)]
     (eval quoted))
   (setv world "goodbye")


### PR DESCRIPTION
Hopefully not too intrusive of a PR, but it's a breaking change.
Introduces two new `HySequence` nodes: `HyFComponent` and `HyFString`.
f-strings are now parsed as `HyFString`s, allowing routines like `walk` and `recur-sym-replace` to descend into expressions within f-strings.

This fixes #1843 and fixes #1938, and I added some tests to ensure no regressions for either.
This also tangentially affects #1948, as the relevant f-string format parsing has been relocated to `lex/parser.py`.