### PR TITLE
Add handling for "=" syntax in f-strings

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -12,6 +12,7 @@ New Features
 ------------------------------
 * New contrib module `destructure` for Clojure-style destructuring.
 * Location of history file now configurable via environment variable `HY_HISTORY`
+* Added handling for "=" syntax in f-strings.
 
 Bug Fixes
 ------------------------------

--- a/docs/language/syntax.rst
+++ b/docs/language/syntax.rst
@@ -107,6 +107,15 @@ string, before any replacement fields are considered, so you may need to
 backslash your backslashes, and you can't comment out a closing brace or the
 string delimiter.
 
+Hy's f-strings are compatible with Python's "=" debugging syntax, subject to
+the above limitations on delimiting identifiers. For example::
+
+    => (setv foo "bar")
+    => (print f"{foo = }")
+    foo = 'bar'
+    => (print f"{foo = !s :_^7}")
+    foo = __bar__
+
 .. _syntax-keywords:
 
 keywords

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1320,7 +1320,34 @@ cee\"} dee" "ey bee\ncee dee"))
   (with [(pytest.raises NameError)]
     (eval quoted))
   (setv world "goodbye")
-  (assert (= (eval quoted) "hello goodbye")))
+  (assert (= (eval quoted) "hello goodbye"))
+
+  ;; '=' debugging syntax.
+  (setv foo "bar")
+  (assert (= f"{foo =}" "foo ='bar'"))
+
+  ;; Whitespace is preserved.
+  (assert (= f"xyz{  foo = }" "xyz  foo = 'bar'"))
+
+  ;; Explicit conversion is applied.
+  (assert (= f"{ foo = !s}" " foo = bar"))
+
+  ;; Format spec supercedes implicit conversion.
+  (setv  pi 3.141593  fill "_")
+  (assert (= f"{pi = :{fill}^8.2f}" "pi = __3.14__"))
+
+  ;; Format spec doesn't clobber the explicit conversion.
+  (with [(pytest.raises
+           ValueError
+           :match r"Unknown format code '?f'? for object of type 'str'")]
+    f"{pi =!s:.3f}")
+
+  ;; Nested "=" is parsed, but fails at runtime, like Python.
+  (setv width 7)
+  (with [(pytest.raises
+           ValueError
+           :match r"I|invalid format spec(?:ifier)?")]
+    f"{pi =:{fill =}^{width =}.2f}"))
 
 
 (defn test-import-syntax []


### PR DESCRIPTION
Closes #1948 

I didn't think it was necessary to add documentation as it's part of Python, let me know if you think otherwise.