### PR TITLE
Allow expressions such as `(require [hy.contrib [walk]])`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -61,7 +61,8 @@ Bug Fixes
 * Fixed namespace pollution caused by automatic imports of Hy builtins and macros.
 * Fixed Hy model objects sometimes not being in scope.
 * Fixed `doc` sometimes failing to find builtin macros.
-* `require` now works with relative imports.
+* `require` now works with relative imports and can import modules, such as
+  `(require [hy.contrib [walk]])`.
 
 Misc. Improvements
 ------------------------------

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1463,7 +1463,14 @@ cee\"} dee" "ey bee\ncee dee"))
   (require [tests.resources.tlib [*]])
   (assert (= (parald 1 2 3) [9 1 2 3]))
   (assert (= (✈ "silly") "plane silly"))
-  (assert (= (hyx_XairplaneX "foolish") "plane foolish")))
+  (assert (= (hyx_XairplaneX "foolish") "plane foolish"))
+
+  (require [tests.resources [tlib macros :as m]])
+  (assert (in "tlib.qplah" __macros__))
+  (assert (in (mangle "m.test-macro") __macros__))
+  (require [os [path]])
+  (with [(pytest.raises hy.errors.HyRequireError)]
+    (hy.eval '(require [tests.resources [does-not-exist]]))))
 
 
 (defn test-require-native []
@@ -1479,11 +1486,14 @@ cee\"} dee" "ey bee\ncee dee"))
   (assert (= x [3 2 1])))
 
 (defn test-relative-require []
-  (require [..resources.macros [nonlocal-test-macro]])
-  (assert (in "nonlocal_test_macro" __macros__))
+  (require [..resources.macros [test-macro]])
+  (assert (in "test_macro" __macros__))
 
   (require [.native-macros [rev]])
-  (assert (in "rev" __macros__)))
+  (assert (in "rev" __macros__))
+
+  (require [. [native-macros :as m]])
+  (assert (in "m.rev" __macros__)))
 
 
 (defn test-encoding-nightmares []


### PR DESCRIPTION
Fixes #2016.

Also gets rid of error `HyRequireError` when requiring a module with no macros, since previously this behavior was inconsistent and I don't see why this should be an error. So previously
```hy
i => (require os.path)
i => (require [os [path]])
Traceback (most recent call last):
  File "stdin-08ce82c15e0a77ce6e17125ffa2f87a3fbdcd4df", line 1, in <module>
    (require [os [path]])
hy.errors.HyRequireError: The module <module 'os' from '/usr/lib/python3.9/os.py'> has no macros or tags
```
But now the second will also not throw an error.