### PR TITLE
Implement Hy builtins as actual builtins

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -12,6 +12,8 @@ Removals
 * `#doc` has been removed. Instead of `#doc @`, say `(doc "#@")`.
 * `__tags__` has been removed. Tag macros are now tracked in
   `__macros__`.
+* `eval` has been removed from core.
+  Use the fully qualified name `hy.eval` instead.
 
 Breaking Changes
 ------------------------------
@@ -56,6 +58,9 @@ Bug Fixes
 * Fixed compiler crash on `.` form with empty attributes.
 * Attempts to assign to constants are now more reliably detected.
 * Fixed bugs with `require` of names that need mangling.
+* Fixed namespace pollution caused by automatic imports of Hy builtins and macros.
+* Fixed Hy model objects sometimes not being in scope.
+* Fixed `doc` sometimes failing to find builtin macros.
 
 0.20.0 (released 2021-01-25)
 ==============================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,8 @@
 API
 ===
 
+.. hy:autofunction:: hy.eval
+
 .. _special-forms:
 
 Special Forms
@@ -684,7 +686,7 @@ Special Forms
        (print "A result from Python:" (py "'hello' + 'world'"))
 
    The code must be given as a single string literal, but you can still use
-   macros, :hy:func:`eval <hy.core.language.eval>`, and related tools to construct the ``py`` form. If
+   macros, :hy:func:`hy.eval <hy.eval>`, and related tools to construct the ``py`` form. If
    having to backslash-escape internal double quotes is getting you down, try a
    :ref:`bracket string <syntax-bracket-strings>`. If you want to evaluate some
    Python code that's only defined at run-time, try the standard Python function
@@ -741,7 +743,7 @@ Special Forms
        HyExpression([
          HySymbol('print'),
          HyString('Hello World')])
-       => (eval x)
+       => (hy.eval x)
        Hello World
 
 
@@ -1197,8 +1199,6 @@ Core
    :members:
 
 .. hy:autofunction:: hy.core.language.calling-module
-
-.. hy:autofunction:: hy.core.language.eval
 
 .. hy:autofunction:: hy.core.language.mangle
 

--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -94,7 +94,7 @@
           "hy.core.language.calling-module-name",
           "hy.core.language.parse-args",
           "hy.core.language.disassemble",
-          "hy.core.language.eval",
+          "hy.eval",
           "hy.core.language.gensym",
           "hy.core.language.keyword",
           "hy.core.language.macroexpand",

--- a/docs/language/interop.rst
+++ b/docs/language/interop.rst
@@ -121,7 +121,7 @@ two separate steps. First, use the ``read_str`` function (or ``read`` for a
     >>> import hy
     >>> expr = hy.read_str("(- (/ (+ 1 3 88) 2) 8)")
 
-Then, use the ``eval`` function to evaluate it:
+Then, use the ``hy.eval`` function to evaluate it:
 
 .. code-block:: python
 

--- a/docs/whyhy.rst
+++ b/docs/whyhy.rst
@@ -122,7 +122,7 @@ benefit of error messages, and models can represent syntactic features that the
 corresponding primitive type can't, such as the order in which elements appear
 in a set literal. However, models can be concatenated and indexed just like
 plain lists, and you can return ordinary Python types from a macro or give them
-to ``eval`` and Hy will automatically promote them to models.
+to ``hy.eval`` and Hy will automatically promote them to models.
 
 Hy takes much of its semantics from Python. For example, Hy is a Lisp-1 because
 Python functions use the same namespace as objects that aren't functions. In

--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -14,6 +14,7 @@ from hy.models import HyExpression, HyInteger, HyKeyword, HyComplex, HyString, H
 
 
 import hy.importer  # NOQA
+hy.importer._inject_builtins()
 # we import for side-effects.
 
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -18,8 +18,6 @@ from hy.lex import mangle, unmangle, hy_parse, parse_one_thing, LexException
 from hy._compat import (PY3_8, reraise)
 from hy.macros import require, macroexpand
 
-import hy.core
-
 import textwrap
 import pkgutil
 import traceback
@@ -167,15 +165,13 @@ class Result(object):
     The Result object is interoperable with python AST objects: when an AST
     object gets added to a Result object, it gets converted on-the-fly.
     """
-    __slots__ = ("imports", "stmts", "temp_variables",
-                 "_expr", "__used_expr")
+    __slots__ = ("stmts", "temp_variables", "_expr", "__used_expr")
 
     def __init__(self, *args, **kwargs):
         if args:
             # emulate kw-only args for future bits.
             raise TypeError("Yo: Hacker: don't pass me real args, dingus")
 
-        self.imports = defaultdict(set)
         self.stmts = []
         self.temp_variables = []
         self._expr = None
@@ -184,7 +180,7 @@ class Result(object):
 
         # XXX: Make sure we only have AST where we should.
         for kwarg in kwargs:
-            if kwarg not in ["imports", "stmts", "expr", "temp_variables"]:
+            if kwarg not in ["stmts", "expr", "temp_variables"]:
                 raise TypeError(
                     "%s() got an unexpected keyword argument '%s'" % (
                         self.__class__.__name__, kwarg))
@@ -216,13 +212,9 @@ class Result(object):
             return self.stmts[-1].col_offset
         return None
 
-    def add_imports(self, mod, imports):
-        """Autoimport `imports` from `mod`"""
-        self.imports[mod].update(imports)
-
     def is_expr(self):
         """Check whether I am a pure expression"""
-        return self._expr and not (self.imports or self.stmts)
+        return self._expr and not self.stmts
 
     @property
     def force_expr(self):
@@ -295,7 +287,6 @@ class Result(object):
 
         # Fairly obvious addition
         result = Result()
-        result.imports = other.imports
         result.stmts = self.stmts + other.stmts
         result.expr = other.expr
         result.temp_variables = other.temp_variables
@@ -304,9 +295,8 @@ class Result(object):
 
     def __str__(self):
         return (
-            "Result(imports=[%s], stmts=[%s], expr=%s)"
+            "Result(stmts=[%s], expr=%s)"
         % (
-            ", ".join(ast.dump(x) for x in self.imports),
             ", ".join(ast.dump(x) for x in self.stmts),
             ast.dump(self.expr) if self.expr else None
         ))
@@ -360,7 +350,6 @@ class HyASTCompiler(object):
             information for informative error messages and debugging.
         """
         self.anon_var_count = 0
-        self.imports = defaultdict(set)
         self.temp_if = None
 
         if not inspect.ismodule(module):
@@ -377,43 +366,9 @@ class HyASTCompiler(object):
         # compilation.
         self.module.__dict__.setdefault('__macros__', {})
 
-        self.can_use_stdlib = not self.module_name.startswith("hy.core")
-
-        self._stdlib = {}
-
-        # Everything in core needs to be explicit (except for
-        # the core macros, which are built with the core functions).
-        if self.can_use_stdlib:
-            # Load stdlib macros into the module namespace.
-            load_macros(self.module)
-
-            # Populate _stdlib.
-            for stdlib_module in hy.core.STDLIB:
-                mod = importlib.import_module(stdlib_module)
-                for e in map(mangle, getattr(mod, 'EXPORTS', [])):
-                    self._stdlib[e] = stdlib_module
-
     def get_anon_var(self):
         self.anon_var_count += 1
         return "_hy_anon_var_%s" % self.anon_var_count
-
-    def update_imports(self, result):
-        """Retrieve the imports from the result object"""
-        for mod in result.imports:
-            self.imports[mod].update(result.imports[mod])
-
-    def imports_as_stmts(self, expr):
-        """Convert the Result's imports to statements"""
-        ret = Result()
-        for module, names in self.imports.items():
-            if None in names:
-                ret += self.compile(mkexpr('import', module).replace(expr))
-            names = sorted(name for name in names if name)
-            if names:
-                ret += self.compile(mkexpr('import',
-                    mklist(module, mklist(*names))))
-        self.imports = defaultdict(set)
-        return ret.stmts
 
     def compile_atom(self, atom):
         # Compilation methods may mutate the atom, so copy it first.
@@ -425,7 +380,6 @@ class HyASTCompiler(object):
             return Result()
         try:
             ret = self.compile_atom(tree)
-            self.update_imports(ret)
             return ret
         except HyCompileError:
             # compile calls compile, so we're going to have multiple raise
@@ -556,7 +510,7 @@ class HyASTCompiler(object):
         `level` is the level of quasiquoting of the current form. We can
         unquote if level is 0.
 
-        Returns a three-tuple (`imports`, `expression`, `splice`).
+        Returns a two-tuple (`expression`, `splice`).
 
         The `splice` return value is used to mark `unquote-splice`d forms.
         We need to distinguish them as want to concatenate them instead of
@@ -571,22 +525,20 @@ class HyASTCompiler(object):
             if len(form) != 2:
                 raise HyTypeError("`%s' needs 1 argument, got %s" % op, len(form) - 1,
                                   self.filename, form, self.source)
-            return set(), form[1], op == "unquote-splice"
+            return form[1], op == "unquote-splice"
         elif op == "quasiquote":
             level += 1
         elif op in ("unquote", "unquote-splice"):
             level -= 1
 
         hytype = form.__class__
-        imports = set([hytype.__name__])
         name = ".".join((hytype.__module__, hytype.__name__))
         body = [form]
 
         if isinstance(form, HySequence):
             contents = []
             for x in form:
-                f_imps, f_contents, splice = self._render_quoted_form(x, level)
-                imports.update(f_imps)
+                f_contents, splice = self._render_quoted_form(x, level)
                 if splice:
                     contents.append(HyExpression([
                         HySymbol("list"),
@@ -616,14 +568,13 @@ class HyASTCompiler(object):
                 body.extend([HyKeyword("brackets"), form.brackets])
 
         ret = HyExpression([HySymbol(name)] + body).replace(form)
-        return imports, ret, False
+        return ret, False
 
     @special(["quote", "quasiquote"], [FORM])
     def compile_quote(self, expr, root, arg):
         level = Inf if root == "quote" else 0   # Only quasiquotes can unquote
-        imports, stmts, _ = self._render_quoted_form(arg, level)
+        stmts, _ = self._render_quoted_form(arg, level)
         ret = self.compile(stmts)
-        ret.add_imports("hy", imports)
         return ret
 
     @special("unpack-iterable", [FORM])
@@ -1199,7 +1150,6 @@ class HyASTCompiler(object):
                          prefix=prefix):
                 # Actually calling `require` is necessary for macro expansions
                 # occurring during compilation.
-                self.imports['hy.macros'].update([None])
                 # The `require` we're creating in AST is the same as above, but used at
                 # run-time (e.g. when modules are loaded via bytecode).
                 ret += self.compile(HyExpression([
@@ -1869,9 +1819,6 @@ class HyASTCompiler(object):
                 attr=mangle(local),
                 ctx=ast.Load())
 
-        if self.can_use_stdlib and mangle(symbol) in self._stdlib:
-            self.imports[self._stdlib[mangle(symbol)]].add(mangle(symbol))
-
         if mangle(symbol) in ("None", "False", "True"):
             return asty.Constant(symbol, value =
                 ast.literal_eval(mangle(symbol)))
@@ -1886,7 +1833,6 @@ class HyASTCompiler(object):
             func=asty.Name(obj, id="HyKeyword", ctx=ast.Load()),
             args=[asty.Str(obj, s=obj.name)],
             keywords=[])
-        ret.add_imports("hy", {"HyKeyword"})
         return ret
 
     @builds_model(HyString, HyBytes)

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1956,13 +1956,13 @@ def hy_eval(hytree, locals=None, module=None, ast_callback=None,
     Examples:
       ::
 
-         => (eval '(print "Hello World"))
+         => (hy.eval '(print "Hello World"))
          "Hello World"
 
       If you want to evaluate a string, use ``read-str`` to convert it to a
       form first::
 
-         => (eval (read-str "(+ 1 1)"))
+         => (hy.eval (read-str "(+ 1 1)"))
          2
 
     Args:

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -105,7 +105,6 @@ Iterator Pattern
 Iterator patterns are specified using round brackets. They are the same as list patterns, but can be safely used with infinite generators. The iterator pattern does not allow for recursive destructuring within the ``:as`` special option.
 "
 
-(import [hy.models [HyDict HyExpression HyKeyword HyList HySymbol]])
 (require [hy.contrib.walk [let]])
 
 (defmacro! ifp [o!pred o!expr #* clauses]

--- a/hy/contrib/hy_repr.hy
+++ b/hy/contrib/hy_repr.hy
@@ -17,8 +17,7 @@ To make the Hy REPL use it for output, invoke Hy like so::
   [math [isnan]]
   re
   datetime
-  collections
-  [hy.models [HyObject HyExpression HySymbol HyKeyword HyInteger HyFloat HyComplex HyList HyDict HySet HyString HyFString HyFComponent HyBytes]])
+  collections)
 
 (try
   (import [_collections_abc [dict-keys dict-values dict-items]])

--- a/hy/contrib/hy_repr.hy
+++ b/hy/contrib/hy_repr.hy
@@ -74,7 +74,7 @@ To make the Hy REPL use it for output, invoke Hy like so::
 
   Like ``repr`` in Python, ``hy-repr`` can round-trip many kinds of
   values. Round-tripping implies that given an object ``x``,
-  ``(eval (read-str (hy-repr x)))`` returns ``x``, or at least a value
+  ``(hy.eval (read-str (hy-repr x)))`` returns ``x``, or at least a value
   that's equal to ``x``.
 
   Examples:

--- a/hy/contrib/pprint.hy
+++ b/hy/contrib/pprint.hy
@@ -74,7 +74,7 @@ The differences that do exist are as follows:
   (first (-safe-repr object {} None 0 True)))
 
 (defn readable? [object]
-  "Determine if (saferepr object) is readable by (eval)."
+  "Determine if (saferepr object) is readable by (hy.eval)."
   (get (-safe-repr object {} None 0 True) 1))
 
 (defn recursive? [object]

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -7,9 +7,7 @@
 .. versionadded:: 0.11.0
 "
 
-(import [hy [HyExpression HyDict]]
-        [hy.models [HySequence]]
-        [functools [partial]]
+(import [functools [partial]]
         [importlib [import-module]]
         [collections [OrderedDict]]
         [hy.macros [macroexpand :as mexpand]]
@@ -249,7 +247,6 @@
   (expand form))
 
 ;; TODO: move to hy.extra.reserved?
-(import hy)
 (setv special-forms (list (.keys hy.compiler._special-form-compilers)))
 
 

--- a/hy/core/__init__.py
+++ b/hy/core/__init__.py
@@ -1,4 +1,8 @@
-STDLIB = [
-    "hy.core.language",
-    "hy.core.shadow"
-]
+from .shadow import *
+from .language import *
+
+# Need to explicitly re-export names since some names (e.g. `-`)
+# start with a `_` after mangling
+from . import shadow
+from . import language
+__all__ = shadow.__all__ + language.__all__

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -7,7 +7,6 @@
 ;;; They are automatically required everywhere, even inside hy.core modules.
 
 (eval-and-compile
-  (import hy)
   ((hy.macros.macro "defmacro")
    (fn [&name macro-name lambda-list #* body]
      #[[the defmacro macro
@@ -58,13 +57,12 @@
          None --file-- None)))
      (for [arg lambda-list]
        (if* (or (= arg '*)
-                (and (isinstance arg HyExpression)
+                (and (isinstance arg hy.models.HyExpression)
                      (= (get arg 0) 'unpack-mapping)))
             (raise (hy.errors.HyTypeError "macros cannot use '*', or '#**'"
                                           macro-name --file-- None))))
      ;; this looks familiar...
      `(eval-and-compile
-        (import hy)
         ((hy.macros.macro ~(str macro-name))
          (fn ~(+ `[&name] lambda-list)
            ~@body))))))
@@ -273,7 +271,6 @@
        => (render-html-tag \"p\" \" --- \" (render-html-tag \"span\" \"\" :class \"fancy\" \"I'm fancy!\") \"I'm to the right of fancy\" \"I'm alone :(\")
        '<p><span class=\"fancy\">I\'m fancy!</span> --- I\'m to right right of fancy --- I\'m alone :(</p>'
   "
-  (import hy)
   (if (not (= (type name) hy.HySymbol))
     (macro-error name "defn takes a name as first argument"))
   `(setv ~name (fn* ~@args)))
@@ -290,7 +287,6 @@
 
        => (defn/a name [params] body)
   "
-  (import hy)
   (if (not (= (type name) hy.HySymbol))
     (macro-error name "defn/a takes a name as first argument"))
   (if (not (isinstance lambda-list hy.HyList))

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -229,7 +229,7 @@
   (import astor)
   (import hy.compiler)
 
-  (setv compiled (hy.compiler.hy-compile tree (calling-module-name)))
+  (setv compiled (hy.compiler.hy-compile tree (calling-module-name) :import-stdlib False))
   ((if codegen
        astor.code-gen.to-source
        astor.dump-tree)
@@ -1397,16 +1397,17 @@
     (parser.add-argument #* positional-arguments #** (dict keyword-arguments)))
   (.parse-args parser args))
 
-(setv EXPORTS
-  '[*map accumulate butlast calling-module calling-module-name chain coll?
-    combinations comp complement compress constantly count cycle dec distinct
-    disassemble drop drop-last drop-while empty? even? every? first
-    flatten float? fraction gensym group-by identity inc instance?
-    integer? integer-char? interleave interpose islice iterable?
-    iterate iterator? juxt keyword keyword? last list? macroexpand
-    macroexpand-1 mangle merge-with multicombinations neg? none? nth
-    numeric? odd? parse-args partition permutations pos? product read read-str
-    remove repeat repeatedly rest reduce second some string? symbol?
-    take take-nth take-while tuple? unmangle xor tee zero? zip-longest
-    HyBytes HyComplex HyDict HyExpression HyFComponent HyFString HyFloat
-    HyInteger HyKeyword HyList HyObject HySequence HySet HyString HySymbol])
+(setv __all__
+  (list (map mangle
+    '[*map accumulate butlast calling-module calling-module-name chain coll?
+      combinations comp complement compress constantly count cycle dec distinct
+      disassemble drop drop-last drop-while empty? even? every? first
+      flatten float? fraction gensym group-by identity inc instance?
+      integer? integer-char? interleave interpose islice iterable?
+      iterate iterator? juxt keyword keyword? last list? macroexpand
+      macroexpand-1 mangle merge-with multicombinations neg? none? nth
+      numeric? odd? parse-args partition permutations pos? product read read-str
+      remove repeat repeatedly rest reduce second some string? symbol?
+      take take-nth take-while tuple? unmangle xor tee zero? zip-longest
+      HyBytes HyComplex HyDict HyExpression HyFComponent HyFString HyFloat
+      HyInteger HyKeyword HyList HyObject HySequence HySet HyString HySymbol])))

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -15,7 +15,7 @@
 (import [hy.models [HySymbol HyKeyword]])
 (import [hy.lex [tokenize mangle unmangle read read-str]])
 (import [hy.lex.exceptions [LexException PrematureEndOfInput]])
-(import [hy.compiler [HyASTCompiler calling-module hy-eval :as eval]])
+(import [hy.compiler [HyASTCompiler calling-module]])
 
 (import [hy.core.shadow [*]])
 
@@ -1398,7 +1398,7 @@
 (setv EXPORTS
   '[*map accumulate butlast calling-module calling-module-name chain coll?
     combinations comp complement compress constantly count cycle dec distinct
-    disassemble drop drop-last drop-while empty? eval even? every? first
+    disassemble drop drop-last drop-while empty? even? every? first
     flatten float? fraction gensym group-by identity inc instance?
     integer? integer-char? interleave interpose islice iterable?
     iterate iterator? juxt keyword keyword? last list? macroexpand

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -12,7 +12,9 @@
 (import operator)  ; shadow not available yet
 (import sys)
 (import [collections.abc :as cabc])
-(import [hy.models [HySymbol HyKeyword]])
+(import [hy.models [HyBytes HyComplex HyDict HyExpression HyFComponent
+                    HyFString HyFloat HyInteger HyKeyword HyList
+                    HyObject HySequence HySet HyString HySymbol]])
 (import [hy.lex [tokenize mangle unmangle read read-str]])
 (import [hy.lex.exceptions [LexException PrematureEndOfInput]])
 (import [hy.compiler [HyASTCompiler calling-module]])
@@ -1405,4 +1407,6 @@
     macroexpand-1 mangle merge-with multicombinations neg? none? nth
     numeric? odd? parse-args partition permutations pos? product read read-str
     remove repeat repeatedly rest reduce second some string? symbol?
-    take take-nth take-while tuple? unmangle xor tee zero? zip-longest])
+    take take-nth take-while tuple? unmangle xor tee zero? zip-longest
+    HyBytes HyComplex HyDict HyExpression HyFComponent HyFString HyFloat
+    HyInteger HyKeyword HyList HyObject HySequence HySet HyString HySymbol])

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -764,7 +764,13 @@
    Use ``require`` to make other macros available.
 
    Use ``(help foo)`` instead for help with runtime objects."
-  `(help (.get __macros__ (mangle '~symbol) None)))
+   (setv symbol (str symbol))
+   (setv mangled (mangle symbol))
+   (setv builtins (gensym "builtins"))
+   `(do (import [builtins :as ~builtins])
+        (help (or (.get __macros__ ~mangled)
+                  (.get (. ~builtins __macros__) ~mangled)
+                  (raise (NameError f"macro {~symbol !r} is not defined"))))))
 
 
 (defmacro cfor [f #* generator]

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -6,13 +6,6 @@
 ;;; These macros form the hy language
 ;;; They are automatically required in every module, except inside hy.core
 
-(import [hy.models [HyList HySymbol]])
-
-(eval-and-compile
-  (import [hy.core.language [*]]))
-
-(require [hy.core.bootstrap [*]])
-
 
 (defmacro as-> [head name #* rest]
   "Beginning with `head`, expand a sequence of assignments `rest` to `name`.

--- a/hy/core/shadow.hy
+++ b/hy/core/shadow.hy
@@ -7,6 +7,7 @@
 (import operator)
 
 (require [hy.core.bootstrap [*]])
+(import [hy.lex [mangle]])
 
 (import [functools [reduce]])
 
@@ -274,10 +275,11 @@
     (setv coll (get coll k)))
   coll)
 
-(setv EXPORTS [
-  '+ '- '* '** '/ '// '% '@
-  '<< '>> '& '| '^ '~
-  '< '> '<= '>= '= '!=
-  'and 'or 'not
-  'is 'is-not 'in 'not-in
-  'get])
+(setv __all__
+  (list (map mangle [
+    '+ '- '* '** '/ '// '% '@
+    '<< '>> '& '| '^ '~
+    '< '> '<= '>= '= '!=
+    'and 'or 'not
+    'is 'is-not 'in 'not-in
+    'get])))

--- a/hy/extra/reserved.hy
+++ b/hy/extra/reserved.hy
@@ -3,7 +3,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import hy sys keyword)
+(import sys keyword)
 
 (setv _cache None)
 

--- a/hy/extra/reserved.hy
+++ b/hy/extra/reserved.hy
@@ -27,8 +27,8 @@
   (global _cache)
   (if (is _cache None) (do
     (setv _cache (frozenset (map unmangle (+
-      hy.core.language.EXPORTS
-      hy.core.shadow.EXPORTS
+      hy.core.__all__
+      (list (.keys hy.core.bootstrap.__macros__))
       (list (.keys hy.core.macros.__macros__))
       keyword.kwlist
       (list (.keys hy.compiler._special_form_compilers))

--- a/hy/lex/__init__.py
+++ b/hy/lex/__init__.py
@@ -199,7 +199,7 @@ def read(from_file=sys.stdin, eof=""):
 
       ::
 
-         => (eval (read))
+         => (hy.eval (read))
          (+ 2 2)
          4
 
@@ -207,9 +207,9 @@ def read(from_file=sys.stdin, eof=""):
 
          => (import io)
          => (setv buffer (io.StringIO "(+ 2 2)\\n(- 2 1)"))
-         => (eval (read :from-file buffer))
+         => (hy.eval (read :from-file buffer))
          4
-         => (eval (read :from-file buffer))
+         => (hy.eval (read :from-file buffer))
          1
 
       ::
@@ -221,7 +221,7 @@ def read(from_file=sys.stdin, eof=""):
          ...  (try (while True
          ...         (setv exp (read f))
          ...         (print "OHY" exp)
-         ...         (eval exp))
+         ...         (hy.eval exp))
          ...       (except [e EOFError]
          ...         (print "EOF!"))))
          OHY HyExpression([
@@ -265,7 +265,7 @@ def read_str(input):
 
       ::
 
-         => (eval (read-str "(print 1)"))
+         => (hy.eval (read-str "(print 1)"))
          1
   """
     return read(StringIO(str(input)))

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -655,6 +655,13 @@ def test_bad_tag_macros():
     can_compile('(defmacro "#a" [x] 3) #a ()')
 
 
+def test_models_accessible():
+    # https://github.com/hylang/hy/issues/1045
+    can_eval('HySymbol')
+    can_eval('HyList')
+    can_eval('HyDict')
+
+
 def test_module_prelude():
     """Make sure the hy prelude appears at the top of a compiled module."""
     hy_ast = can_compile('', import_stdlib=True)

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -632,12 +632,12 @@ def test_eval_generator_with_return():
 
 def test_futures_imports():
     """Make sure __future__ imports go first, especially when builtins are
-    automatically added (e.g. via use of a builtin name like `name`)."""
+    automatically added (e.g. via use of a builtin name like `last`)."""
     hy_ast = can_compile((
         '(import [__future__ [print_function]])\n'
         '(import sys)\n'
-        '(setv name [1 2])'
-        '(print (first name))'))
+        '(setv last [1 2])'
+        '(print (first last))'))
 
     assert hy_ast.body[0].module == '__future__'
 

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -24,8 +24,8 @@ def _ast_spotcheck(arg, root, secondary):
     assert getattr(root, arg) == getattr(secondary, arg)
 
 
-def can_compile(expr):
-    return hy_compile(hy_parse(expr), __name__)
+def can_compile(expr, import_stdlib=False):
+    return hy_compile(hy_parse(expr), __name__, import_stdlib=import_stdlib)
 
 
 def can_eval(expr):
@@ -478,7 +478,7 @@ def test_ast_unicode_strings():
     def _compile_string(s):
         hy_s = HyString(s)
 
-        code = hy_compile([hy_s], __name__, filename='<string>', source=s)
+        code = hy_compile([hy_s], __name__, filename='<string>', source=s, import_stdlib=False)
         # We put hy_s in a list so it isn't interpreted as a docstring.
 
         # code == ast.Module(body=[ast.Expr(value=ast.List(elts=[ast.Str(s=xxx)]))])
@@ -640,17 +640,6 @@ def test_futures_imports():
         '(print (first name))'))
 
     assert hy_ast.body[0].module == '__future__'
-    assert hy_ast.body[1].module == 'hy.core.language'
-
-    hy_ast = can_compile((
-        '(import sys)\n'
-        '(import [__future__ [print_function]])\n'
-        '(setv name [1 2])'
-        '(print (first name))'))
-
-    assert hy_ast.body[0].module == '__future__'
-    assert hy_ast.body[1].module == 'hy.core.language'
-
 
 def test_inline_python():
     can_compile('(py "1 + 1")')
@@ -664,3 +653,16 @@ def test_bad_tag_macros():
     cant_compile('(defmacro "#a" [] (raise (ValueError))) #a ()')
     cant_compile('(defmacro "#a" [x] (raise (ValueError))) #a ()')
     can_compile('(defmacro "#a" [x] 3) #a ()')
+
+
+def test_module_prelude():
+    """Make sure the hy prelude appears at the top of a compiled module."""
+    hy_ast = can_compile('', import_stdlib=True)
+    assert len(hy_ast.body) == 1
+    assert isinstance(hy_ast.body[0], ast.Import)
+    assert hy_ast.body[0].module == 'hy'
+
+    hy_ast = can_compile('(setv flag (keyword? HySymbol))', import_stdlib=True)
+    assert len(hy_ast.body) == 2
+    assert isinstance(hy_ast.body[0], ast.Import)
+    assert hy_ast.body[0].module == 'hy'

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -53,7 +53,7 @@ def test_runpy():
 
 
 def test_stringer():
-    _ast = hy_compile(hy_parse("(defn square [x] (* x x))"), __name__)
+    _ast = hy_compile(hy_parse("(defn square [x] (* x x))"), __name__, import_stdlib=False)
 
     assert type(_ast.body[0]) == ast.FunctionDef
 

--- a/tests/native_tests/comprehensions.hy
+++ b/tests/native_tests/comprehensions.hy
@@ -92,7 +92,7 @@
         (for [~@(cut expr 1 -1)]
           (.append out ~(get expr -1)))
         out)))
-    (setv result (eval expr))
+    (setv result (hy.eval expr))
     (when (= specialop "dfor")
       (setv result (.keys result)))
     (assert (= (sorted result) answer) (str expr)))))

--- a/tests/native_tests/contrib/destructure.hy
+++ b/tests/native_tests/contrib/destructure.hy
@@ -214,9 +214,9 @@
 
 (defn test-errors []
   (with [(pytest.raises TypeError)]
-    (eval (macroexpand '(setv+ [a b] 1))))
+    (hy.eval (macroexpand '(setv+ [a b] 1))))
   (with [(pytest.raises AttributeError)]
-    (eval (macroexpand '(setv+ {a :a} 1))))
+    (hy.eval (macroexpand '(setv+ {a :a} 1))))
   (with [(pytest.raises SyntaxError)]
     (destructure '{a b c} {:a 1}))
   (with [(pytest.raises SyntaxError)]

--- a/tests/native_tests/contrib/hy_repr.hy
+++ b/tests/native_tests/contrib/hy_repr.hy
@@ -121,11 +121,10 @@
     "(Fooey :cd 11 :a_b 12)")))
 
 (defn test-hy-model-constructors []
-  (import hy)
-  (assert (= (hy-repr (hy.HyInteger 7)) "'7"))
-  (assert (= (hy-repr (hy.HyString "hello")) "'\"hello\""))
-  (assert (= (hy-repr (hy.HyList [1 2 3])) "'[1 2 3]"))
-  (assert (= (hy-repr (hy.HyDict [1 2 3])) "'{1 2  3}")))
+  (assert (= (hy-repr (HyInteger 7)) "'7"))
+  (assert (= (hy-repr (HyString "hello")) "'\"hello\""))
+  (assert (= (hy-repr (HyList [1 2 3])) "'[1 2 3]"))
+  (assert (= (hy-repr (HyDict [1 2 3])) "'{1 2  3}")))
 
 (defn test-hy-repr-self-reference []
 

--- a/tests/native_tests/contrib/hy_repr.hy
+++ b/tests/native_tests/contrib/hy_repr.hy
@@ -32,10 +32,10 @@
     [1 [2 3] (, 4 (, 'mysymbol :mykeyword)) {"a" b"hello"} '(f #* a #** b)]
     '[1 [2 3] (, 4 (, mysymbol :mykeyword)) {"a" b"hello"} (f #* a #** b)]])
   (for [original-val values]
-    (setv evaled (eval (read-str (hy-repr original-val))))
+    (setv evaled (hy.eval (read-str (hy-repr original-val))))
     (assert (= evaled original-val))
     (assert (is (type evaled) (type original-val))))
-  (assert (isnan (eval (read-str (hy-repr NaN))))))
+  (assert (isnan (hy.eval (read-str (hy-repr NaN))))))
 
 (defn test-hy-repr-roundtrip-from-str []
   (setv strs [
@@ -63,7 +63,7 @@
     ":akeyword"
     "'(f #* args #** kwargs)"])
   (for [original-str strs]
-    (setv rep (hy-repr (eval (read-str original-str))))
+    (setv rep (hy-repr (hy.eval (read-str original-str))))
     (assert (= rep original-str))))
 
 (defn test-hy-repr-no-roundtrip []
@@ -74,7 +74,7 @@
   (setv orig `[a ~5.0])
   (setv reprd (hy-repr orig))
   (assert (= reprd "'[a 5.0]"))
-  (setv result (eval (read-str reprd)))
+  (setv result (hy.eval (read-str reprd)))
 
   (assert (is (type (get orig 1)) float))
   (assert (is (type (get result 1)) HyFloat)))

--- a/tests/native_tests/contrib/slicing.hy
+++ b/tests/native_tests/contrib/slicing.hy
@@ -30,12 +30,12 @@
 
   (assert (= #: ... Ellipsis))
 
-  (assert (= (eval (hy-parse "#: 1:[1 2]:2")) :2))
-  (assert (= (eval (hy-parse "#: 1:[1 2]")) [1 2]))
+  (assert (= (hy.eval (hy-parse "#: 1:[1 2]:2")) :2))
+  (assert (= (hy.eval (hy-parse "#: 1:[1 2]")) [1 2]))
 
   (with [(pytest.raises TypeError)]
     ;; slice takes at most 3 args
-    (eval (hy-parse "#: 1:2:3:4")))
+    (hy.eval (hy-parse "#: 1:2:3:4")))
 
   (with [(pytest.raises NameError)]
-    (eval (hy-parse "#: 1:abc:2"))))
+    (hy.eval (hy-parse "#: 1:abc:2"))))

--- a/tests/native_tests/contrib/test_pprint.hy
+++ b/tests/native_tests/contrib/test_pprint.hy
@@ -121,7 +121,7 @@
  [[[[[1 2 3]
      "1 2"]]]]]]FOO])
 
-  (setv o (eval (read-str exp)))
+  (setv o (hy.eval (read-str exp)))
   (assert (= (pprint.pformat o :width 16) exp))
   (assert (= (pprint.pformat o :width 17) exp))
   (assert (= (pprint.pformat o :width 22) exp))

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -4,6 +4,8 @@
 
 ;;;; some simple helpers
 
+(import pytest)
+
 (defn assert-true [x]
   (assert (= True x)))
 
@@ -699,6 +701,17 @@ result['y in globals'] = 'y' in globals()")
                         <p> Move along. (Nothing to see here.)</p>)))
 
 (defn test-doc [capsys]
+  ;; https://github.com/hylang/hy/issues/1970
+  ;; Let's first make sure we can doc the builtin macros
+  ;; before we create the user macros.
+  (doc doc)
+  (setv [out err] (.readouterr capsys))
+  (assert (in "Gets help for a macro function" out))
+
+  (doc "#@")
+  (setv [out err] (.readouterr capsys))
+  (assert (in "with-decorator tag macro" out))
+
   (defmacro <-mangle-> []
     "a fancy docstring"
     '(+ 2 2))
@@ -716,7 +729,12 @@ result['y in globals'] = 'y' in globals()")
   (doc "#pillgrums")
   (setv [out err] (.readouterr capsys))
   (assert (in "Look at the quality of that picture!" out))
-  (assert (empty? err)))
+  (assert (empty? err))
+
+  ;; make sure doc raises an error instead of
+  ;; presenting a default value help screen
+  (with [(pytest.raises NameError)]
+    (doc does-not-exist)))
 
 
 (defn test-do-n []

--- a/tests/native_tests/extra/reserved.hy
+++ b/tests/native_tests/extra/reserved.hy
@@ -11,6 +11,7 @@
   (assert (in "pass" (names)))
   (assert (in "class" (names)))
   (assert (in "defclass" (names)))
+  (assert (in "defmacro" (names)))
   (assert (in "->" (names)))
   (assert (in "keyword?" (names)))
   (assert (not-in "foo" (names)))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1672,7 +1672,7 @@ macros()
 (defmacro identify-keywords [#* elts]
   `(list
     (map
-     (fn [x] (if (is-keyword x) "keyword" "other"))
+     (fn [x] (if (keyword? x) "keyword" "other"))
      ~elts)))
 
 (defn test-keywords-and-macros []

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -74,7 +74,7 @@
   (setv y 0 x 1 y x)
   (assert (= y 1))
   (with [(pytest.raises HyLanguageError)]
-    (eval '(setv a 1 b))))
+    (hy.eval '(setv a 1 b))))
 
 
 (defn test-setv-returns-none []
@@ -144,7 +144,7 @@
       (try 1 (except [True AssertionError] 2))
       (defclass True [])]]
     (with [e (pytest.raises HyLanguageError)]
-      (eval form))
+      (hy.eval form))
     (assert (in "Can't assign" e.value.msg))))
 
 
@@ -183,7 +183,7 @@
   ; https://github.com/hylang/hy/issues/1790
   (global while-cond-var)
   (setv while-cond-var 10)
-  (eval
+  (hy.eval
     '(do
       (defmacro while-cond []
         (global while-cond-var)
@@ -1137,51 +1137,51 @@
 
 (defn test-eval []
   "NATIVE: test eval"
-  (assert (= 2 (eval (quote (+ 1 1)))))
+  (assert (= 2 (hy.eval (quote (+ 1 1)))))
   (setv x 2)
-  (assert (= 4 (eval (quote (+ x 2)))))
+  (assert (= 4 (hy.eval (quote (+ x 2)))))
   (setv test-payload (quote (+ x 2)))
   (setv x 4)
-  (assert (= 6 (eval test-payload)))
-  (assert (= 9 ((eval (quote (fn [x] (+ 3 3 x)))) 3)))
-  (assert (= 1 (eval (quote 1))))
-  (assert (= "foobar" (eval (quote "foobar"))))
+  (assert (= 6 (hy.eval test-payload)))
+  (assert (= 9 ((hy.eval (quote (fn [x] (+ 3 3 x)))) 3)))
+  (assert (= 1 (hy.eval (quote 1))))
+  (assert (= "foobar" (hy.eval (quote "foobar"))))
   (setv x (quote 42))
-  (assert (= x (eval x)))
-  (assert (= 27 (eval (+ (quote (*)) (* [(quote 3)] 3)))))
-  (assert (= None (eval (quote (print ""))))))
+  (assert (= x (hy.eval x)))
+  (assert (= 27 (hy.eval (+ (quote (*)) (* [(quote 3)] 3)))))
+  (assert (= None (hy.eval (quote (print ""))))))
 
 
 (defn test-eval-false []
-  (assert (is (eval 'False) False))
-  (assert (is (eval 'None) None))
-  (assert (= (eval '0) 0))
-  (assert (= (eval '"") ""))
-  (assert (= (eval 'b"") b""))
-  (assert (= (eval ':) :))
-  (assert (= (eval '[]) []))
-  (assert (= (eval '(,)) (,)))
-  (assert (= (eval '{}) {}))
-  (assert (= (eval '#{}) #{})))
+  (assert (is (hy.eval 'False) False))
+  (assert (is (hy.eval 'None) None))
+  (assert (= (hy.eval '0) 0))
+  (assert (= (hy.eval '"") ""))
+  (assert (= (hy.eval 'b"") b""))
+  (assert (= (hy.eval ':) :))
+  (assert (= (hy.eval '[]) []))
+  (assert (= (hy.eval '(,)) (,)))
+  (assert (= (hy.eval '{}) {}))
+  (assert (= (hy.eval '#{}) #{})))
 
 
 (defn test-eval-globals []
   "NATIVE: test eval with explicit global dict"
-  (assert (= 'bar (eval (quote foo) {'foo 'bar})))
-  (assert (= 1 (do (setv d {}) (eval '(setv x 1) d) (eval (quote x) d))))
+  (assert (= 'bar (hy.eval (quote foo) {'foo 'bar})))
+  (assert (= 1 (do (setv d {}) (hy.eval '(setv x 1) d) (hy.eval (quote x) d))))
   (setv d1 {}  d2 {})
-  (eval '(setv x 1) d1)
+  (hy.eval '(setv x 1) d1)
   (with [e (pytest.raises NameError)]
-    (eval (quote x) d2)))
+    (hy.eval (quote x) d2)))
 
 (defn test-eval-failure []
   "NATIVE: test eval failure modes"
   ; yo dawg
-  (with [(pytest.raises TypeError)] (eval '(eval)))
+  (with [(pytest.raises TypeError)] (hy.eval '(hy.eval)))
   (defclass C)
-  (with [(pytest.raises TypeError)] (eval (C)))
-  (with [(pytest.raises TypeError)] (eval 'False []))
-  (with [(pytest.raises TypeError)] (eval 'False {} 1)))
+  (with [(pytest.raises TypeError)] (hy.eval (C)))
+  (with [(pytest.raises TypeError)] (hy.eval 'False []))
+  (with [(pytest.raises TypeError)] (hy.eval 'False {} 1)))
 
 (defn test-eval-quasiquote []
   ; https://github.com/hylang/hy/issues/1174
@@ -1195,26 +1195,26 @@
       "apple bloom" b"apple bloom" "⚘" b"\x00"
       [] #{} {}
       [1 2 3] #{1 2 3} {"a" 1 "b" 2}]]
-    (assert (= (eval `(identity ~x)) x))
-    (assert (= (eval x) x)))
+    (assert (= (hy.eval `(identity ~x)) x))
+    (assert (= (hy.eval x) x)))
 
   (setv kw :mykeyword)
-  (assert (= (get (eval `[~kw]) 0) kw))
-  (assert (= (eval kw) kw))
+  (assert (= (get (hy.eval `[~kw]) 0) kw))
+  (assert (= (hy.eval kw) kw))
 
   ; Tuples wrap to HyLists, not HyExpressions.
-  (assert (= (eval (,)) []))
-  (assert (= (eval (, 1 2 3)) [1 2 3]))
+  (assert (= (hy.eval (,)) []))
+  (assert (= (hy.eval (, 1 2 3)) [1 2 3]))
 
-  (assert (= (eval `(+ "a" ~(+ "b" "c"))) "abc"))
+  (assert (= (hy.eval `(+ "a" ~(+ "b" "c"))) "abc"))
 
   (setv l ["a" "b"])
   (setv n 1)
-  (assert (= (eval `(get ~l ~n) "b")))
+  (assert (= (hy.eval `(get ~l ~n) "b")))
 
   (setv d {"a" 1 "b" 2})
   (setv k "b")
-  (assert (= (eval `(get ~d ~k)) 2)))
+  (assert (= (hy.eval `(get ~d ~k)) 2)))
 
 
 (defn test-quote-bracket-string-delim []
@@ -1288,9 +1288,9 @@ cee\"} dee" "ey bee\ncee dee"))
   (setv quoted 'f"hello {world}")
   (assert (isinstance quoted HyFString))
   (with [(pytest.raises NameError)]
-    (eval quoted))
+    (hy.eval quoted))
   (setv world "goodbye")
-  (assert (= (eval quoted) "hello goodbye"))
+  (assert (= (hy.eval quoted) "hello goodbye"))
 
   ;; '=' debugging syntax.
   (setv foo "bar")
@@ -1621,13 +1621,13 @@ macros()
   (import [hy.models [HyExpression]])
 
   (setv stdin-buffer (StringIO "(+ 2 2)\n(- 2 2)"))
-  (assert (= (eval (read stdin-buffer)) 4))
+  (assert (= (hy.eval (read stdin-buffer)) 4))
   (assert (isinstance (read stdin-buffer) HyExpression))
 
   "Multiline test"
   (setv stdin-buffer (StringIO "(\n+\n41\n1\n)\n(-\n2\n1\n)"))
-  (assert (= (eval (read stdin-buffer)) 42))
-  (assert (= (eval (read stdin-buffer)) 1))
+  (assert (= (hy.eval (read stdin-buffer)) 42))
+  (assert (= (hy.eval (read stdin-buffer)) 1))
 
   "EOF test"
   (setv stdin-buffer (StringIO "(+ 2 2)"))

--- a/tests/native_tests/mangling.hy
+++ b/tests/native_tests/mangling.hy
@@ -140,7 +140,7 @@
   (setv sym 'foo?)
   (assert (= sym "foo?"))
   (assert (!= sym "is_foo"))
-  (setv out (eval `(do
+  (setv out (hy.eval `(do
                      (setv ~sym 10)
                      [foo? is_foo])))
   (assert (= out [10 10])))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -2,7 +2,9 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import pytest
+(import os sys
+        importlib
+        pytest
         [hy.errors [HyTypeError HyMacroExpansionError]])
 
 (defmacro rev [#* body]
@@ -401,6 +403,49 @@ in expansions."
   (assert (= "This is the local version of `nonlocal-test-macro` returning 3!"
              #test-module-tag-2 3)))
 
+(defn test-requires-pollutes-core []
+  ;; https://github.com/hylang/hy/issues/1978
+  ;; Macros loaded from an external module should not pollute `__macros__`
+  ;; with macros from core.
+
+  (setv pyc-file (importlib.util.cache-from-source
+                   (os.path.realpath
+                     (os.path.join
+                       "tests" "resources" "macros.hy"))))
+
+  ;; Remove any cached byte-code, so that this runs from source and
+  ;; gets evaluated in this module.
+  (when (os.path.isfile pyc-file)
+    (os.unlink pyc-file)
+    (.clear sys.path_importer_cache)
+    (when (in  "tests.resources.macros" sys.modules)
+      (del (get sys.modules "tests.resources.macros"))
+      (__macros__.clear)))
+
+  ;; Ensure that bytecode isn't present when we require this module.
+  (assert (not (os.path.isfile pyc-file)))
+
+  (defn require-macros []
+    (require [tests.resources.macros :as m])
+
+    (assert (in (mangle "m.test-macro") __macros__))
+    (for [macro-name __macros__]
+      (assert (not (and (in "with" macro-name)
+                        (!= "with" macro-name))))))
+
+  (require-macros)
+
+  ;; Now that bytecode is present, reload the module, clear the `require`d
+  ;; macros and tags, and rerun the tests.
+  (assert (os.path.isfile pyc-file))
+
+  ;; Reload the module and clear the local macro context.
+  (.clear sys.path_importer_cache)
+  (del (get sys.modules "tests.resources.macros"))
+  (.clear __macros__)
+
+  (require-macros))
+
 #@(pytest.mark.xfail
 (defn test-macro-from-module []
   "Macros loaded from an external module, which itself `require`s macros, should
@@ -411,9 +456,6 @@ in expansions."
  loaded and used.
 
  Additionally, we confirm that `require` statements are executed via loaded bytecode."
-
-  (import os sys marshal types)
-  (import importlib)
 
   (setv pyc-file (importlib.util.cache-from-source
                    (os.path.realpath

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -64,23 +64,23 @@
 (defn test-macro-kw []
   "NATIVE: test that an error is raised when * or #** is used in a macro"
   (try
-    (eval '(defmacro f [* a b]))
+    (hy.eval '(defmacro f [* a b]))
     (except [e HyTypeError]
       (assert (= e.msg "macros cannot use '*', or '#**'")))
     (else (assert False)))
 
   (try
-    (eval '(defmacro f [#** kw]))
+    (hy.eval '(defmacro f [#** kw]))
     (except [e HyTypeError]
       (assert (= e.msg "macros cannot use '*', or '#**'")))
     (else (assert False))))
 
 (defn test-macro-bad-name []
   (with [excinfo (pytest.raises HyTypeError)]
-    (eval '(defmacro :kw [])))
+    (hy.eval '(defmacro :kw [])))
   (assert (= (. excinfo value msg) "received a `HyKeyword' instead of a symbol or string for macro name"))
   (with [excinfo (pytest.raises HyTypeError)]
-    (eval '(defmacro "foo.bar" [])))
+    (hy.eval '(defmacro "foo.bar" [])))
   (assert (= (. excinfo value msg) "periods are not allowed in macro names")))
 
 (defn test-fn-calling-macro []
@@ -494,7 +494,7 @@ in expansions."
   (setv test-expr (hy-parse "(defmacro blah [x] `(print ~@z)) (blah y)"))
 
   (with [excinfo (pytest.raises HyMacroExpansionError)]
-    (eval test-expr))
+    (hy.eval test-expr))
 
   (setv output (traceback.format_exception_only
                  excinfo.type excinfo.value))
@@ -515,7 +515,7 @@ in expansions."
   ;; This should throw a `HyWrapperError` that gets turned into a
   ;; `HyMacroExpansionError`.
   (with [excinfo (pytest.raises HyMacroExpansionError)]
-    (eval '(do (defmacro wrap-error-test []
+    (hy.eval '(do (defmacro wrap-error-test []
                  (fn []))
                (wrap-error-test))))
   (assert (in "HyWrapperError" (str excinfo.value))))

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -25,7 +25,7 @@
 
 (defmacro forbid [expr]
   `(assert (try
-    (eval '~expr)
+    (hy.eval '~expr)
     (except [[TypeError SyntaxError]] True)
     (else (raise AssertionError)))))
 

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -2,8 +2,6 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy [HyExpression HySymbol HyString HyBytes HyDict]])
-
 
 (defn test-quote []
   "NATIVE: test for quoting functionality"

--- a/tests/resources/bin/require_and_eval.hy
+++ b/tests/resources/bin/require_and_eval.hy
@@ -1,3 +1,3 @@
 (require [hy.extra.anaphoric [ap-if]])
 
-(print (eval '(ap-if (+ "a" "b") (+ it "c"))))
+(print (hy.eval '(ap-if (+ "a" "b") (+ it "c"))))

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -343,6 +343,13 @@ def test_bin_hy_builtins():
     assert type(builtins.quit) is hy.cmdline.HyQuitter
 
 
+def test_bin_hy_shadowing_core():
+    # make sure we don't shadow user symbols with hy's core
+    # https://github.com/hylang/hy/issues/791
+    output, _ = run_cmd("hy", "(defn keyword? [x] True)\n(keyword? 4)")
+    assert "True" in output
+
+
 def test_bin_hy_main():
     output, _ = run_cmd("hy tests/resources/bin/main.hy")
     assert "Hello World" in output


### PR DESCRIPTION
Fixes #791, fixes #1045, fixes #1978.

I might have gotten a little carried away but I think I have a working implementation for getting rid of autoimports.

WIth this change, the compiler inserts a call to `hy.importer._hy_inject_builtins` at the top of each module. This function adds all of hy's core/stdlib to the `builtins` module so that they can be called as if they had been imported.

Upsides:
- No more autoimports and associated shadowing bugs
- Does not add to exported symbols in modules

Possible downsides:
- Had to rename `eval` to `hy-eval` so it doesn't clash with python's builtin (alternatively, we could drop `eval` from the core as mentioned in #1644 and have it used as `hy.eval` instead)
- All Hy models need qualified names now (e.g. can't reference `HySymbol` directly, but we can still use `hy.HySymbol`)
- Modifying `builtins` affects non-Hy code as well. E.g.:
```python
>>> import hy
>>> import empty  # a completely empty .hy file
>>> is_keyword
<function is_keyword at 0x7f14686ead30>
```
These will get shadowed by any local assignments though, so properly written python code will be unaffected. However, it's still a potentially confusing effect.