### PR TITLE
Add pattern matching support for Python 3.10

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ import importlib
 import py
 import pytest
 import hy
-from hy._compat import PY3_8
+from hy._compat import PY3_8, PY3_10
 
 NATIVE_TESTS = os.path.join("", "tests", "native_tests", "")
 
@@ -12,7 +12,9 @@ _fspath_pyimport = py.path.local.pyimport
 
 
 def pytest_ignore_collect(path, config):
-    return (("py3_8_only" in path.basename and not PY3_8) or None)
+    return (("py3_8_only" in path.basename and not PY3_8)
+            or ("py3_10_only" in path.basename and not PY3_10)
+            or None)
 
 
 def pyimport_patch_mismatch(self, **kwargs):

--- a/tests/native_tests/pattern_matching.hy
+++ b/tests/native_tests/pattern_matching.hy
@@ -9,32 +9,21 @@
                         [0 :nothing]
                         [1 :correct])))
 
-  (setv res (match [1 2 3]
-              [[1 x 3]
-               (print "x" x)
-               (setv x 500)
-               x]))
-  (setv [out err] (.readouterr capsys))
-  (assert (= out "x 2"))
-  (assert res 500)
-
   (assert (= 2 (match {"a" 1 "b" 2}
                  [{"a" 1 "b" b} b])))
 
   (assert (= {"a" 1} (match {"a" 1 "b" [0]}
                        [{"b" [x]} :if (> x 0) x]
-                       [{"b" _ #** d} d])))
-
-  (assert (= 1 (:or (dict :or 1)))))
+                       [{"b" _ #** d} d]))))
 
 (defn test-match-objects []
 
   (defclass Foo []
-    (defn --init-- [self bar]
+    (defn __init__ [self bar]
       (setv self.bar bar))
-    (defn --repr-- [self]
+    (defn __repr__ [self]
       f"Foo(bar={self.bar})")
-    (defn --eq-- [self other]
+    (defn __eq__ [self other]
       (and (= Foo (type other))
            (= self.bar other.bar))))
 
@@ -46,12 +35,35 @@
                             :if (= x 3)
                             [a b]]))))
 
+(defn test-statements [capsys]
+  (setv res (match [1 2 3]
+              [[1 x 3]
+               (print "x" x)
+               (setv x 500)
+               x]))
+  (setv [out err] (.readouterr capsys))
+  (assert (= out "x 2\n"))
+  (assert res 500)
+
+  (match 1
+    [0 :if (print 0) 0]
+    [x :if (do (print "x" x) False) x]
+    [y :if (do (print "y" y) True) y])
+  (setv [out err] (.readouterr capsys))
+  (assert (= out "x 1\ny 1\n"))
+  )
+
 (defn test-errors []
   (with [(pytest.raises hy.errors.HySyntaxError)]
-    (match 1
-      [(:as (:or 1 2 3) (+ 1 1))
-       "here"]))
-  (with [(pytest.raises hy.errors.HySyntaxError)]
-    (match 1 [x x] 2))
-  (with [(pytest.raises hy.errors.HySyntaxError)]
-    (match [0 1 2] [(lfor i (range 3) i) :here])))
+    (-> '(match 1
+           [(:as (:or 1 2 3) (+ 1 1))
+            "here"])
+        (hy.compiler.hy-compile "__main__")))
+  #_(with [(pytest.raises hy.errors.HySyntaxError)]
+    (-> '(match 1 [x x] 2)
+        (hy.compiler.hy-compile "__main__")))
+  (with [(pytest.raises SyntaxError)]
+    (-> '(match [0 1 2] [(lfor i (range 3) i) :here])
+        (hy.compiler.hy-compile "__main__")
+        (compile "<string>" "exec")
+        exec)))

--- a/tests/native_tests/pattern_matching.hy
+++ b/tests/native_tests/pattern_matching.hy
@@ -1,0 +1,57 @@
+;; Copyright 2021 the authors.
+;; This file is part of Hy, which is free software licensed under the Expat
+;; license. See the LICENSE.
+
+(import pytest)
+
+(defn test-match [capsys]
+  (assert (= :correct (match 1
+                        [0 :nothing]
+                        [1 :correct])))
+
+  (setv res (match [1 2 3]
+              [[1 x 3]
+               (print "x" x)
+               (setv x 500)
+               x]))
+  (setv [out err] (.readouterr capsys))
+  (assert (= out "x 2"))
+  (assert res 500)
+
+  (assert (= 2 (match {"a" 1 "b" 2}
+                 [{"a" 1 "b" b} b])))
+
+  (assert (= {"a" 1} (match {"a" 1 "b" [0]}
+                       [{"b" [x]} :if (> x 0) x]
+                       [{"b" _ #** d} d])))
+
+  (assert (= 1 (:or (dict :or 1)))))
+
+(defn test-match-objects []
+
+  (defclass Foo []
+    (defn --init-- [self bar]
+      (setv self.bar bar))
+    (defn --repr-- [self]
+      f"Foo(bar={self.bar})")
+    (defn --eq-- [self other]
+      (and (= Foo (type other))
+           (= self.bar other.bar))))
+
+  (assert (= 3 (match (Foo 3)
+                 [(Foo :bar (:as (:or 1 2 3) x)) x])))
+
+  (assert (= [1 (Foo 3)] (match {"a" 1 "b" (Foo 3)}
+                           [{"a" a "b" (:as (Foo :bar x) b)}
+                            :if (= x 3)
+                            [a b]]))))
+
+(defn test-errors []
+  (with [(pytest.raises hy.errors.HySyntaxError)]
+    (match 1
+      [(:as (:or 1 2 3) (+ 1 1))
+       "here"]))
+  (with [(pytest.raises hy.errors.HySyntaxError)]
+    (match 1 [x x] 2))
+  (with [(pytest.raises hy.errors.HySyntaxError)]
+    (match [0 1 2] [(lfor i (range 3) i) :here])))

--- a/tests/native_tests/py3_10_only_pattern_matching.hy
+++ b/tests/native_tests/py3_10_only_pattern_matching.hy
@@ -2,6 +2,9 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
+;; Tests where the emitted code relies on Python ≥3.10.
+;; conftest.py skips this file when running on Python <3.10.
+
 (import pytest)
 
 (defn test-match [capsys]


### PR DESCRIPTION
[Pattern matching](https://www.python.org/dev/peps/pep-0636/) has been added to Python 3.10.

I've added functions to the compiler to dispatch for the `match` special form and compile it to the correct `ast.Match*` nodes.

It seems to be fully functional, but there are a few edge cases with statements within patterns and guards. I'm not sure what the best way to deal with them would be. Currently it ignores any special forms in patterns, treating everything literally, and it discards any statements from guards. Both of these behaviours can lead to slightly weird results.

This is the syntax that I've implemented:
```hy
(match test-expression case1 ... caseN)
```
where each case is of the form
```hy
[pattern :if guard body]
```
where the `:if guard` is optional for each case and `body` can have many forms. Most patterns are specified in the same way as they would be in Python, and are fully composable. The exceptions are the or and as patterns, which are specified as
```hy
(:or pattern1 ... patternN)
(:as pattern name)
```
Objects are matched in the same way as in Python with normal function calls.

Here are a few examples from the PEP tutorial translated to hy:
```py
match point:
    case Point(x, y) if x == y:
        print(f"Y=X at {x}")
    case Point(x, y):
        print(f"Not on the diagonal")
```
```hy
(match point
  [(Point x y) :if (= x y)
   (print f"Y=X at {x}")]
  [(Point x y)
   (print f"Not on the diagonal")])
```
```py
match event.get():
    case Click(position=(x, y)):
        handle_click_at(x, y)
    case KeyPress(key_name="Q") | Quit():
        game.quit()
    case KeyPress(key_name="up arrow"):
        game.go_north()
    ...
    case KeyPress():
        pass # Ignore other keystrokes
    case other_event:
        raise ValueError(f"Unrecognized event: {other_event}")
```
```hy
(match (.get event)
  [(Click :position [x y])
   (handle-click-at x y)]
  [(:or (KeyPress :key-name "Q") (Quit))
   (.quit game)]
  [(KeyPress :key-name "up arrow")
   (.go-north game)]
  ...
  [(KeyPress)
   (pass) ; Ignore other keystrokes
   ]
  [other-event
   (raise (ValueError f"Unrecognized even: {other-event}"))])
```

Note that astor doesn't seem to support Python 3.10, and, in particular, doesn't know what to do with `ast.Match`, so this breaks `hy2py` and `--spy`.

