### PR TITLE
Fix compiler crash on malformed `.` special form

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,6 +22,7 @@ Bug Fixes
 * Fixed symbol `J` being incorrectly parsed as a complex number
 * Fixed error handling for non-symbol macro names
 * `doc` and `#doc` now work with names that require mangling.
+* Fixed compiler crash on `.` form with empty attributes.
 
 0.20.0 (released 2021-01-25)
 ==============================

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1781,6 +1781,9 @@ class HyASTCompiler(object):
                 # Get the method name (the last named attribute
                 # in the chain of attributes)
                 attrs = [HySymbol(a).replace(root) for a in root.split(".")[1:]]
+                if not all(attrs):
+                    raise self._syntax_error(expr,
+                         "cannot access empty attribute")
                 root = attrs.pop()
 
                 # Get the object we're calling the method on

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -555,6 +555,7 @@ def test_attribute_access():
     cant_compile("(. foo bar :baz [0] quux [frob])")
     cant_compile("(. foo bar baz (0) quux [frob])")
     cant_compile("(. foo bar baz [0] quux {frob})")
+    cant_compile("(.. foo bar baz)")
 
 
 def test_attribute_empty():


### PR DESCRIPTION
Hy compiler would crash on a root with multiple dots in a row:
```
=> (.. "crashme")
Traceback (most recent call last):
  File "/home/scauligi/workspace/hy/venv/bin/hy", line 12, in <module>
    sys.exit(hy_main())
  File "/usr/lib/python3.9/code.py", line 232, in interact
    more = self.push(line)
  File "/usr/lib/python3.9/code.py", line 258, in push
    more = self.runsource(source, self.filename)
  File "/usr/lib/python3.9/code.py", line 63, in runsource
    code = self.compile(source, filename, symbol)
  File "/usr/lib/python3.9/codeop.py", line 178, in __call__
    return _maybe_compile(self.compiler, source, filename, symbol)
hy.errors.HyCompileError: Internal Compiler Bug 😱
```

This fixes that.