### PR TITLE
Feature: Add callable for macro to core

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,7 +24,7 @@ Breaking Changes
 
 New Features
 ------------------------------
-* New standard macros `do-n` and `list-n`
+* New standard macros `do-n`, `list-n`, and `cfor`
 * New contrib module `destructure` for Clojure-style destructuring.
 * Location of history file now configurable via environment variable `HY_HISTORY`
 * Added handling for "=" syntax in f-strings.

--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -111,6 +111,7 @@
           "hy.core.macros.as->",
           "hy.core.macros.->",
           "hy.core.macros.->>",
+          "hy.core.macros.cfor",
           "hy.core.macros.doto",
           "hy.core.macros.of",
           "hy.core.macros.unless",

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -772,3 +772,35 @@
 
    Use ``(help foo)`` instead for help with runtime objects."
   `(help (.get __macros__ (mangle '~symbol) None)))
+
+
+(defmacro cfor [f &rest generator]
+  #[[syntactic sugar for passing a ``generator`` expression to the callable ``f``
+
+  Its syntax is the same as :ref:`generator expression <py:genexpr>`, but takes
+  a function ``f`` that the generator will be immedietly passed to. Equivalent
+  to ``(f (gfor ...))``.
+
+  Examples:
+  ::
+     => (cfor tuple x (range 10) :if (odd? x) x)
+     (, 1 3 5 7 9)
+
+  The equivalent in python would be:
+
+     >>> tuple(x for x in range(10) if is_odd(x))
+
+  Some other common functions that take iterables::
+
+     => (cfor all x [1 3 8 5] (< x 10))
+     True
+
+     => (with [f (open "AUTHORS")]
+     ...  (cfor max
+     ...        author (.splitlines (f.read))
+     ...        :setv name (.group (re.match r"\* (.*?) <" author) 1)
+     ...        :if (name.startswith "A")
+     ...        (len name)))
+     20 ;; The number of characters in the longest author's name that starts with 'A'
+  ]]
+  `(~f (gfor ~@generator)))

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -744,3 +744,9 @@ result['y in globals'] = 'y' in globals()")
 
   (setv l (list (range 10)))
   (assert (= (list-n 3 (.pop l)) [9 8 7])))
+
+(defn test-cfor []
+  (assert (= (cfor tuple x (range 10) :if (odd? x) x) (, 1 3 5 7 9)))
+  (assert (= (cfor all x [1 3 8 5] (< x 10))) True)
+  (assert (= (cfor dict x "ABCD" [x True])
+             {"A" True  "B" True  "C" True  "D" True})))


### PR DESCRIPTION
Closes #867 

This is a pretty common idiom that python even has its own sugar for so I think it makes sense to add to core. 

This should probably be grouped next to the other comprehension forms in docs, but isn't possible right now in sphinx hydomain. Once we have the new `defn` args syntax nailed down, i'll go and push an update to `hydomain` to fix all the stuff we've broken in master and give us more control on the organization of the api autodocs. 