### PR TITLE
Fixes #1944: macro-expanded ast nodes had bad lineno/col info

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,13 @@
 .. default-role:: code
 
+Unreleased
+==============================
+
+Bug Fixes
+------------------------------
+* Fixed a bug where AST nodes from macro expansion did not properly
+  receive source location info.
+
 0.20.0 (released 2021-01-25)
 ==============================
 

--- a/hy/models.py
+++ b/hy/models.py
@@ -50,7 +50,7 @@ class HyObject(object):
     `abc` starting at the first column would have `start_column` 1 and
     `end_column` 3.
     """
-    properties = ["module", "start_line", "end_line", "start_column",
+    properties = ["module", "_start_line", "end_line", "_start_column",
                   "end_column"]
 
     def replace(self, other, recursive=False):
@@ -62,6 +62,22 @@ class HyObject(object):
             raise TypeError("Can't replace a non Hy object '{}' with a Hy object '{}'".format(repr(other), repr(self)))
 
         return self
+
+    @property
+    def start_line(self):
+        return getattr(self, "_start_line", 1)
+
+    @start_line.setter
+    def start_line(self, value):
+        self._start_line = value
+
+    @property
+    def start_column(self):
+        return getattr(self, "_start_column", 1)
+
+    @start_column.setter
+    def start_column(self, value):
+        self._start_column = value
 
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, super(HyObject, self).__repr__())
@@ -84,10 +100,6 @@ def wrap_value(x):
         raise HyWrapperError("Don't know how to wrap {!r}: {!r}".format(type(x), x))
     if isinstance(x, HyObject):
         new = new.replace(x, recursive=False)
-    if not hasattr(new, "start_column"):
-        new.start_column = 0
-    if not hasattr(new, "start_line"):
-        new.start_line = 0
     return new
 
 

--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -2,13 +2,13 @@
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.
 
-from hy.macros import macro, macroexpand
+from hy.macros import macro, macroexpand, tag_macroexpand
 from hy.lex import tokenize
 
 from hy.models import HyString, HyList, HySymbol, HyExpression, HyFloat
 from hy.errors import HyMacroExpansionError
 
-from hy.compiler import HyASTCompiler
+from hy.compiler import HyASTCompiler, mangle
 
 import pytest
 
@@ -60,3 +60,12 @@ def test_macroexpand_nan():
    x = macroexpand(HyFloat(NaN), __name__, HyASTCompiler(__name__))
    assert type(x) is HyFloat
    assert math.isnan(x)
+
+def test_macroexpand_source_data():
+    # https://github.com/hylang/hy/issues/1944
+    ast = HyString('a')
+    ast.start_line = 3
+    ast.start_column = 5
+    bad = tag_macroexpand(mangle("@"), ast, "hy.core.macros")
+    assert bad.start_line == 3
+    assert bad.start_column == 5


### PR DESCRIPTION
Fixes #1944.

The AST nodes coming out of the `#@` expansion had a line/column number of 0 because of how "default" HyObject properties were being handled, causing an index underflow.
This change patches HyObjects to handle default properties better (and also changes the default info to 1 to prevent any future underflow bugs).

`wrap_value()` in `models.py` initialized `HyObject`s with 0'd out source locations, causing `HyObject.replace()` to not update these objects with the proper source locations later as it looks like they're already set.
I added a `__getattr__` method to `HyObject` so that it can return a default value for these properties if they're not yet set, while still allowing them to be overridden if they have not truly been initialized.