### PR TITLE
Feature: Simplify Fn args and support positional only args

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,17 @@ Breaking Changes
   `(:key obj)` is now equivalent to `(get obj (. :key name))`.
 * To require a tag macro `foo`, instead of `(require [module [foo]])`,
   you must now say `(require [module ["#foo"]])`.
+* Simplified `fn` parameters, added support for positional only arguments, and removed
+  implicit `None` for optional arguments.
+  The equivalent of::
+
+    def hello(a, /, b, c=None, *, d, e="world", **kwargs): pass
+
+  is now::
+
+    (defn hello [a / b [c None] * d [e "world"] #** kwargs])
+
+  check the docs or use ``(doc defn)`` at the repl for more details.
 
 New Features
 ------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,7 +35,7 @@ Special Forms
 
       ; Annotate a as an int, c as an int, and b as a str.
       ; Equivalent to: def func(a: int, b: str = None, c: int = 1): ...
-      (defn func [^int a &optional ^str b ^int [c 1]] ...)
+      (defn func [^int a ^str [b None] ^int [c 1]] ...)
 
    The rules are:
 
@@ -85,7 +85,7 @@ Special Forms
    unknown keys raises an :exc:`IndexError` (on lists and tuples) or a
    :exc:`KeyError` (on dictionaries).
 
-.. hy:function:: (fn [name &rest arags])
+.. hy:function:: (fn [name #* arags])
 
    ``fn``, like Python's ``lambda``, can be used to define an anonymous function.
    Unlike Python's ``lambda``, the body of the function can comprise several
@@ -124,7 +124,7 @@ Special Forms
        Multiplies input by three and returns result
        (END)
 
-.. hy:function:: (fn/a [name &rest args])
+.. hy:function:: (fn/a [name #* args])
 
    ``fn/a`` is a variant of ``fn`` than defines an anonymous coroutine.
    The parameters are similar to ``defn/a``: the first parameter is
@@ -167,7 +167,7 @@ Special Forms
      ...       (print "Try again")))
 
 
-.. hy:function:: (cmp [&rest args])
+.. hy:function:: (cmp [#* args])
 
    ``cmp`` creates a :ref:`comparison expression <py:comparisons>`. It isn't
    required for unchained comparisons, which have only one comparison operator,
@@ -215,7 +215,7 @@ Special Forms
        ...     (continue))
        ...   (side-effect2))
 
-.. hy:function:: (do [&rest body])
+.. hy:function:: (do [#* body])
 
    ``do`` (called ``progn`` in some Lisps) takes any number of forms,
    evaluates them, and returns the value of the last one, or ``None`` if no
@@ -228,7 +228,7 @@ Special Forms
        => (+ 1 (do (setv x (+ 1 1)) x))
        3
 
-.. hy:function:: (for [&rest args])
+.. hy:function:: (for [#* args])
 
    ``for`` is used to evaluate some forms for each element in an iterable
    object, such as a list. The return values of the forms are discarded and
@@ -282,7 +282,7 @@ Special Forms
        3
        loop finished
 
-.. hy:function:: (assert [condition &optional label])
+.. hy:function:: (assert [condition [label None]])
 
    ``assert`` is used to verify conditions while the program is
    running. If the condition is not met, an :exc:`AssertionError` is
@@ -328,7 +328,7 @@ Special Forms
        (set-a 5)
        (print-a)
 
-.. hy:function:: (get [coll key1 &rest keys])
+.. hy:function:: (get [coll key1 #* keys])
 
    ``get`` is used to access single elements in collections. ``get`` takes at
    least two parameters: the *data structure* and the *index* or *key* of the
@@ -358,7 +358,7 @@ Special Forms
    .. note:: ``get`` raises an IndexError if a list or a tuple is queried for an
              index that is out of bounds.
 
-.. hy:macro:: (import [&rest forms])
+.. hy:macro:: (import [#* forms])
 
    ``import`` is used to import modules, like in Python. There are several ways
    that ``import`` can be used.
@@ -401,7 +401,7 @@ Special Forms
        ;; Python: from sys import *
        (import [sys [*]])
 
-.. hy:function:: (eval-and-compile [&rest body])
+.. hy:function:: (eval-and-compile [#* body])
 
    ``eval-and-compile`` is a special form that takes any number of forms. The input forms are evaluated as soon as the ``eval-and-compile`` form is compiled, instead of being deferred until run-time. The input forms are also left in the program so they can be executed at run-time as usual. So, if you compile and immediately execute a program (as calling ``hy foo.hy`` does when ``foo.hy`` doesn't have an up-to-date byte-compiled version), ``eval-and-compile`` forms will be evaluated twice.
 
@@ -419,7 +419,7 @@ Special Forms
 
    Had the ``defn`` not been wrapped in ``eval-and-compile``, ``m`` wouldn't be able to call ``add``, because when the compiler was expanding ``(m 3)``, ``add`` wouldn't exist yet.
 
-.. hy:function:: (eval-when-compile [&rest body])
+.. hy:function:: (eval-when-compile [#* body])
 
    ``eval-when-compile`` is like ``eval-and-compile``, but the code isn't executed at run-time. Hence, ``eval-when-compile`` doesn't directly contribute any code to the final program, although it can still change Hy's state while compiling (e.g., by defining a function).
 
@@ -437,7 +437,7 @@ Special Forms
        (print (m 3))     ; prints 5
        (print (add 3 6)) ; raises NameError: name 'add' is not defined
 
-.. hy:macro:: (lfor [binding iterable &rest body])
+.. hy:macro:: (lfor [binding iterable #* body])
 
    The comprehension forms ``lfor``, :hy:macro:`sfor`, :hy:macro:`dfor`, :hy:macro:`gfor`, and :hy:func:`for`
    are used to produce various kinds of loops, including Python-style
@@ -494,7 +494,7 @@ Special Forms
    contain Python statements, with the attendant consequences for calling
    ``return``. By contrast, ``for`` shares the caller's scope.
 
-.. hy:macro:: (dfor [binding iterable &rest body])
+.. hy:macro:: (dfor [binding iterable #* body])
 
     ``dfor`` creates a :ref:`dictionary comprehension <py:dict>`. Its syntax
     is the same as that of `:hy:macro:`lfor` except that the final value form must be
@@ -509,7 +509,7 @@ Special Forms
         {0: 0, 1: 10, 2: 20, 3: 30, 4: 40}
 
 
-.. hy:macro:: (gfor [binding iterable &rest body])
+.. hy:macro:: (gfor [binding iterable #* body])
 
    ``gfor`` creates a :ref:`generator expression <py:genexpr>`. Its syntax
    is the same as that of :hy:macro:`lfor`. The difference is that ``gfor`` returns
@@ -527,12 +527,12 @@ Special Forms
        => accum
        [0, 1, 2, 3, 4, 5]
 
-.. hy:macro:: (sfor [binding iterable &rest body])
+.. hy:macro:: (sfor [binding iterable #* body])
 
    ``sfor`` creates a set comprehension. ``(sfor CLAUSES VALUE)`` is
    equivalent to ``(set (lfor CLAUSES VALUE))``. See :hy:macro:`lfor`.
 
-.. hy:function:: (setv [&rest args])
+.. hy:function:: (setv [#* args])
 
    ``setv`` is used to bind a value, object, or function to a symbol.
 
@@ -566,7 +566,7 @@ Special Forms
        a b ['c', 'd', 'e', 'f', 'g']
 
 
-.. hy:function:: (setx [&rest args])
+.. hy:function:: (setx [#* args])
 
    Whereas ``setv`` creates an assignment statement, ``setx`` creates an assignment expression (see :pep:`572`). It requires Python 3.8 or later. Only one target–value pair is allowed, and the target must be a bare symbol, but the ``setx`` form returns the assigned value instead of ``None``.
 
@@ -579,7 +579,7 @@ Special Forms
        3 is greater than 0
 
 
-.. hy:function:: (defclass [class-name super-classes &rest body])
+.. hy:function:: (defclass [class-name super-classes #* body])
 
    New classes are declared with ``defclass``. It can take optional parameters in the following order:
    a list defining (a) possible super class(es) and a string (:term:`py:docstring`).
@@ -745,7 +745,7 @@ Special Forms
        Hello World
 
 
-.. hy:function:: (require [&rest args])
+.. hy:function:: (require [#* args])
 
    ``require`` is used to import macros from one or more given modules. It allows
    parameters in all the same formats as ``import``. The ``require`` form itself
@@ -861,7 +861,7 @@ Special Forms
        => (print (f 4))
        None
 
-.. hy:function:: (cut [coll &optional start stop step])
+.. hy:function:: (cut [coll [start None] [stop None] [step None])
 
    ``cut`` can be used to take a subset of a list and create a new list from it.
    The form takes at least one parameter specifying the list to cut. Two
@@ -892,7 +892,7 @@ Special Forms
        => (cut collection -4 -2)
        [6, 7]
 
-.. hy:function:: (raise [&optional exception])
+.. hy:function:: (raise [[exception None]])
 
    The ``raise`` form can be used to raise an ``Exception`` at
    runtime. Example usage:
@@ -915,7 +915,7 @@ Special Forms
    or no arguments to re-raise the last ``Exception``.
 
 
-.. hy:function:: (try [&rest body])
+.. hy:function:: (try [#* body])
 
    The ``try`` form is used to catch exceptions (``except``) and run cleanup
    actions (``finally``).
@@ -1049,7 +1049,7 @@ Special Forms
    leaving no effects on the list it is enclosed in, therefore resulting in
    ``('+' 1 2)``.
 
-.. hy:function:: (while [condition &rest body])
+.. hy:function:: (while [condition #* body])
 
    ``while`` compiles to a :py:keyword:`while` statement. It is used to execute a
    set of forms as long as a condition is met. The first argument to ``while`` is
@@ -1107,7 +1107,7 @@ Special Forms
        In condition
        At end of outer loop
 
-.. hy:function:: (with-decorator [&rest args])
+.. hy:function:: (with-decorator [#* args])
 
    ``with-decorator`` is used to wrap a function with another. The function
    performing the decoration should accept a single value: the function being
@@ -1208,7 +1208,7 @@ Core
 
 .. hy:autofunction:: hy.core.language.read
 
-.. hy:function:: (chain [&rest iters])
+.. hy:function:: (chain [#* iters])
 
    builtin alias for `itertools.chain <https://docs.python.org/3/library/itertools.html#itertools.chain>`_
 
@@ -1252,11 +1252,11 @@ Core
       [2, -4]
 
 
-.. hy:function:: (group-by [iterable &optional key])
+.. hy:function:: (group-by [iterable [key None]])
 
    builtin alias for `itertools.groupby <https://docs.python.org/3/library/itertools.html#itertools.groupby>`_
 
-.. hy:function:: (islice [iterable &rest args])
+.. hy:function:: (islice [iterable #* args])
 
    Builtin alias for `itertools.islice <https://docs.python.org/3/library/itertools.html#itertools.islice>`_
 
@@ -1277,7 +1277,7 @@ Core
 
    Builtin alias for `itertools.takewhile <https://docs.python.org/3/library/itertools.html#itertools.takewhile>`_
 
-.. hy:function:: (tee [iterable &optional [n 2]])
+.. hy:function:: (tee [iterable [n 2]])
 
    Builtin alias for `itertools.tee <https://docs.python.org/3/library/itertools.html#itertools.tee>`_
 
@@ -1289,11 +1289,11 @@ Core
 
    Builtin alias for `itertools.combinations_with_replacement <https://docs.python.org/3/library/itertools.html#itertools.combinations_with_replacement>`_
 
-.. hy:function:: (permutations [iterable &optional r])
+.. hy:function:: (permutations [iterable [r None]])
 
    Builtin alias for `itertools.permutations <https://docs.python.org/3/library/itertools.html#itertools.permutations>`_
 
-.. hy:function:: (product [&rest args &kwonly [repeat 1]])
+.. hy:function:: (product [#* args * [repeat 1]])
 
    Builtin alias for `itertools.product <https://docs.python.org/3/library/itertools.html#itertools.product>`_
 
@@ -1317,15 +1317,15 @@ Core
 
    Builtin alias for `itertools.filterfalse <https://docs.python.org/3/library/itertools.html#itertools.filterfalse>`_
 
-.. hy:function:: (zip-longest [&rest iterables &kwonly fillvalue])
+.. hy:function:: (zip-longest [#* iterables * fillvalue])
 
    Builtin alias for `itertools.zip_longest <https://docs.python.org/3/library/itertools.html#itertools.zip_longest>`_
 
-.. hy:function:: (accumulate [iterable &optional func &kwonly initial])
+.. hy:function:: (accumulate [iterable [func None] * initial])
 
    Builtin alias for `itertools.accumulate <https://docs.python.org/3/library/itertools.html#itertools.accumulate>`_
 
-.. hy:function:: (count [&optional [start 0] [step 1]])
+.. hy:function:: (count [[start 0] [step 1]])
 
    Builtin alias for `itertools.count <https://docs.python.org/3/library/itertools.html#itertools.count>`_
 
@@ -1343,7 +1343,7 @@ Core
 
    Builtin alias for `itertools.cycle <https://docs.python.org/3/library/itertools.html#itertools.cycle>`_
 
-.. hy:function:: (repeat [object &optional times])
+.. hy:function:: (repeat [object [times None]])
 
    Returns an iterator (infinite) of ``x``.
 
@@ -1354,7 +1354,7 @@ Core
 
    Builtin alias for `itertools.repeat <https://docs.python.org/3/library/itertools.html#itertools.repeat>`_
 
-.. hy:function:: (reduce [function iterable &optional initializer])
+.. hy:function:: (reduce [function iterable [initializer None]])
 
    Builtin alias for `functools.reduce <https://docs.python.org/3/library/functools.html#functools.reduce>`_
 

--- a/docs/language/model_patterns.rst
+++ b/docs/language/model_patterns.rst
@@ -97,7 +97,7 @@ Here's how you could write a simple macro using model patterns:
 
 .. code-block:: clj
 
-    (defmacro pairs [&rest args]
+    (defmacro pairs [#* args]
       (import [funcparserlib.parser [many]])
       (import [hy.model-patterns [whole SYM FORM]])
       (setv [args] (->> args (.parse (whole [

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -449,7 +449,7 @@ Special Arguments
 Macros and special forms are normally indented one space past the parent bracket,
 but can also have "special" arguments that are indented like function arguments.
 
- + Macros with an ``&rest body`` argument contain an implicit ``do``.
+ + Macros with an ``#* body`` argument contain an implicit ``do``.
  + The body is never special, but the arguments before it are.
 
 .. code-block:: clj
@@ -955,7 +955,7 @@ like ``foo-bar``, not ``foo_bar``.
       (defn __init__ [self] ...))
 
     ;; OK, but would be module private. (No import *)
-    (def ->dict [&rest pairs]
+    (def ->dict [#* pairs]
       (dict (partition pairs)))
 
 Thanks

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -221,7 +221,7 @@ Special symbols in the parameter list of ``defn`` or ``fn`` allow you to
 indicate optional arguments, provide default values, and collect unlisted
 arguments::
 
-    (defn test [a b &optional c [d "x"] &rest e]
+    (defn test [a b [c None] [d "x"] #* e]
       [a b c d e])
     (print (test 1 2))            ; => [1, 2, None, 'x', ()]
     (print (test 1 2 3 4 5 6 7))  ; => [1, 2, 3, 4, (5, 6, 7)]

--- a/docs/whyhy.rst
+++ b/docs/whyhy.rst
@@ -34,7 +34,7 @@ for as long as the condition is true, but at least once.
 
 ::
 
-    (defmacro do-while [condition &rest body]
+    (defmacro do-while [condition #* body]
       `(do
         ~body
         (while ~condition

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -108,7 +108,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
 (import [hy.models [HyDict HyExpression HyKeyword HyList HySymbol]])
 (require [hy.contrib.walk [let]])
 
-(defmacro! ifp [o!pred o!expr &rest clauses]
+(defmacro! ifp [o!pred o!expr #* clauses]
   "Takes a binary predicate ``pred``, an expression ``expr``, and a set of
   clauses. Each clause can be of the form ``cond res`` or ``cond :>> res``. For
   each clause, if ``(pred cond expr)`` evaluates to true, returns ``res`` in
@@ -156,7 +156,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
            ~(emit pred expr more)))))
   `~(emit g!pred g!expr clauses))
 
-(defmacro setv+ [&rest pairs]
+(defmacro setv+ [#* pairs]
   "Assignment with destructuring for both mappings and iterables.
 
   Destructuring equivalent of ``setv``. Binds symbols found in a pattern
@@ -174,7 +174,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
               sym))
     (del ~@gsyms)))
 
-(defmacro dict=: [&rest pairs]
+(defmacro dict=: [#* pairs]
   "Destructure into dict
 
   Same as ``setv+``, except returns a dictionary with symbols to be defined,
@@ -190,7 +190,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
      (del ~@gsyms)
      ~result))
 
-(defn destructure [binds expr &optional gsyms]
+(defn destructure [binds expr [gsyms None]]
   "
   Destructuring bind.
 
@@ -267,7 +267,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
                  (destructure #* (expand-lookup target lookup) gsyms))))
        ((fn [xs] (reduce + xs result)))))
 
-(defn find-magics [bs &optional [keys? False] [as? False]]
+(defn find-magics [bs [keys? False] [as? False]]
   (setv x (first bs)
         y (second bs))
   (if (none? x)
@@ -348,47 +348,47 @@ Iterator patterns are specified using round brackets. They are the same as list 
                                 s [(HyKeyword k) v]
                             s)))))
 
-(defmacro/g! defn+ [fn-name args &rest doc+body]
+(defmacro/g! defn+ [fn-name args #* doc+body]
   "Define function `fn-name` with destructuring within `args`.
 
-  Note that `&rest`, `&optional` etc have no special meaning and are
+  Note that `#*` etc have no special meaning and are
   intepretted as any other argument.
   "
   (setv [doc body] (if (string? (first doc+body))
                      [(first doc+body) (rest doc+body)]
                      [None doc+body]))
-  `(defn ~fn-name [&rest ~g!args &kwargs ~g!kwargs]
+  `(defn ~fn-name [#* ~g!args #** ~g!kwargs]
      ~doc
      ~(-expanded-setv args g!args g!kwargs)
      ~@body))
 
-(defmacro/g! fn+ [args &rest body]
+(defmacro/g! fn+ [args #* body]
   "Return anonymous function with destructuring within `args`
 
-  Note that `&rest`, `&optional` etc have no special meaning and are
+  Note that `*`, `/`, etc have no special meaning and are
   intepretted as any other argument.
   "
-  `(fn [&rest ~g!args &kwargs ~g!kwargs]
+  `(fn [#* ~g!args #** ~g!kwargs]
      ~(-expanded-setv args g!args g!kwargs)
      ~@body))
 
-(defmacro/g! defn/a+ [fn-name args &rest doc+body]
+(defmacro/g! defn/a+ [fn-name args #* doc+body]
   "Async variant of ``defn+``."
   (setv [doc body] (if (string? (first doc+body))
                      [(first doc+body) (rest doc+body)]
                      [None doc+body]))
-  `(defn/a ~fn-name [&rest ~g!args &kwargs ~g!kwargs]
+  `(defn/a ~fn-name [#* ~g!args #** ~g!kwargs]
      ~doc
      ~(-expanded-setv args g!args g!kwargs)
      ~@body))
 
-(defmacro/g! fn/a+ [args &rest body]
+(defmacro/g! fn/a+ [args #* body]
   "Async variant of ``fn+``."
-  `(fn/a [&rest ~g!args &kwargs ~g!kwargs]
+  `(fn/a [#* ~g!args #** ~g!kwargs]
      ~(-expanded-setv args g!args g!kwargs)
      ~@body))
 
-(defmacro let+ [args &rest body]
+(defmacro let+ [args #* body]
   "let macro with full destructuring with `args`"
   (if (odd? (len args))
     (macro-error args "let bindings must be paired"))

--- a/hy/contrib/hy_repr.hy
+++ b/hy/contrib/hy_repr.hy
@@ -27,7 +27,7 @@ To make the Hy REPL use it for output, invoke Hy like so::
     (setv [dict-keys dict-values dict-items] [C C C])))
 
 (setv -registry {})
-(defn hy-repr-register [types f &optional placeholder]
+(defn hy-repr-register [types f [placeholder None]]
   "``hy-repr-register`` lets you set the function that ``hy-repr`` calls to
   represent a type.
 

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -48,7 +48,7 @@ tail-call optimization (TCO) in their Hy code.
   (setv active [False])
   (setv accumulated [])
 
-  (fn [&rest args]
+  (fn [#* args]
     (.append accumulated args)
     (when (not (first active))
       (assoc active 0 True)
@@ -58,7 +58,7 @@ tail-call optimization (TCO) in their Hy code.
       result)))
 
 
-(defmacro/g! fnr [signature &rest body]
+(defmacro/g! fnr [signature #* body]
   (setv new-body (prewalk
     (fn [x] (if (and (symbol? x) (= x "recur")) g!recur-fn x))
     body))
@@ -70,14 +70,14 @@ tail-call optimization (TCO) in their Hy code.
     ~g!recur-fn))
 
 
-(defmacro defnr [name lambda-list &rest body]
+(defmacro defnr [name lambda-list #* body]
   (if (not (= (type name) HySymbol))
     (macro-error name "defnr takes a name as first argument"))
   `(do (require hy.contrib.loop)
        (setv ~name (hy.contrib.loop.fnr ~lambda-list ~@body))))
 
 
-(defmacro/g! loop [bindings &rest body]
+(defmacro/g! loop [bindings #* body]
   "``loop`` establishes a recursion point. With ``loop``, ``recur``
   rebinds the variables set in the recursion point and sends code
   execution back to that recursion point. If ``recur`` is used in a
@@ -85,7 +85,7 @@ tail-call optimization (TCO) in their Hy code.
   causes chaos. Fixing this to detect if recur is in a tail-call position
   and erroring if not is a giant TODO.
 
-  Usage: ``(loop bindings &rest body)``
+  Usage: ``(loop bindings #* body)``
 
   Examples:
     ::

--- a/hy/contrib/pprint.hy
+++ b/hy/contrib/pprint.hy
@@ -43,7 +43,7 @@ The differences that do exist are as follows:
       object context maxlevels level))
   (import [pprint [-safe-repr :as -safe-py-repr]]))
 
-(defn pprint [object &rest args &kwargs kwargs]
+(defn pprint [object #* args #** kwargs]
   "Pretty-print a Python object to a stream [default is sys.stdout].
 
   Examples:
@@ -61,14 +61,11 @@ The differences that do exist are as follows:
   "
   (.pprint (PrettyPrinter #* args #** kwargs) object))
 
-(defn pformat [object &rest args &kwargs kwargs]
+(defn pformat [object #* args #** kwargs]
   "Format a Python object into a pretty-printed representation."
   (.pformat (PrettyPrinter #* args #** kwargs) object))
 
-(defn pp [object
-          &optional [sort-dicts False]
-          &rest args
-          &kwargs kwargs]
+(defn pp [object [sort-dicts False] #* args #** kwargs]
   "Pretty-print a Python object"
   (pprint object #* args :sort-dicts sort-dicts #** kwargs))
 
@@ -84,8 +81,7 @@ The differences that do exist are as follows:
   "Determine if object requires a recursive representation."
   (get (-safe-repr object {} None 0 True) 2))
 
-(defn -safe-repr [object context maxlevels level
-                  &optional [sort-dicts True]]
+(defn -safe-repr [object context maxlevels level [sort-dicts True]]
   (setv typ (type object)
         r (getattr typ "__repr__" None))
 
@@ -194,9 +190,8 @@ The differences that do exist are as follows:
        output stream available at construction will be used.
      compact: If true, several items will be combined in one line.
      sort-dicts: If True, dict keys are sorted. (only available for python >= 3.8)"
-  (defn --init-- [self
-                  &optional [indent 1] [width 80] depth stream
-                  &kwonly [compact False] [sort-dicts True]]
+  (defn --init-- [self [indent 1] [width 80] [depth None] [stream None]
+                  * [compact False] [sort-dicts True]]
     (when (and (not PY3_8) (not sort-dicts))
         (raise (ValueError "sort-dicts is not available for python versions < 3.8")))
     (setv self.-sort-dicts True)

--- a/hy/contrib/profile.hy
+++ b/hy/contrib/profile.hy
@@ -9,7 +9,7 @@
 These macros make debugging where bottlenecks exist easier."
 
 
-(defmacro profile/calls [&rest body]
+(defmacro profile/calls [#* body]
   "``profile/calls`` allows you to create a call graph visualization.
   **Note:** You must have `Graphviz <http://www.graphviz.org/>`_
   installed for this to work.
@@ -28,7 +28,7 @@ These macros make debugging where bottlenecks exist easier."
 
 
 ;; TODO not showing up
-(defmacro/g! profile/cpu [&rest body]
+(defmacro/g! profile/cpu [#* body]
   "Profile a bit of code
 
   Examples:

--- a/hy/contrib/sequences.hy
+++ b/hy/contrib/sequences.hy
@@ -101,7 +101,7 @@ This results in the sequence ``[0 1 1 2 3 5 8 13 21 34 ...]``.
      "string representation of this sequence"
      (.--str-- self)))
 
-(defmacro seq [param &rest seq-code]
+(defmacro seq [param #* seq-code]
   "Creates a sequence defined in terms of ``n``.
 
   Examples:
@@ -109,7 +109,7 @@ This results in the sequence ``[0 1 1 2 3 5 8 13 21 34 ...]``.
   "
   `(Sequence (fn ~param (do ~@seq-code))))
 
-(defmacro defseq [seq-name param &rest seq-code]
+(defmacro defseq [seq-name param #* seq-code]
   "Creates a sequence defined in terms of ``n`` and assigns it to a given name.
 
   Examples:

--- a/hy/contrib/slicing.hy
+++ b/hy/contrib/slicing.hy
@@ -49,7 +49,7 @@ or more manually using the tag macro as::
 
       sym)))
 
-(defmacro ncut [seq key1 &rest keys]
+(defmacro ncut [seq key1 #* keys]
   "N-Dimensional ``cut`` macro with shorthand slice notation.
 
   Libraries like ``numpy`` and ``pandas`` extend Python's sequence

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -208,7 +208,7 @@
   (and (instance? HyExpression form)
        form))
 
-(defn macroexpand-all [form &optional module-name]
+(defn macroexpand-all [form [module-name None]]
   "Recursively performs all possible macroexpansions in form, using the ``require`` context of ``module-name``.
   `macroexpand-all` assumes the calling module's context if unspecified.
   "
@@ -222,7 +222,7 @@
   (defn expand [form]
     (nonlocal quote-level)
     ;; manages quote levels
-    (defn +quote [&optional [x 1]]
+    (defn +quote [[x 1]]
       (nonlocal quote-level)
       (setv head (first form))
       (+= quote-level x)
@@ -283,7 +283,6 @@
 
 
 (defn symbolexpand [form expander
-                    &optional
                     [protected (frozenset)]
                     [quote-level 0]]
   (.expand (SymbolExpander form expander protected quote-level)))
@@ -296,14 +295,14 @@
           self.protected protected
           self.quote-level quote-level))
 
-  (defn expand-symbols [self form &optional protected quote-level]
+  (defn expand-symbols [self form [protected None] [quote-level None]]
     (if (none? protected)
         (setv protected self.protected))
     (if (none? quote-level)
         (setv quote-level self.quote-level))
     (symbolexpand form self.expander protected quote-level))
 
-  (defn traverse [self form &optional protected quote-level]
+  (defn traverse [self form [protected None] [quote-level None]]
     (if (none? protected)
         (setv protected self.protected))
     (if (none? quote-level)
@@ -316,7 +315,7 @@
           form))
 
   ;; manages quote levels
-  (defn +quote [self &optional [x 1]]
+  (defn +quote [self [x 1]]
     `(~(self.head) ~@(self.traverse (self.tail)
                                     :quote-level (+ self.quote-level x))))
 
@@ -449,7 +448,7 @@
         ;; recursive base case--it's an atom. Put it back.
         (self.handle-base))))
 
-(defmacro smacrolet [bindings &rest body]
+(defmacro smacrolet [bindings #* body]
   "symbol macro let.
 
   Replaces symbols in body, but only where it would be a valid let binding.
@@ -468,7 +467,7 @@
                 (fn [symbol]
                   (.get bindings symbol symbol))))
 
-(defmacro let [bindings &rest body]
+(defmacro let [bindings #* body]
   "sets up lexical bindings in its body
 
   ``let`` creates lexically-scoped names for local variables.

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -9,7 +9,7 @@
 (eval-and-compile
   (import hy)
   ((hy.macros.macro "defmacro")
-   (fn [&name macro-name lambda-list &rest body]
+   (fn [&name macro-name lambda-list #* body]
      #[[the defmacro macro
      ``defmacro`` is used to define macros. The general format is
      ``(defmacro name [parameters] expr)``.
@@ -69,7 +69,7 @@
          (fn ~(+ `[&name] lambda-list)
            ~@body))))))
 
-(defmacro if [&rest args]
+(defmacro if [#* args]
   "Conditionally evaluate alternating test and then expressions.
 
   ``if / if*`` respect Python *truthiness*, that is, a *test* fails if it
@@ -110,10 +110,10 @@
                   ~(get args 1)
                   (if ~@(cut args 2))))))
 
-(defmacro macro-error [expression reason &optional [filename '--name--]]
+(defmacro macro-error [expression reason [filename '--name--]]
   `(raise (hy.errors.HyMacroExpansionError ~reason ~filename ~expression None)))
 
-(defmacro defn [name &rest args]
+(defmacro defn [name #* args]
   "Define `name` as a function with `args` as the signature, annotations, and body.
 
   ``defn`` is used to define functions. It requires two arguments: a name (given
@@ -278,7 +278,7 @@
     (macro-error name "defn takes a name as first argument"))
   `(setv ~name (fn* ~@args)))
 
-(defmacro defn/a [name lambda-list &rest body]
+(defmacro defn/a [name lambda-list #* body]
   "Define `name` as a function with `lambda-list` signature and body `body`.
 
   ``defn/a`` macro is a variant of ``defn`` that instead defines

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -56,10 +56,11 @@
        (raise (hy.errors.HyTypeError
          "periods are not allowed in macro names"
          None --file-- None)))
-     (for [kw '[&kwonly &kwargs]]
-       (if* (in kw lambda-list)
-            (raise (hy.errors.HyTypeError (% "macros cannot use %s"
-                                             kw)
+     (for [arg lambda-list]
+       (if* (or (= arg '*)
+                (and (isinstance arg HyExpression)
+                     (= (get arg 0) 'unpack-mapping)))
+            (raise (hy.errors.HyTypeError "macros cannot use '*', or '#**'"
                                           macro-name --file-- None))))
      ;; this looks familiar...
      `(eval-and-compile

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -70,7 +70,7 @@
   "
   (and (iterable? coll) (not (string? coll))))
 
-(defn comp [&rest fs]
+(defn comp [#* fs]
   "Return the function from composing the given functions `fs`.
 
   Compose zero or more functions into a new function. The new function will
@@ -95,7 +95,7 @@
       (do (setv rfs (reversed fs)
                 first-f (next rfs)
                 fs (tuple rfs))
-          (fn [&rest args &kwargs kwargs]
+          (fn [#* args #** kwargs]
             (setv res (first-f #* args #** kwargs))
             (for [f fs]
               (setv res (f res)))
@@ -125,7 +125,7 @@
 
        => (inverse False)
        True"
-  (fn [&rest args &kwargs kwargs]
+  (fn [#* args #** kwargs]
     (not (f #* args #** kwargs))))
 
 (defn constantly [value]
@@ -153,7 +153,7 @@
         => (answer 1 :foo 2)
         42
   "
-  (fn [&rest args &kwargs kwargs]
+  (fn [#* args #** kwargs]
     value))
 
 (defn keyword? [k]
@@ -201,7 +201,7 @@
   "
   (- n 1))
 
-(defn disassemble [tree &optional [codegen False]]
+(defn disassemble [tree [codegen False]]
   "Return the python AST for a quoted Hy `tree` as a string.
 
   If the second argument `codegen` is true, generate python code instead.
@@ -526,7 +526,7 @@
 (setv _gensym_counter 0)
 (setv _gensym_lock (Lock))
 
-(defn gensym [&optional [g "G"]]
+(defn gensym [[g "G"]]
   "Generate a unique symbol for use in macros without accidental name clashes.
 
   .. versionadded:: 0.9.12
@@ -556,7 +556,7 @@
        (finally (.release _gensym_lock)))
   new_symbol)
 
-(defn calling-module-name [&optional [n 1]]
+(defn calling-module-name [[n 1]]
   "Get the name of the module calling `n` levels up the stack from the
   `calling-module-name` function call (by default, one level up)"
   (import inspect)
@@ -682,7 +682,7 @@
     (except [ValueError] False)
     (except [TypeError] False)))
 
-(defn interleave [&rest seqs]
+(defn interleave [#* seqs]
   "Return an iterable of the first item in each of `seqs`, then the second etc.
 
   .. versionadded:: 0.10.1
@@ -810,7 +810,7 @@
   "
   (isinstance x cabc.Iterator))
 
-(defn juxt [f &rest fs]
+(defn juxt [f #* fs]
   "Return a function applying each `fs` to args, collecting results in a list.
 
   .. versionadded:: 0.12.0
@@ -835,7 +835,7 @@
        [27, 21, 72, 8.0]
   "
   (setv fs (+ (, f) fs))
-  (fn [&rest args &kwargs kwargs]
+  (fn [#* args #** kwargs]
     (lfor f fs (f #* args #** kwargs))))
 
 (defn last [coll]
@@ -909,7 +909,7 @@
   (setv module (calling-module))
   (hy.macros.macroexpand-1 form module (HyASTCompiler module)))
 
-(defn merge-with [f &rest maps]
+(defn merge-with [f #* maps]
   "Return the map of `maps` joined onto the first via the function `f`.
 
   .. versionadded:: 0.10.1
@@ -1011,7 +1011,7 @@
   (import numbers)
   (instance? numbers.Number x))
 
-(defn nth [coll n &optional [default None]]
+(defn nth [coll n [default None]]
   "Return `n`th item in `coll` or `None` (specify `default`) if out of bounds.
 
   Returns the *n*-th item in a collection, counting from 0. Return the
@@ -1079,7 +1079,7 @@
 
 ;; TODO Autodoc can't parse arbitrary object default params
 (setv -sentinel (object))
-(defn partition [coll &optional [n 2] step [fillvalue -sentinel]]
+(defn partition [coll [n 2] [step None] [fillvalue -sentinel]]
   "Usage: ``(partition coll [n] [step] [fillvalue])``
 
   Chunks *coll* into *n*-tuples (pairs by default).
@@ -1361,7 +1361,7 @@
     False
     (or a b)))
 
-(defn parse-args [spec &optional args &kwargs parser-args]
+(defn parse-args [spec [args None] #** parser-args]
   "Return arguments namespace parsed from *args* or ``sys.argv`` with
   :py:meth:`argparse.ArgumentParser.parse_args` according to *spec*.
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -14,7 +14,7 @@
 (require [hy.core.bootstrap [*]])
 
 
-(defmacro as-> [head name &rest rest]
+(defmacro as-> [head name #* rest]
   "Beginning with `head`, expand a sequence of assignments `rest` to `name`.
 
   .. versionadded:: 0.12.0
@@ -98,7 +98,7 @@
      ~name))
 
 
-(defmacro assoc [coll k1 v1 &rest other-kvs]
+(defmacro assoc [coll k1 v1 #* other-kvs]
   "Associate key/index value pair(s) to a collection `coll` like a dict or list.
 
   ``assoc`` is used to associate a key with a value in a dictionary or to set an
@@ -158,7 +158,7 @@
       `(~node [~p1 ~p2] ~(_with node args body)))))
 
 
-(defmacro with [args &rest body]
+(defmacro with [args #* body]
   "Wrap execution of `body` within a context manager given as bracket `args`.
 
   ``with`` is used to wrap the execution of a block within a context manager. The
@@ -195,7 +195,7 @@
   (_with 'with* args body))
 
 
-(defmacro with/a [args &rest body]
+(defmacro with/a [args #* body]
   "Wrap execution of `body` with/ain a context manager given as bracket `args`.
 
   ``with/a`` behaves like ``with``, but is used to wrap the execution of
@@ -223,7 +223,7 @@
     case it returns ``None``."
   (_with 'with/a* args body))
 
-(defmacro cond [&rest branches]
+(defmacro cond [#* branches]
   "Build a nested if clause with each `branch` a [cond result] bracket pair.
 
   Examples:
@@ -269,7 +269,7 @@
         [(first branch) `(do ~@(cut branch 1))])))))
 
 
-(defmacro -> [head &rest args]
+(defmacro -> [head #* args]
   "Thread `head` first through the `rest` of the forms.
 
   ``->`` (or the *threading macro*) is used to avoid nesting of expressions. The
@@ -291,7 +291,7 @@
   ret)
 
 
-(defmacro doto [form &rest expressions]
+(defmacro doto [form #* expressions]
   "Perform possibly mutating `expressions` on `form`, returning resulting obj.
 
   .. versionadded:: 0.10.1
@@ -324,7 +324,7 @@
      ~f))
 
 
-(defmacro ->> [head &rest args]
+(defmacro ->> [head #* args]
   "Thread `head` last through the `rest` of the forms.
 
   ``->>`` (or the *threading tail macro*) is similar to the *threading macro*, but
@@ -346,7 +346,7 @@
   ret)
 
 
-(defmacro of [base &rest args]
+(defmacro of [base #* args]
   "Shorthand for indexing for type annotations.
 
   If only one arguments are given, this expands to just that argument. If two arguments are
@@ -397,7 +397,7 @@
     `(get ~base (, ~@args))))
 
 
-(defmacro if-not [test not-branch &optional yes-branch]
+(defmacro if-not [test not-branch [yes-branch None]]
   "Like `if`, but execute the first branch when the test fails
 
   .. versionadded:: 0.10.0
@@ -417,7 +417,7 @@
   `(if* (not ~test) ~not-branch ~yes-branch))
 
 
-(defmacro lif [&rest args]
+(defmacro lif [#* args]
   "Like `if`, but anything that is not None is considered true.
 
   .. versionadded:: 0.10.0
@@ -456,7 +456,7 @@
                   (lif ~@(cut args 2))))))
 
 
-(defmacro lif-not [test not-branch &optional yes-branch]
+(defmacro lif-not [test not-branch [yes-branch None]]
   "Like `if-not`, but anything that is not None is considered true.
 
   .. versionadded:: 0.11.0
@@ -475,7 +475,7 @@
   `(if* (is ~test None) ~not-branch ~yes-branch))
 
 
-(defmacro when [test &rest body]
+(defmacro when [test #* body]
   "Execute `body` when `test` is true
 
   ``when`` is similar to ``unless``, except it tests when the given conditional is
@@ -491,7 +491,7 @@
   `(if ~test (do ~@body)))
 
 
-(defmacro unless [test &rest body]
+(defmacro unless [test #* body]
   "Execute `body` when `test` is false
 
   The ``unless`` macro is a shorthand for writing an ``if`` statement that checks if
@@ -512,7 +512,7 @@
     ~@body))
 
 
-(defmacro do-n [count-form &rest body]
+(defmacro do-n [count-form #* body]
   "Execute `body` a number of times equal to `count-form` and return
   ``None``. (To collect return values, use :hy:macro:`list-n`
   instead.) Negative values of the count are treated as 0.
@@ -530,7 +530,7 @@
   (_do-n count-form body))
 
 
-(defmacro list-n [count-form &rest body]
+(defmacro list-n [count-form #* body]
   "Like :hy:macro:`do-n`, but the results are collected into a list.
 
   ::
@@ -546,7 +546,7 @@
     ~l))
 
 
-(defmacro with-gensyms [args &rest body]
+(defmacro with-gensyms [args #* body]
   "Execute `body` with `args` as bracket of names to gensym for use in macros.
 
   .. versionadded:: 0.9.12
@@ -580,7 +580,7 @@
     ~@body))
 
 
-(defmacro defmacro/g! [name args &rest body]
+(defmacro defmacro/g! [name args #* body]
   "Like `defmacro`, but symbols prefixed with 'g!' are gensymed.
 
   .. versionadded:: 0.9.12
@@ -617,7 +617,7 @@
      ~@body))
 
 
-(defmacro defmacro! [name args &rest body]
+(defmacro defmacro! [name args #* body]
   "Like `defmacro/g!`, with automatic once-only evaluation for 'o!' params.
 
   Such 'o!' params are available within `body` as the equivalent 'g!' symbol.
@@ -666,7 +666,7 @@
           ~@~body)))
 
 
-(defmacro defmain [args &rest body]
+(defmacro defmain [args #* body]
   "Write a function named \"main\" and do the 'if __main__' dance.
 
   .. versionadded:: 0.10.1
@@ -678,7 +678,7 @@
   Examples:
     ::
 
-       => (defmain [&rest args]
+       => (defmain [#* args]
        ...  (do-something-with args))
 
     is the equivalent of:
@@ -707,7 +707,7 @@
     module ``argparse`` in the usual way::
 
        => (import argparse)
-       => (defmain [&rest _]
+       => (defmain [#* _]
        ...   (setv parser (argparse.ArgumentParser))
        ...   (.add-argument parser \"STRING\"
        ...     :help \"string to replicate\")
@@ -721,7 +721,7 @@
         restval (gensym))
   `(when (= --name-- "__main__")
      (import sys)
-     (setv ~retval ((fn [~@(or args `[&rest ~restval])] ~@body) #* sys.argv))
+     (setv ~retval ((fn [~@(or args `[#* ~restval])] ~@body) #* sys.argv))
      (if (integer? ~retval)
        (sys.exit ~retval))))
 
@@ -735,7 +735,7 @@
   `(with-decorator ~@decorators ~fndef))
 
 
-(defmacro comment [&rest body]
+(defmacro comment [#* body]
   "Ignores body and always expands to None
 
   The ``comment`` macro ignores its body and always expands to ``None``.
@@ -774,7 +774,7 @@
   `(help (.get __macros__ (mangle '~symbol) None)))
 
 
-(defmacro cfor [f &rest generator]
+(defmacro cfor [f #* generator]
   #[[syntactic sugar for passing a ``generator`` expression to the callable ``f``
 
   Its syntax is the same as :ref:`generator expression <py:genexpr>`, but takes

--- a/hy/core/shadow.hy
+++ b/hy/core/shadow.hy
@@ -10,7 +10,7 @@
 
 (import [functools [reduce]])
 
-(defn + [&rest args]
+(defn + [#* args]
   "Shadowed `+` operator adds `args`."
   (if
     (= (len args) 0)
@@ -20,13 +20,13 @@
     ; else
       (reduce operator.add args)))
 
-(defn - [a1 &rest a-rest]
+(defn - [a1 #* a-rest]
   "Shadowed `-` operator subtracts each `a-rest` from `a1`."
   (if a-rest
     (reduce operator.sub a-rest a1)
     (- a1)))
 
-(defn * [&rest args]
+(defn * [#* args]
   "Shadowed `*` operator multiplies `args`."
   (if
     (= (len args) 0)
@@ -36,7 +36,7 @@
     ; else
       (reduce operator.mul args)))
 
-(defn ** [a1 a2 &rest a-rest]
+(defn ** [a1 a2 #* a-rest]
   "Shadowed `**` operator takes `a1` to the power of `a2`, ..., `a-rest`."
   ; We use `-foldr` instead of `reduce` because exponentiation
   ; is right-associative.
@@ -44,13 +44,13 @@
 (defn -foldr [f xs]
   (reduce (fn [x y] (f y x)) (cut xs None None -1)))
 
-(defn / [a1 &rest a-rest]
+(defn / [a1 #* a-rest]
   "Shadowed `/` operator divides `a1` by each `a-rest`."
   (if a-rest
     (reduce operator.truediv a-rest a1)
     (/ 1 a1)))
 
-(defn // [a1 a2 &rest a-rest]
+(defn // [a1 a2 #* a-rest]
   "Shadowed `//` operator floor divides `a1` by `a2`, ..., `a-rest`."
   (reduce operator.floordiv (+ (, a2) a-rest) a1))
 
@@ -58,25 +58,25 @@
   "Shadowed `%` operator takes `x` modulo `y`."
   (% x y))
 
-(defn @ [a1 &rest a-rest]
+(defn @ [a1 #* a-rest]
   "Shadowed `@` operator matrix multiples `a1` by each `a-rest`."
   (reduce operator.matmul a-rest a1))
 
-(defn << [a1 a2 &rest a-rest]
+(defn << [a1 a2 #* a-rest]
   "Shadowed `<<` operator performs left-shift on `a1` by `a2`, ..., `a-rest`."
   (reduce operator.lshift (+ (, a2) a-rest) a1))
 
-(defn >> [a1 a2 &rest a-rest]
+(defn >> [a1 a2 #* a-rest]
   "Shadowed `>>` operator performs right-shift on `a1` by `a2`, ..., `a-rest`."
   (reduce operator.rshift (+ (, a2) a-rest) a1))
 
-(defn & [a1 &rest a-rest]
+(defn & [a1 #* a-rest]
   "Shadowed `&` operator performs bitwise-and on `a1` by each `a-rest`."
   (if a-rest
     (reduce operator.and_ a-rest a1)
     a1))
 
-(defn | [&rest args]
+(defn | [#* args]
   "Shadowed `|` operator performs bitwise-or on `a1` by each `a-rest`."
   (if
     (= (len args) 0)
@@ -99,38 +99,38 @@
   (if a-rest
     (and #* (gfor (, x y) (zip (+ (, a1) a-rest) a-rest) (op x y)))
     True))
-(defn < [a1 &rest a-rest]
+(defn < [a1 #* a-rest]
   "Shadowed `<` operator perform lt comparison on `a1` by each `a-rest`."
   (comp-op operator.lt a1 a-rest))
-(defn <= [a1 &rest a-rest]
+(defn <= [a1 #* a-rest]
   "Shadowed `<=` operator perform le comparison on `a1` by each `a-rest`."
   (comp-op operator.le a1 a-rest))
-(defn = [a1 &rest a-rest]
+(defn = [a1 #* a-rest]
   "Shadowed `=` operator perform eq comparison on `a1` by each `a-rest`."
   (comp-op operator.eq a1 a-rest))
-(defn is [a1 &rest a-rest]
+(defn is [a1 #* a-rest]
   "Shadowed `is` keyword perform is on `a1` by each `a-rest`."
   (comp-op operator.is_ a1 a-rest))
-(defn != [a1 a2 &rest a-rest]
+(defn != [a1 a2 #* a-rest]
   "Shadowed `!=` operator perform neq comparison on `a1` by `a2`, ..., `a-rest`."
   (comp-op operator.ne a1 (+ (, a2) a-rest)))
-(defn is-not [a1 a2 &rest a-rest]
+(defn is-not [a1 a2 #* a-rest]
   "Shadowed `is-not` keyword perform is-not on `a1` by `a2`, ..., `a-rest`."
   (comp-op operator.is-not a1 (+ (, a2) a-rest)))
-(defn in [a1 a2 &rest a-rest]
+(defn in [a1 a2 #* a-rest]
   "Shadowed `in` keyword perform `a1` in `a2` in …."
   (comp-op (fn [x y] (in x y)) a1 (+ (, a2) a-rest)))
-(defn not-in [a1 a2 &rest a-rest]
+(defn not-in [a1 a2 #* a-rest]
   "Shadowed `not in` keyword perform `a1` not in `a2` not in…."
   (comp-op (fn [x y] (not-in x y)) a1 (+ (, a2) a-rest)))
-(defn >= [a1 &rest a-rest]
+(defn >= [a1 #* a-rest]
   "Shadowed `>=` operator perform ge comparison on `a1` by each `a-rest`."
   (comp-op operator.ge a1 a-rest))
-(defn > [a1 &rest a-rest]
+(defn > [a1 #* a-rest]
   "Shadowed `>` operator perform gt comparison on `a1` by each `a-rest`."
   (comp-op operator.gt a1 a-rest))
 
-(defn and [&rest args]
+(defn and [#* args]
   "Shadowed `and` keyword perform and on `args`.
 
   ``and`` is used in logical expressions. It takes at least two parameters.
@@ -176,7 +176,7 @@
     ; else
       (reduce (fn [x y] (and x y)) args)))
 
-(defn or [&rest args]
+(defn or [#* args]
   "Shadowed `or` keyword perform or on `args`.
 
   ``or`` is used in logical expressions. It takes at least two parameters. It
@@ -240,7 +240,7 @@
   "
   (not x))
 
-(defn get [coll key1 &rest keys]
+(defn get [coll key1 #* keys]
   "Access item in `coll` indexed by `key1`, with optional `keys` nested-access.
 
   ``get`` is used to access single elements in collections. ``get`` takes at

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -27,7 +27,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
 ;;; Macro to help write anaphoric macros
 
-(defmacro rit [&rest body]
+(defmacro rit [#* body]
   "Supply `it` as a gensym and R as a function to replace `it` with the
   given gensym throughout expressions."
   `(do
@@ -40,7 +40,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
 ;;; These macros make writing functional programs more concise
 
-(defmacro ap-if [test-form then-form &optional else-form]
+(defmacro ap-if [test-form then-form [else-form None]]
   "As :ref:`if <if>`, but the result of the test form is named ``it`` in
   the subsequent forms. As with ``if``, the else-clause is optional.
 
@@ -56,7 +56,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
      (if ~it ~(R then-form) ~(R else-form)))))
 
 
-(defmacro ap-each [xs &rest body]
+(defmacro ap-each [xs #* body]
   "Evaluate the body forms for each element ``it`` of ``xs`` and return ``None``.
 
   Examples:
@@ -69,7 +69,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
   (rit `(for [~it ~xs] ~@(R body))))
 
 
-(defmacro ap-each-while [xs form &rest body]
+(defmacro ap-each-while [xs form #* body]
   "As ``ap-each``, but the form ``pred`` is run before the body forms on
   each iteration, and the loop ends if ``pred`` is false.
 
@@ -139,7 +139,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
   (rit `(gfor  ~it ~xs  :if (not ~(R form))  ~it)))
 
 
-(defmacro ap-dotimes [n &rest body]
+(defmacro ap-dotimes [n #* body]
   "Equivalent to ``(ap-each (range n) body…)``.
 
   Examples:
@@ -188,7 +188,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
     ~x)))
 
 
-(defmacro! ap-reduce [form o!xs &optional [initial-value None]]
+(defmacro! ap-reduce [form o!xs [initial-value None]]
   "This macro is an anaphoric version of :py:func:`reduce`. It works as
   follows:
 
@@ -229,7 +229,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
   A ``%i`` symbol designates the (1-based) *i* th parameter (such as ``%3``).
   Only the maximum ``%i`` determines the number of ``%i`` parameters--the
   others need not appear in the expression.
-  ``%*`` and ``%**`` name the ``&rest`` and ``&kwargs`` parameters, respectively.
+  ``%*`` and ``%**`` name the ``#*`` and ``#**`` parameters, respectively.
 
   Examples:
     ::

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -265,12 +265,12 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
                                max
                                inc))
                 (HySymbol (+ "%" (str i))))
-        ;; generate the &rest parameter only if '%* is present in expr
+        ;; generate the #* parameter only if '%* is present in expr
         ~@(if (in '%* %symbols)
-              '(&rest %*))
-        ;; similarly for &kwargs and %**
+              '(#* %*))
+        ;; similarly for #** and %**
         ~@(if (in '%** %symbols)
-              '(&kwargs %**))]
+              '(#** %**))]
      ~expr))
 
 

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -418,8 +418,8 @@ def test_ast_non_decoratable():
 
 def test_ast_lambda_lists():
     """Ensure the compiler chokes on invalid lambda-lists"""
-    cant_compile('(fn [&optional [a b c]] a)')
-    cant_compile('(fn [&optional [1 2]] (list 1 2))')
+    cant_compile('(fn [[a b c]] a)')
+    cant_compile('(fn [[1 2]] (list 1 2))')
 
 
 def test_ast_print():
@@ -436,20 +436,20 @@ def test_ast_tuple():
 
 def test_lambda_list_keywords_rest():
     """ Ensure we can compile functions with lambda list keywords."""
-    can_compile("(fn [x &rest xs] (print xs))")
-    cant_compile("(fn [x &rest xs &rest ys] (print xs))")
-    can_compile("(fn [&optional a &rest xs] (print xs))")
+    can_compile("(fn [x #* xs] (print xs))")
+    cant_compile("(fn [x #* xs #* ys] (print xs))")
+    can_compile("(fn [[a None] #* xs] (print xs))")
 
 
 def test_lambda_list_keywords_kwargs():
-    """ Ensure we can compile functions with &kwargs."""
-    can_compile("(fn [x &kwargs kw] (list x kw))")
-    cant_compile("(fn [x &kwargs xs &kwargs ys] (list x xs ys))")
-    can_compile("(fn [&optional x &kwargs kw] (list x kw))")
+    """ Ensure we can compile functions with #** kwargs."""
+    can_compile("(fn [x #** kw] (list x kw))")
+    cant_compile("(fn [x #** xs #** ys] (list x xs ys))")
+    can_compile("(fn [[x None] #** kw] (list x kw))")
 
 
 def test_lambda_list_keywords_kwonly():
-    kwonly_demo = "(fn [&kwonly a [b 2]] (print 1) (print a b))"
+    kwonly_demo = "(fn [* a [b 2]] (print 1) (print a b))"
     code = can_compile(kwonly_demo)
     for i, kwonlyarg_name in enumerate(('a', 'b')):
         assert kwonlyarg_name == code.body[0].args.kwonlyargs[i].arg
@@ -459,9 +459,9 @@ def test_lambda_list_keywords_kwonly():
 
 def test_lambda_list_keywords_mixed():
     """ Ensure we can mix them up."""
-    can_compile("(fn [x &rest xs &kwargs kw] (list x xs kw))")
-    cant_compile("(fn [x &rest xs &fasfkey {bar \"baz\"}])")
-    can_compile("(fn [x &rest xs &kwonly kwoxs &kwargs kwxs]"
+    can_compile("(fn [x #* xs #** kw] (list x xs kw))")
+    cant_compile("(fn [x #* xs &fasfkey {bar \"baz\"}])")
+    can_compile("(fn [x #* xs kwoxs #** kwxs]"
                 "  (list x xs kwxs kwoxs))")
 
 

--- a/tests/native_tests/contrib/destructure.hy
+++ b/tests/native_tests/contrib/destructure.hy
@@ -263,4 +263,3 @@
           "options" "xyzq"}]
     (assert (= [a b c d style colour options]
                [1 2 3 4 "pretty" "purple" "xyzq"]))))
-

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -89,26 +89,26 @@
 
 (defn test-smacrolet []
   (setv form '(do
-                (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                (setv foo (fn [a [b 1]] (* b (inc a))))
                 (* b (foo 7)))
         form1 (macroexpand
                 '(smacrolet [b c]
-                   (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                   (setv foo (fn [a [b 1]] (* b (inc a))))
                    (* b (foo 7))))
         form2 (macroexpand
                 '(smacrolet [a c]
-                   (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                   (setv foo (fn [a [b 1]] (* b (inc a))))
                    (* b (foo 7))))
         form3 (macroexpand
                 '(smacrolet [foo bar]
-                   (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                   (setv foo (fn [a [b 1]] (* b (inc a))))
                    (* b (foo 7)))))
   (assert (= form1 '(do
-                      (setv foo (fn [a &optional [b 1]] (* b (inc a))))
+                      (setv foo (fn [a [b 1]] (* b (inc a))))
                       (* c (foo 7)))))
   (assert (= form2 form))
   (assert (= form3 '(do
-                      (setv bar (fn [a &optional [b 1]] (* b (inc a))))
+                      (setv bar (fn [a [b 1]] (* b (inc a))))
                       (* b (bar 7))))))
 
 (defn test-let-basic []
@@ -334,7 +334,7 @@
         a 88
         c 64
         &rest 12]
-    (defn foo [a b &rest xs]
+    (defn foo [a b #* xs]
       (-= a 1)
       (setv xs (list xs))
       (.append xs 42)
@@ -350,7 +350,7 @@
 (defn test-let-kwargs []
   (let [kws 6
         &kwargs 13]
-    (defn foo [&kwargs kws]
+    (defn foo [#** kws]
       (, &kwargs kws))
     (assert (= kws 6))
     (assert (= (foo :a 1)
@@ -360,7 +360,7 @@
   (let [a 1
         b 6
         d 2]
-    (defn foo [&optional [a a] b [c d]]
+    (defn foo [[a a] [b None] [c d]]
       (, a b c))
     (assert (= (foo)
                (, 1 None 2)))
@@ -369,7 +369,7 @@
 
 (defn test-let-closure []
   (let [count 0]
-    (defn +count [&optional [x 1]]
+    (defn +count [[x 1]]
       (+= count x)
       count))
   ;; let bindings can still exist outside of a let body

--- a/tests/native_tests/extra/anaphoric.hy
+++ b/tests/native_tests/extra/anaphoric.hy
@@ -173,7 +173,7 @@
   (assert (= (#%(identity (, %5 %4 %3 %2 %1)) 1 2 3 4 5) (, 5 4 3 2 1)))
   (assert (= (#%(identity (, %1 %2 %3 %4 %5)) 1 2 3 4 5) (, 1 2 3 4 5)))
   (assert (= (#%(identity (, %1 %5 %2 %3 %4)) 1 2 3 4 5) (, 1 5 2 3 4)))
-  ;; test &rest
+  ;; test #*
   (assert (= (#%(sum %*) 1 2 3) 6))
   (assert (= (#%(identity (, %1 %*)) 10 1 2 3) (, 10 (, 1 2 3))))
   ;; no parameters
@@ -190,7 +190,7 @@
   (assert (= (#%(%1 2 4) +) 6))
   (assert (= (#%(%1 2 4) -) -2))
   (assert (= (#%(%1 2 4) /) 0.5))
-  ;; test &rest &kwargs
+  ;; test #* #**
   (assert (= (#%(, %* %**) 1 2 :a 'b)
              (, (, 1 2)
                 (dict :a 'b))))

--- a/tests/native_tests/mangling.hy
+++ b/tests/native_tests/mangling.hy
@@ -126,7 +126,7 @@
   (assert (= (f :foo? 3 :☘ 4 :a 1 :a-b 2) [1 2 3 4]))
   (assert (= (f :is_foo 3 :hyx_XshamrockX 4 :a 1 :a_b 2) [1 2 3 4]))
 
-  (defn g [&kwargs x]
+  (defn g [#** x]
     x)
   (assert (= (g :foo? 3 :☘ 4 :a 1 :a-b 2)
              {"a" 1  "a_b" 2  "is_foo" 3  "hyx_XshamrockX" 4}))

--- a/tests/native_tests/model_patterns.hy
+++ b/tests/native_tests/model_patterns.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(defmacro do-until [&rest args]
+(defmacro do-until [#* args]
   (import
     [hy.model-patterns [whole FORM notpexpr dolike]]
     [funcparserlib.parser [many]])
@@ -26,7 +26,7 @@
     (until (+= n 1) (>= n 3)))
   (assert (= s "xxxx")))
 
-(defmacro loop [&rest args]
+(defmacro loop [#* args]
   (import
     [hy.model-patterns [whole FORM sym SYM]]
     [funcparserlib.parser [many]])

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -5,7 +5,7 @@
 (import pytest
         [hy.errors [HyTypeError HyMacroExpansionError]])
 
-(defmacro rev [&rest body]
+(defmacro rev [#* body]
   "Execute the `body` statements in reverse"
   (quasiquote (do (unquote-splice (list (reversed body))))))
 
@@ -40,7 +40,7 @@
   (defmacro a-list [] [1 2])
   (assert (= (a-list) [1 2]))
 
-  (defmacro a-tuple [&rest b] b)
+  (defmacro a-tuple [#* b] b)
   (assert (= (a-tuple 1 2) [1 2]))
 
   (defmacro a-dict [] {1 2})
@@ -62,17 +62,17 @@
   (foo x y))
 
 (defn test-macro-kw []
-  "NATIVE: test that an error is raised when &kwonly or &kwargs is used in a macro"
+  "NATIVE: test that an error is raised when * or #** is used in a macro"
   (try
-    (eval '(defmacro f [&kwonly a b]))
+    (eval '(defmacro f [* a b]))
     (except [e HyTypeError]
-      (assert (= e.msg "macros cannot use &kwonly")))
+      (assert (= e.msg "macros cannot use '*', or '#**'")))
     (else (assert False)))
 
   (try
-    (eval '(defmacro f [&kwargs kw]))
+    (eval '(defmacro f [#** kw]))
     (except [e HyTypeError]
-      (assert (= e.msg "macros cannot use &kwargs")))
+      (assert (= e.msg "macros cannot use '*', or '#**'")))
     (else (assert False))))
 
 (defn test-macro-bad-name []
@@ -89,9 +89,9 @@
 
 (defn test-optional-and-unpacking-in-macro []
   ; https://github.com/hylang/hy/issues/1154
-  (defn f [&rest args]
+  (defn f [#* args]
     (+ "f:" (repr args)))
-  (defmacro mac [&optional x]
+  (defmacro mac [[x None]]
    `(f #* [~x]))
   (assert (= (mac) "f:(None,)")))
 
@@ -266,8 +266,8 @@
   (setv foo 40)
   (foo! (+= foo 1))
   (assert (= 41 foo))
-  ;; test &optional args
-  (defmacro! bar! [o!a &optional [o!b 1]] `(do ~g!a ~g!a ~g!b ~g!b))
+  ;; test optional args
+  (defmacro! bar! [o!a [o!b 1]] `(do ~g!a ~g!a ~g!b ~g!b))
   ;; test that o!s are evaluated once only
   (bar! (+= foo 1) (+= foo 1))
   (assert (= 43 foo))
@@ -334,7 +334,7 @@
     x)
 
   (try
-    (defmain [&rest args]
+    (defmain [#* args]
       (main 42))
     (assert False)
     (except [e SystemExit]

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(defmacro op-and-shadow-test [op &rest body]
+(defmacro op-and-shadow-test [op #* body]
   ; Creates two tests with the given `body`, one where all occurrences
   ; of the symbol `f` are syntactically replaced with `op` (a test of
   ; the real operator), and one where the body is preceded by an

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -88,7 +88,7 @@
   (assert (= q qq)))
 
 
-(defmacro doodle [&rest body]
+(defmacro doodle [#* body]
   `(do ~@body))
 
 (defn test-unquote-splice []

--- a/tests/native_tests/tag_macros.hy
+++ b/tests/native_tests/tag_macros.hy
@@ -88,12 +88,12 @@
   (defn increment-arguments [func]
     "Increments each argument passed to the decorated function."
     ((wraps func)
-       (fn [&rest args &kwargs kwargs]
+       (fn [#* args #** kwargs]
          (func #* (map inc args)
                #** (dfor [k v] (.items kwargs) [k (inc v)])))))
 
   #@(increment-arguments
-     (defn foo [&rest args &kwargs kwargs]
+     (defn foo [#* args #** kwargs]
        "Bar."
        (, args kwargs)))
 
@@ -108,7 +108,7 @@
   ;; We can use the #@ tag macro to apply more than one decorator
   #@(increment-arguments
      increment-arguments
-     (defn double-foo [&rest args &kwargs kwargs]
+     (defn double-foo [#* args #** kwargs]
        "Bar."
        (, args kwargs)))
 

--- a/tests/resources/bin/main.hy
+++ b/tests/resources/bin/main.hy
@@ -1,4 +1,4 @@
-(defmain [&rest args]
+(defmain [#* args]
   (print (+ "<" (.join "|" (cut args 1)) ">"))
   (print "Hello World")
   (if (in "exit1" args)

--- a/tests/resources/macros.hy
+++ b/tests/resources/macros.hy
@@ -1,12 +1,12 @@
 (setv module-name-var "tests.resources.macros")
 
 (defmacro thread-set-ab []
-  (defn f [&rest args] (.join "" (+ (, "a") args)))
+  (defn f [#* args] (.join "" (+ (, "a") args)))
   (setv variable (HySymbol (-> "b" (f))))
   `(setv ~variable 2))
 
 (defmacro threadtail-set-cd []
-  (defn f [&rest args] (.join "" (+ (, "c") args)))
+  (defn f [#* args] (.join "" (+ (, "c") args)))
   (setv variable (HySymbol (->> "d" (f))))
   `(setv ~variable 5))
 

--- a/tests/resources/pydemo.hy
+++ b/tests/resources/pydemo.hy
@@ -116,7 +116,7 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
   (else
     (setv ran-try-else True)))
 
-(defn fun [a b &optional [c 9] [d 10] &rest args &kwargs kwargs]
+(defn fun [a b [c 9] [d 10] #* args #** kwargs]
   "function docstring"
   [a b c d args (sorted (.items kwargs))])
 (setv funcall1 (fun 1 2 3 4 "a" "b" "c" :k1 "v1" :k2 "v2"))

--- a/tests/resources/tlib.hy
+++ b/tests/resources/tlib.hy
@@ -1,9 +1,9 @@
 (setv SECRET_MESSAGE "Hello World")
 
-(defmacro qplah [&rest tree]
+(defmacro qplah [#* tree]
   `[8 ~@tree])
 
-(defmacro parald [&rest tree]
+(defmacro parald [#* tree]
   `[9 ~@tree])
 
 (defmacro ✈ [arg]


### PR DESCRIPTION
Closes #1411 
This is a quick and dirty implementation of what we were talking about in #1411. I haven't updated any tests, documentation, or core method definitions since I wanna get y'alls opinions on this before jumping into that mammoth task. 

To paraphrase the discussion:

- `/` demarks the end of positional only arguments
- `*` demarks the start of keyword only arguments
- `^ann #* <sym>` collects varargs into `<sym>` and also marks the start keyword only arguments
- `^ann #** <sym>` collects keyword varargs into `<sym>`
- `^ann <sym>` demarks a positional argument
- `^ann [<sym> <default>]` demarks a keyword argument
-  and there is no more shorthand for a keyword defaulting to None

with function definitions looking like this:
```hy
(defn afunc [a ^int b / c [d 1] * ^str e ^int [f 2] g ^str #** kwargs])
```
with the equivalent python looking like
```python
def afunc(a, b: int, /, c, d=1, *, e: str, f: int=2, g, **kwargs: str): pass
```