### PR TITLE
Fixed relative import for `require` and added tests

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -61,6 +61,7 @@ Bug Fixes
 * Fixed namespace pollution caused by automatic imports of Hy builtins and macros.
 * Fixed Hy model objects sometimes not being in scope.
 * Fixed `doc` sometimes failing to find builtin macros.
+* `require` now works with relative imports.
 
 Misc. Improvements
 ------------------------------

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -152,7 +152,17 @@ def require(source_module, target_module, assignments, prefix=""):
 
     if not inspect.ismodule(source_module):
         try:
-            source_module = importlib.import_module(source_module)
+            if source_module.startswith("."):
+                source_dirs = source_module.split(".")
+                target_dirs = (getattr(target_module, "__name__", target_module)
+                               .split("."))
+                while source_dirs and target_dirs and source_dirs[0] == "":
+                    source_dirs.pop(0)
+                    target_dirs.pop()
+                package = ".".join(target_dirs + source_dirs[:-1])
+            else:
+                package = None
+            source_module = importlib.import_module(source_module, package)
         except ImportError as e:
             reraise(HyRequireError, HyRequireError(e.args[0]), None)
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1478,6 +1478,13 @@ cee\"} dee" "ey bee\ncee dee"))
   (rev (.append x 1) (.append x 2) (.append x 3))
   (assert (= x [3 2 1])))
 
+(defn test-relative-require []
+  (require [..resources.macros [nonlocal-test-macro]])
+  (assert (in "nonlocal_test_macro" __macros__))
+
+  (require [.native-macros [rev]])
+  (assert (in "rev" __macros__)))
+
 
 (defn test-encoding-nightmares []
   "NATIVE: test unicode encoding escaping crazybits"


### PR DESCRIPTION
Fixes #1897.

I started with of with @jams2's patch, but that didn't allow for multiple "." in the source module. This should work with any valid relative path.