### PR TITLE
Remove the dependency on astor for Pythons ≥ 3.9

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -62,6 +62,10 @@ Bug Fixes
 * Fixed Hy model objects sometimes not being in scope.
 * Fixed `doc` sometimes failing to find builtin macros.
 
+Misc. Improvements
+------------------------------
+* The library `astor` is no longer required on Pythons ≥ 3.9.
+
 0.20.0 (released 2021-01-25)
 ==============================
 

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -764,7 +764,7 @@ def hy2py_main():
         _ast = hy_compile(hst, '__main__', filename=filename, source=source)
 
     if options.with_ast:
-        _print_for_windows(astor.dump_tree(_ast))
+        _print_for_windows(ast.dump(_ast))
         print()
         print()
 

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -24,8 +24,6 @@ import hashlib
 import codeop
 import builtins
 
-import astor.code_gen
-
 import hy
 
 from hy.lex import hy_parse, mangle
@@ -39,6 +37,7 @@ from hy.importer import runhy, HyLoader
 from hy.completer import completion, Completer
 from hy.macros import macro, require
 from hy.models import HyExpression, HyString, HySymbol
+from hy._compat import ast_unparse
 
 
 sys.last_type = None
@@ -311,7 +310,7 @@ class HyREPL(code.InteractiveConsole, object):
                 new_ast = ast.Module(
                     exec_ast.body + ([] if eval_ast is None else [ast.Expr(eval_ast.body)]),
                     type_ignores=[])
-                print(astor.to_source(new_ast))
+                print(ast_unparse(new_ast))
             except Exception:
                 msg = 'Exception in AST callback:\n{}\n'.format(
                     traceback.format_exc())
@@ -770,7 +769,7 @@ def hy2py_main():
         print()
 
     if not options.without_python:
-        _print_for_windows(astor.code_gen.to_source(_ast))
+        _print_for_windows(ast_unparse(_ast))
 
     parser.exit(0)
 

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -729,8 +729,6 @@ def hyc_main():
 
 # entry point for cmd line script "hy2py"
 def hy2py_main():
-    import platform
-
     options = dict(prog="hy2py", usage="%(prog)s [options] [FILE]",
                    formatter_class=argparse.RawDescriptionHelpFormatter)
     parser = argparse.ArgumentParser(**options)
@@ -759,16 +757,7 @@ def hy2py_main():
         hst = hy_parse(source, filename=filename)
 
     if options.with_source:
-        # need special printing on Windows in case the
-        # codepage doesn't support utf-8 characters
-        if platform.system() == "Windows":
-            for h in hst:
-                try:
-                    print(h)
-                except:
-                    print(str(h).encode('utf-8'))
-        else:
-            print(hst)
+        _print_for_windows(hst)
         print()
         print()
 
@@ -776,18 +765,12 @@ def hy2py_main():
         _ast = hy_compile(hst, '__main__', filename=filename, source=source)
 
     if options.with_ast:
-        if platform.system() == "Windows":
-            _print_for_windows(astor.dump_tree(_ast))
-        else:
-            print(astor.dump_tree(_ast))
+        _print_for_windows(astor.dump_tree(_ast))
         print()
         print()
 
     if not options.without_python:
-        if platform.system() == "Windows":
-            _print_for_windows(astor.code_gen.to_source(_ast))
-        else:
-            print(astor.code_gen.to_source(_ast))
+        _print_for_windows(astor.code_gen.to_source(_ast))
 
     parser.exit(0)
 
@@ -795,11 +778,15 @@ def hy2py_main():
 # need special printing on Windows in case the
 # codepage doesn't support utf-8 characters
 def _print_for_windows(src):
-    for line in src.split("\n"):
-        try:
-            print(line)
-        except:
-            print(line.encode('utf-8'))
+    import platform
+    if platform.system() == "Windows":
+        for line in src.split("\n"):
+            try:
+                print(line)
+            except:
+                print(line.encode('utf-8'))
+    else:
+        print(src)
 
 # remove PYTHON* environment variables,
 # such as "PYTHONPATH"

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -226,13 +226,12 @@
        => (disassemble '(print \"Hello World!\") True)
        print('Hello World!')
   "
-  (import astor)
-  (import hy.compiler)
+  (import ast hy.compiler hy._compat)
 
   (setv compiled (hy.compiler.hy-compile tree (calling-module-name) :import-stdlib False))
   ((if codegen
-       astor.code-gen.to-source
-       astor.dump-tree)
+       hy._compat.ast-unparse
+       ast.dump)
     compiled))
 
 (defn distinct [coll]

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -229,10 +229,13 @@
   (import ast hy.compiler hy._compat)
 
   (setv compiled (hy.compiler.hy-compile tree (calling-module-name) :import-stdlib False))
-  ((if codegen
-       hy._compat.ast-unparse
-       ast.dump)
-    compiled))
+  (if
+    codegen
+      (hy._compat.ast-unparse compiled)
+    hy._compat.PY3_9
+      (ast.dump compiled :indent 1)
+    True
+      (ast.dump compiled)))
 
 (defn distinct [coll]
   "Return a generator from the original collection `coll` with no duplicates.

--- a/setup.py
+++ b/setup.py
@@ -63,9 +63,10 @@ class Install(install):
 
 install_requires = [
     'rply>=0.7.7',
-    'astor>=0.8',
     'funcparserlib>=0.3.6',
     'colorama']
+if sys.version_info < (3, 9):
+    install_requires.append('astor>=0.8')
 if os.name == 'nt':
     install_requires.append('pyreadline>=2.1')
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1576,19 +1576,18 @@ cee\"} dee" "ey bee\ncee dee"))
 
 (defn test-disassemble []
   "NATIVE: Test the disassemble function"
-  (assert (= (disassemble '(do (leaky) (leaky) (macros)))
-    (.format "Module(
-    body=[Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),
-        Expr(value=Call(func=Name(id='leaky'), args=[], keywords=[])),
-        Expr(value=Call(func=Name(id='macros'), args=[], keywords=[]))]{})"
-      (if PY3_8 ",\n    type_ignores=[]" ""))))
-  (assert (= (disassemble '(do (leaky) (leaky) (macros)) True)
-             "leaky()
-leaky()
-macros()
-"))
-  (assert (= (re.sub r"[() ]" "" (disassemble `(+ ~(+ 1 1) 40) True))
-             "2+40\n")))
+  (defn nos [x] (re.sub r"\s" "" x))
+  (assert (= (nos (disassemble '(do (leaky) (leaky) (macros))))
+    (nos (.format
+      "Module(
+          body=[Expr(value=Call(func=Name(id='leaky', ctx=Load()), args=[], keywords=[])),
+              Expr(value=Call(func=Name(id='leaky', ctx=Load()), args=[], keywords=[])),
+              Expr(value=Call(func=Name(id='macros', ctx=Load()), args=[], keywords=[]))]{})"
+      (if PY3_8 ",type_ignores=[]" "")))))
+  (assert (= (nos (disassemble '(do (leaky) (leaky) (macros)) True))
+             "leaky()leaky()macros()"))
+  (assert (= (re.sub r"[()\n ]" "" (disassemble `(+ ~(+ 1 1) 40) True))
+             "2+40")))
 
 
 (defn test-attribute-access []

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -152,9 +152,9 @@
 
 (defn test-gensym-in-macros []
   (import ast)
-  (import [astor.code-gen [to-source]])
   (import [hy.compiler [hy-compile]])
   (import [hy.lex [hy-parse]])
+  (import [hy._compat [ast-unparse]])
   (setv macro1 "(defmacro nif [expr pos zero neg]
       (setv g (gensym))
       `(do
@@ -169,8 +169,8 @@
   ;; gensym each time
   (setv _ast1 (hy-compile (hy-parse macro1) __name__))
   (setv _ast2 (hy-compile (hy-parse macro1) __name__))
-  (setv s1 (to_source _ast1))
-  (setv s2 (to_source _ast2))
+  (setv s1 (ast-unparse _ast1))
+  (setv s2 (ast-unparse _ast2))
   ;; and make sure there is something new that starts with _G\uffff
   (assert (in (mangle "_G\uffff") s1))
   (assert (in (mangle "_G\uffff") s2))
@@ -179,9 +179,9 @@
 
 (defn test-with-gensym []
   (import ast)
-  (import [astor.code-gen [to-source]])
   (import [hy.compiler [hy-compile]])
   (import [hy.lex [hy-parse]])
+  (import [hy._compat [ast-unparse]])
   (setv macro1 "(defmacro nif [expr pos zero neg]
       (with-gensyms [a]
         `(do
@@ -196,17 +196,17 @@
   ;; gensym each time
   (setv _ast1 (hy-compile (hy-parse macro1) __name__))
   (setv _ast2 (hy-compile (hy-parse macro1) __name__))
-  (setv s1 (to_source _ast1))
-  (setv s2 (to_source _ast2))
+  (setv s1 (ast-unparse _ast1))
+  (setv s2 (ast-unparse _ast2))
   (assert (in (mangle "_a\uffff") s1))
   (assert (in (mangle "_a\uffff") s2))
   (assert (not (= s1 s2))))
 
 (defn test-defmacro/g! []
   (import ast)
-  (import [astor.code-gen [to-source]])
   (import [hy.compiler [hy-compile]])
   (import [hy.lex [hy-parse]])
+  (import [hy._compat [ast-unparse]])
   (setv macro1 "(defmacro/g! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
@@ -220,8 +220,8 @@
   ;; gensym each time
   (setv _ast1 (hy-compile (hy-parse macro1) __name__))
   (setv _ast2 (hy-compile (hy-parse macro1) __name__))
-  (setv s1 (to_source _ast1))
-  (setv s2 (to_source _ast2))
+  (setv s1 (ast-unparse _ast1))
+  (setv s2 (ast-unparse _ast2))
   (assert (in (mangle "_res\uffff") s1))
   (assert (in (mangle "_res\uffff") s2))
   (assert (not (= s1 s2)))
@@ -234,9 +234,9 @@
 (defn test-defmacro! []
   ;; defmacro! must do everything defmacro/g! can
   (import ast)
-  (import [astor.code-gen [to-source]])
   (import [hy.compiler [hy-compile]])
   (import [hy.lex [hy-parse]])
+  (import [hy._compat [ast-unparse]])
   (setv macro1 "(defmacro! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
@@ -250,8 +250,8 @@
   ;; gensym each time
   (setv _ast1 (hy-compile (hy-parse macro1) __name__))
   (setv _ast2 (hy-compile (hy-parse macro1) __name__))
-  (setv s1 (to_source _ast1))
-  (setv s2 (to_source _ast2))
+  (setv s1 (ast-unparse _ast1))
+  (setv s2 (ast-unparse _ast2))
   (assert (in (mangle "_res\uffff") s1))
   (assert (in (mangle "_res\uffff") s2))
   (assert (not (= s1 s2)))


### PR DESCRIPTION
Python 3.9 added `ast.unparse`, which can do most of the work. It has some bugs that I fixed in `astor`, which I've worked around here, but I've submitted a patch to CPython to fix them for real (python/cpython#24897).