### PR TITLE
Make `doc` and `#doc` work with mangling

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,6 +20,7 @@ Bug Fixes
 * Fixed expressions within f-strings being inaccessible to macros.
 * Fixed symbol `J` being incorrectly parsed as a complex number
 * Fixed error handling for non-symbol macro names
+* `doc` and `#doc` now work with names that require mangling.
 
 0.20.0 (released 2021-01-25)
 ==============================

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -733,11 +733,11 @@
 
    Use ``#doc foo`` instead for help with tag macro ``#foo``.
    Use ``(help foo)`` instead for help with runtime objects."
-  `(help (.get __macros__ '~symbol None)))
+  `(help (.get __macros__ (mangle '~symbol) None)))
 
 
 (deftag doc [symbol]
   "tag macro documentation
 
    Gets help for a tag macro function available in this module."
-  `(help (.get __tags__ '~symbol None)))
+  `(help (.get __tags__ (mangle '~symbol) None)))

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -700,12 +700,17 @@ result['y in globals'] = 'y' in globals()")
                         <p> Move along. (Nothing to see here.)</p>)))
 
 (defn test-doc [capsys]
-  (defmacro testmacdoc []
+  (defmacro <-mangle-> []
     "a fancy docstring"
     '(+ 2 2))
-  (doc testmacdoc)
+  (doc <-mangle->)
   (setv [out err] (.readouterr capsys))
+  ;; https://github.com/hylang/hy/issues/1946
   (assert (.startswith (.strip out)
-            "Help on function testmacdoc in module "))
+            f"Help on function {(mangle '<-mangle->)} in module "))
   (assert (in "a fancy docstring" out))
+  (assert (empty? err))
+  #doc @
+  (setv [out err] (.readouterr capsys))
+  (assert (in "with-decorator tag macro" out))
   (assert (empty? err)))


### PR DESCRIPTION
Closes #1946.

Adds call to `mangle` in the doc macros so that they work with names such as `->`.