### PR TITLE
Rename `defn` to `def` and `defclass` to `class`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -17,6 +17,8 @@ Removals
 
 Breaking Changes
 ------------------------------
+* `defn` has been renamed to `def`.
+* `defclass` has been renamed to `class`.
 * f-strings are now parsed as a separate `HyFString` node,
   which is a collection of `HyString` and `HyFComponent` nodes.
 * Calling a `HyKeyword`  now looks up by its (string) name instead by its self.


### PR DESCRIPTION
I haven't actually made the changes yet. I opened this PR to check for sufficient agreement before I forge ahead.

Anyway, I'm thinking this is a good time to do this because then `defn` will get renamed to `def` and lambda lists will change in the same release, so users can use which keyword is used in a Hy program as a hint as to whether the code has been updated.