### PR TITLE
Policy: change the interval for uncontroversial merges to 3 days

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -125,7 +125,7 @@ There are two situations in which a PR is allowed to be merged:
 1. When it is approved by **two** members of Hy's core team other than the PR's
    author. Changes to the documentation, or trivial changes to code, need only
    **one** approving member.
-2. When the PR is at least **two weeks** old and **no** member of the Hy core
+2. When the PR is at least **three days** old and **no** member of the Hy core
    team has expressed disapproval of the PR in its current state. (Exception: a
    PR to create a new release is not eligible to be merged under this criterion,
    only the first one.)


### PR DESCRIPTION
#1508 has been a big success. Whereas perfectly good PRs once sat unmerged for months because nobody other than the author could get around to reviewing them, now an uncontroversial change can get merged in at worst 2 weeks. Still, 2 weeks is a while, and I've yet to see such a long interval produce late objections or vetos to a change. In all the cases over the past few years in which a PR was objected to or changes were requested, the objection came within a day or two of the PR's creation. So after the first few days, all the waiting does is slow down an inevitable merge. Faster merges would not only allow bug fixes and new features to become available more quickly; it would also encourage new Hy developers to make more PRs because of the warm fuzzy feeling of prompt integration of one's changes.

@hylang/core Are you guys on board with this?