### PR TITLE
Fix: Tag macro expansion compiler crash

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,7 @@ Bug Fixes
 * Fixed symbol `J` being incorrectly parsed as a complex number
 * Fixed error handling for non-symbol macro names
 * `doc` and `#doc` now work with names that require mangling.
+* Fixed exceptions in tag macros crashing compiler
 
 0.20.0 (released 2021-01-25)
 ==============================

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -129,6 +129,12 @@
   (if (or (= tag-name ":")
           (= tag-name "&"))
       (raise (hy.errors.HyNameError (% "%s can't be used as a tag macro name" tag-name))))
+
+  (if (!= (len lambda-list) 1)
+      (raise (hy.errors.HyTypeError
+               (% "tag macros must take one and only one argument, received: '%s' with lambda-list: '%s'"
+                  (, (len lambda-list) (list lambda-list)))
+               tag-name --file-- None)))
   (setv tag-name (.replace (hy.models.HyString tag-name)
                            tag-name))
   `(eval-and-compile

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -611,7 +611,7 @@ def test_compiler_macro_tag_try():
     """Check that try forms within defmacro/deftag are compiled correctly"""
     # https://github.com/hylang/hy/issues/1350
     can_compile("(defmacro foo [] (try None (except [] None)) `())")
-    can_compile("(deftag foo [] (try None (except [] None)) `())")
+    can_compile("(deftag foo [a] (try None (except [] None)) `())")
 
 
 def test_ast_good_yield_from():


### PR DESCRIPTION
Closes #1965.

tag macro expansion was missing the equivalent `with macro_exceptions` context manager meaning user errors in macros crashed the compiler. Also enforced the unary constraint of `deftag` that @jams2 and I noticed would also crash the compiler if not adhered to. 