### PR TITLE
Custom history location

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,3 +105,4 @@
 * Joshua Munn <public@elysee-munn.family>
 * Peter Andreev <appa@gmx.co.uk>
 * Sunjay Cauligi <scauligi@eng.ucsd.edu>
+* David Tscheppen <david.tscheppen@gmail.com>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,6 +11,7 @@ Breaking Changes
 New Features
 ------------------------------
 * New contrib module `destructure` for Clojure-style destructuring.
+* Location of history file now configurable via environment variable `HY_HISTORY`
 
 Bug Fixes
 ------------------------------

--- a/docs/language/repl.rst
+++ b/docs/language/repl.rst
@@ -62,6 +62,19 @@ Once an exception has been thrown in an interactive session, the most recent exc
   <class 'ZeroDivisionError'>
 
 
+.. _repl-configuration:
+
+Configuration
+-------------
+
+.. _history-location:
+
+Location of history
+^^^^^^^^^^^^^^^^^^^
+
+The default location for the history of REPL inputs is ``~/.hy-history``. This can be changed by setting the environment variable ``HY_HISTORY`` to your preferred location. For example, if you are using Bash, it can be set with ``export HY_HISTORY=/path/to/my/.custom-hy-history``.
+
+
 --------
 
 .. [#] https://en.wikipedia.org/wiki/Read-eval-print_loop

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -117,7 +117,8 @@ def completion(completer=None):
         readline.set_completer(completer.complete)
         readline.set_completer_delims(delims)
 
-        history = os.path.expanduser("~/.hy-history")
+        history = os.environ.get(
+            "HY_HISTORY", os.path.expanduser("~/.hy-history"))
         readline.parse_and_bind("set blink-matching-paren on")
 
         try:

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from hy.completer import completion
+import pytest
+import tempfile
+
+
+@pytest.mark.skipif(
+    "readline" not in sys.modules,
+    reason="Module 'readline' is not available.")
+def test_history_custom_location():
+    import readline
+
+    expected_entry = '(print "Hy, custom history file!")'
+
+    with tempfile.TemporaryDirectory() as tmp:
+        history_location = tmp + os.sep + ".hy-custom-history"
+        os.environ["HY_HISTORY"] = history_location
+
+        with completion():
+            readline.clear_history()
+            readline.add_history(expected_entry)
+
+        with open(history_location, "r") as hf:
+            actual_entry = hf.readline()
+            assert expected_entry in actual_entry


### PR DESCRIPTION
Closes #1833

Adds setting of the location of the history file to the value of the `HY_HISTORY` environment variable in the `completion` context manager, if provided.