### PR TITLE
Fixes 'J' being parsed as a complex and fixes error messages for bad `defmacro` names

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,6 +18,7 @@ Bug Fixes
   receive source location info.
 * Fixed bug in `smacrolet` by replacing `module-name` argument with `&name`.
 * Fixed expressions within f-strings being inaccessible to macros.
+* Fixed symbol `J` being incorrectly parsed as a complex number
 
 0.20.0 (released 2021-01-25)
 ==============================

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -19,6 +19,7 @@ Bug Fixes
 * Fixed bug in `smacrolet` by replacing `module-name` argument with `&name`.
 * Fixed expressions within f-strings being inaccessible to macros.
 * Fixed symbol `J` being incorrectly parsed as a complex number
+* Fixed error handling for non-symbol macro names
 
 0.20.0 (released 2021-01-25)
 ==============================

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -15,7 +15,7 @@
           (raise
             (hy.errors.HyTypeError
               (% "received a `%s' instead of a symbol for macro name"
-                 (. (type name) __name__))
+                 (. (type macro-name) __name__))
               None --file-- None)))
      (for [kw '[&kwonly &kwargs]]
        (if* (in kw lambda-list)

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -379,7 +379,7 @@ def symbol_like(obj):
     except ValueError:
         pass
 
-    if obj != 'j':
+    if obj not in ('j', 'J'):
         try:
             return HyComplex(obj)
         except ValueError:

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -75,6 +75,16 @@
       (assert (= e.msg "macros cannot use &kwargs")))
     (else (assert False))))
 
+(defn test-macro-bad-name []
+  "NATIVE: test that the proper error is raised when a non-symbol is used for a macro or tag name"
+  (with [excinfo (pytest.raises HyTypeError)]
+    (eval '(defmacro :kw [])))
+  (assert (= (. excinfo value msg) "received a `HyKeyword' instead of a symbol for macro name"))
+
+  (with [excinfo (pytest.raises HyTypeError)]
+    (eval '(deftag :kw [])))
+  (assert (= (. excinfo value msg) "received a `HyKeyword' instead of a symbol for tag macro name")))
+
 (defn test-fn-calling-macro []
   "NATIVE: test macro calling a plain function"
   (assert (= 3 (bar 1 2))))

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -179,6 +179,7 @@ def test_lex_expression_complex():
     assert t("-0.5j") == f(HyComplex(-0.5j))
     assert t("1.e7j") == f(HyComplex(1e7j))
     assert t("j") == f(HySymbol("j"))
+    assert t("J") == f(HySymbol("J"))
     assert isnan(t("NaNj")[0][1].imag)
     assert t("nanj") == f(HySymbol("nanj"))
     assert t("Inf+Infj") == f(HyComplex(complex(float("inf"), float("inf"))))
@@ -393,8 +394,12 @@ def test_complex():
     # This is a regression test for #143
     entry = tokenize("(1j)")[0][0]
     assert entry == HyComplex("1.0j")
+    entry = tokenize("(1J)")[0][0]
+    assert entry == HyComplex("1.0j")
     entry = tokenize("(j)")[0][0]
     assert entry == HySymbol("j")
+    entry = tokenize("(J)")[0][0]
+    assert entry == HySymbol("J")
 
 
 def test_tag_macro():


### PR DESCRIPTION
Two relatively minor bugfixes, with regression tests. No associated open issues (that I'm aware of).
Let me know if I should split this into two commits / two PRs.