### PR TITLE
Add Python 3.9 to supported versions in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
   - pypy3
 install:
   - pip install -r requirements-travis.txt

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Code Generators",
         "Topic :: Software Development :: Compilers",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
I'm guessing this was just an oversight? :sweat_smile:

I thought about adding 3.10 here as well, but we've seen bad mojo in the past from claiming to support the alphas too soon and then seeing breaking changes before release. :grimacing:

(Happy to adjust and include 3.10 though if that's what maintainers prefer! :heart:)