### PR TITLE
Add macros `do-n` and `list-n`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,6 +24,7 @@ Breaking Changes
 
 New Features
 ------------------------------
+* New standard macros `do-n` and `list-n`
 * New contrib module `destructure` for Clojure-style destructuring.
 * Location of history file now configurable via environment variable `HY_HISTORY`
 * Added handling for "=" syntax in f-strings.

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -507,6 +507,45 @@
   `(if-not ~test (do ~@body)))
 
 
+(defn _do-n [count-form body]
+  `(for [~(gensym) (range ~count-form)]
+    ~@body))
+
+
+(defmacro do-n [count-form &rest body]
+  "Execute `body` a number of times equal to `count-form` and return
+  ``None``. (To collect return values, use :hy:macro:`list-n`
+  instead.) Negative values of the count are treated as 0.
+
+  This macro is implemented as a :hy:macro:`for` loop, so you can use
+  :hy:macro:`break` and :hy:macro:`continue` in the body.
+
+  ::
+
+     => (do-n 3 (print \"hi\"))
+     hi
+     hi
+     hi
+  "
+  (_do-n count-form body))
+
+
+(defmacro list-n [count-form &rest body]
+  "Like :hy:macro:`do-n`, but the results are collected into a list.
+
+  ::
+
+    => (setv counter 0)
+    => (list-n 5 (+= counter 1) counter)
+    [1 2 3 4 5]
+  "
+  (setv l (gensym))
+  `(do
+    (setv ~l [])
+    ~(_do-n count-form [`(.append ~l (do ~@body))])
+    ~l))
+
+
 (defmacro with-gensyms [args &rest body]
   "Execute `body` with `args` as bracket of names to gensym for use in macros.
 

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -717,3 +717,30 @@ result['y in globals'] = 'y' in globals()")
   (setv [out err] (.readouterr capsys))
   (assert (in "Look at the quality of that picture!" out))
   (assert (empty? err)))
+
+
+(defn test-do-n []
+  (setv n 0)
+
+  (do-n 1 (+= n 1))
+  (assert (= n 1))
+  (do-n 3 (+= n 1))
+  (assert (= n 4))
+  (do-n 0 (+= n 1))
+  (assert (= n 4))
+  (do-n -2 (+= n 1))
+  (assert (= n 4))
+
+  (do-n 2 (+= n 1) (+= n 2))
+  (assert (= n 10))
+
+  (do-n 2 (+= n 1) (+= n 2) (break))
+  (assert (= n 13)))
+
+
+(defn test-list-n []
+
+  (assert (= (list-n 4 1) [1 1 1 1]))
+
+  (setv l (list (range 10)))
+  (assert (= (list-n 3 (.pop l)) [9 8 7])))


### PR DESCRIPTION
These are syntactic sugar for `for` loops when you don't need the loop variable for anything. I thought of naming one of them `dotimes`, but I decided it would be needlessly confusing because of the differences from Common Lisp's `dotimes`.