### PR TITLE
Fix `exec_module` usage

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -246,7 +246,9 @@ class HyREPL(code.InteractiveConsole, object):
         if os.environ.get("HYSTARTUP"):
             try:
                 loader = HyLoader("__hystartup__", os.environ.get("HYSTARTUP"))
-                mod = loader.exec_module()
+                spec = importlib.util.spec_from_loader(loader.name, loader)
+                mod = importlib.util.module_from_spec(spec)
+                loader.exec_module(mod)
                 imports = mod.__dict__.get(
                     '__all__',
                     [name for name in mod.__dict__ if not name.startswith("_")]

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -61,15 +61,13 @@ def test_stringer():
 def test_imports():
     path = os.getcwd() + "/tests/resources/importer/a.hy"
     testLoader = HyLoader("tests.resources.importer.a", path)
+    spec = importlib.util.spec_from_loader(testLoader.name, testLoader)
+    mod = importlib.util.module_from_spec(spec)
 
-    def _import_test():
-        try:
-            return testLoader.exec_module()
-        except:
-            return "Error"
+    with pytest.raises(NameError) as excinfo:
+        testLoader.exec_module(mod)
 
-    assert _import_test() == "Error"
-    assert _import_test() is not None
+    assert "thisshouldnotwork" in excinfo.value.args[0]
 
 
 def test_import_error_reporting():


### PR DESCRIPTION
Turns out `exec_module` requires the module be supplied as an argument; this broke HYSTARTUP after #1989.
Also fixes a test that was incorrectly passing.
