### PR TITLE
Rename hy model types

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -36,6 +36,10 @@ Breaking Changes
   check the docs or use ``(doc defn)`` at the repl for more details.
 * `mangle` no longer converts leading hyphens to underscores, and
   `unmangle` no longer converts leading underscores to hyphens.
+* Hy models have been renamed to exclude `Hy` from their names. They are no
+  longer autoimported and must be accessed through the `hy.models`
+  namespace. `repr` reflects these changes, so, for example, `HyList` will now
+  show up as `hy.models.List`.
 
 New Features
 ------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -740,9 +740,9 @@ Special Forms
 
        => (setv x '(print "Hello World"))
        => x  ; variable x is set to unevaluated expression
-       HyExpression([
-         HySymbol('print'),
-         HyString('Hello World')])
+       hy.models.Expression([
+         hy.models.Symbol('print'),
+         hy.models.String('Hello World')])
        => (hy.eval x)
        Hello World
 
@@ -1001,14 +1001,14 @@ Special Forms
 
        => (setv nickname "Cuddles")
        => (quasiquote (= nickname (unquote nickname)))
-       HyExpression([
-         HySymbol('='),
-         HySymbol('nickname'),
+       hy.models.Expression([
+         hy.models.Symbol('='),
+         hy.models.Symbol('nickname'),
          'Cuddles'])
        => `(= nickname ~nickname)
-       HyExpression([
-         HySymbol('='),
-         HySymbol('nickname'),
+       hy.models.Expression([
+         hy.models.Symbol('='),
+         hy.models.Symbol('nickname'),
          'Cuddles'])
 
 
@@ -1026,23 +1026,23 @@ Special Forms
 
        => (setv nums [1 2 3 4])
        => (quasiquote (+ (unquote-splice nums)))
-       HyExpression([
-         HySymbol('+'),
+       hy.models.Expression([
+         hy.models.Symbol('+'),
          1,
          2,
          3,
          4])
        => `(+ ~@nums)
-       HyExpression([
-         HySymbol('+'),
+       hy.models.Expression([
+         hy.models.Symbol('+'),
          1,
          2,
          3,
          4])
        => `[1 2 ~@(if (neg? (first nums)) nums)]
-       HyList([
-         HyInteger(1),
-         HyInteger(2)])
+       hy.models.List([
+         hy.models.Integer(1),
+         hy.models.Integer(2)])
 
    Here, the last example evaluates to ``('+' 1 2)``, since the condition
    ``(< (nth nums 0) 0)`` is ``False``, which makes this ``if`` expression

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -17,20 +17,20 @@ Hy models are a very thin layer on top of regular Python objects,
 representing Hy source code as data. Models only add source position
 information, and a handful of methods to support clean manipulation of
 Hy source code, for instance in macros. To achieve that goal, Hy models
-are mixins of a base Python class and :ref:`HyObject`.
+are mixins of a base Python class and :ref:`Object`.
 
 .. _hyobject:
 
-HyObject
+Object
 ~~~~~~~~
 
-``hy.models.HyObject`` is the base class of Hy models. It only
+``hy.models.Object`` is the base class of Hy models. It only
 implements one method, ``replace``, which replaces the source position
 of the current object with the one passed as argument. This allows us to
 keep track of the original position of expressions that get modified by
 macros, be that in the compiler or in pure hy macros.
 
-``HyObject`` is not intended to be used directly to instantiate Hy
+``Object`` is not intended to be used directly to instantiate Hy
 models, but only as a mixin for other classes.
 
 Compound Models
@@ -50,37 +50,37 @@ respectively, to ``False``.
 
 .. _hysequence:
 
-HySequence
+Sequence
 ~~~~~~~~~~
 
-``hy.models.HySequence`` is the abstract base class of "iterable" Hy
-models, such as HyExpression and HyList.
+``hy.models.Sequence`` is the abstract base class of "iterable" Hy
+models, such as hy.models.Expression and hy.models.List.
 
-Adding a HySequence to another iterable object reuses the class of the
+Adding a Sequence to another iterable object reuses the class of the
 left-hand-side object, a useful behavior when you want to concatenate Hy
 objects in a macro, for instance.
 
-HySequences are (mostly) immutable: you can't add, modify, or remove
-elements. You can still append to a variable containing a HySequence with
-``+=`` and otherwise construct new HySequences out of old ones.
+Sequences are (mostly) immutable: you can't add, modify, or remove
+elements. You can still append to a variable containing a Sequence with
+``+=`` and otherwise construct new Sequences out of old ones.
 
 
 .. _hylist:
 
-HyList
+List
 ~~~~~~
 
-``hy.models.HyList`` is a :ref:`HySequence` for bracketed ``[]``
+``hy.models.List`` is a :ref:`Sequence` for bracketed ``[]``
 lists, which, when used as a top-level expression, translate to Python
 list literals in the compilation phase.
 
 
 .. _hyexpression:
 
-HyExpression
+Expression
 ~~~~~~~~~~~~
 
-``hy.models.HyExpression`` inherits :ref:`HySequence` for
+``hy.models.Expression`` inherits :ref:`Sequence` for
 parenthesized ``()`` expressions. The compilation result of those
 expressions depends on the first element of the list: the compiler
 dispatches expressions between compiler special-forms, user-defined
@@ -88,10 +88,10 @@ macros, and regular Python function calls.
 
 .. _hydict:
 
-HyDict
+Dict
 ~~~~~~
 
-``hy.models.HyDict`` inherits :ref:`HySequence` for curly-bracketed
+``hy.models.Dict`` inherits :ref:`Sequence` for curly-bracketed
 ``{}`` expressions, which compile down to a Python dictionary literal.
 
 Atomic Models
@@ -99,7 +99,7 @@ Atomic Models
 
 In the input stream, double-quoted strings, respecting the Python
 notation for strings, are parsed as a single token, which is directly
-parsed as a :ref:`HyString`.
+parsed as a :ref:`String`.
 
 An uninterrupted string of characters, excluding spaces, brackets,
 quotes, double-quotes and comments, is parsed as an identifier.
@@ -107,36 +107,36 @@ quotes, double-quotes and comments, is parsed as an identifier.
 Identifiers are resolved to atomic models during the parsing phase in
 the following order:
 
- - :ref:`HyInteger <hy_numeric_models>`
- - :ref:`HyFloat <hy_numeric_models>`
- - :ref:`HyComplex <hy_numeric_models>` (if the atom isn't a bare ``j``)
- - :ref:`HyKeyword` (if the atom starts with ``:``)
- - :ref:`HySymbol`
+ - :ref:`Integer <hy_numeric_models>`
+ - :ref:`Float <hy_numeric_models>`
+ - :ref:`Complex <hy_numeric_models>` (if the atom isn't a bare ``j``)
+ - :ref:`Keyword` (if the atom starts with ``:``)
+ - :ref:`Symbol`
 
 .. _hystring:
 
-HyString
+String
 ~~~~~~~~
 
-``hy.models.HyString`` represents string literals (including bracket strings),
+``hy.models.String`` represents string literals (including bracket strings),
 which compile down to unicode string literals (``str``) in Python.
 
-``HyString``\s are immutable.
+``String``\s are immutable.
 
 Hy literal strings can span multiple lines, and are considered by the
 parser as a single unit, respecting the Python escapes for unicode
 strings.
 
-``HyString``\s have an attribute ``brackets`` that stores the custom
+``String``\s have an attribute ``brackets`` that stores the custom
 delimiter used for a bracket string (e.g., ``"=="`` for ``#[==[hello
 world]==]`` and the empty string for ``#[[hello world]]``).
-``HyString``\s that are not produced by bracket strings have their
+``String``\s that are not produced by bracket strings have their
 ``brackets`` set to ``None``.
 
-HyBytes
+Bytes
 ~~~~~~~
 
-``hy.models.HyBytes`` is like ``HyString``, but for sequences of bytes.
+``hy.models.Bytes`` is like ``String``, but for sequences of bytes.
 It inherits from ``bytes``.
 
 .. _hy_numeric_models:
@@ -144,23 +144,23 @@ It inherits from ``bytes``.
 Numeric Models
 ~~~~~~~~~~~~~~
 
-``hy.models.HyInteger`` represents integer literals, using the ``int``
+``hy.models.Integer`` represents integer literals, using the ``int``
 type.
 
-``hy.models.HyFloat`` represents floating-point literals.
+``hy.models.Float`` represents floating-point literals.
 
-``hy.models.HyComplex`` represents complex literals.
+``hy.models.Complex`` represents complex literals.
 
 Numeric models are parsed using the corresponding Python routine, and
 valid numeric python literals will be turned into their Hy counterpart.
 
 .. _hysymbol:
 
-HySymbol
+Symbol
 ~~~~~~~~
 
-``hy.models.HySymbol`` is the model used to represent symbols in the Hy
-language. Like ``HyString``, it inherits from ``str`` (or ``unicode`` on Python
+``hy.models.Symbol`` is the model used to represent symbols in the Hy
+language. Like ``String``, it inherits from ``str`` (or ``unicode`` on Python
 2).
 
 Symbols are :ref:`mangled <mangling>` when they are compiled
@@ -168,13 +168,13 @@ to Python variable names.
 
 .. _hykeyword:
 
-HyKeyword
+Keyword
 ~~~~~~~~~
 
-``hy.models.HyKeyword`` represents keywords in Hy. Keywords are
+``hy.models.Keyword`` represents keywords in Hy. Keywords are
 symbols starting with a ``:``. See :ref:`syntax-keywords`.
 
-The ``.name`` attribute of a ``hy.models.HyKeyword`` provides
+The ``.name`` attribute of a ``hy.models.Keyword`` provides
 the (:ref:`unmangled <mangling>`) string representation of the keyword without the initial ``:``.
 For example::
 
@@ -261,29 +261,29 @@ can build the ``type()`` that we have, and dispatch to the method that can
 handle it. If we don't have any methods that can build that type, we raise
 an internal ``Exception``.
 
-For instance, if we have a ``HyString``, we have an almost 1-to-1 mapping of
-Hy AST to Python AST. The ``compile_string`` method takes the ``HyString``, and
+For instance, if we have a ``String``, we have an almost 1-to-1 mapping of
+Hy AST to Python AST. The ``compile_string`` method takes the ``String``, and
 returns an ``ast.Str()`` that's populated with the correct line-numbers and
 content.
 
 Macro-Expand
 ~~~~~~~~~~~~
 
-If we get a ``HyExpression``, we'll attempt to see if this is a known
+If we get a ``Expression``, we'll attempt to see if this is a known
 Macro, and push to have it expanded by invoking ``hy.macros.macroexpand``, then
 push the result back into ``HyASTCompiler.compile``.
 
 Second Stage Expression-Dispatch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The only special case is the ``HyExpression``, since we need to create different
+The only special case is the ``Expression``, since we need to create different
 AST depending on the special form in question. For instance, when we hit an
 ``(if True True False)``, we need to generate a ``ast.If``, and properly
 compile the sub-nodes. This is where the ``@builds()`` with a String as an
 argument comes in.
 
 For the ``compile_expression`` (which is defined with an
-``@builds(HyExpression)``) will dispatch based on the string of the first
+``@builds(Expression)``) will dispatch based on the string of the first
 argument. If, for some reason, the first argument is not a string, it will
 properly handle that case as well (most likely by raising an ``Exception``).
 

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -125,7 +125,7 @@ That's not how to think of Lisp code; think tree structure, not delimiters.
           2]}
 
     ;; OK
-    ;; A string is an atom, not a HySequence.
+    ;; A string is an atom, not a Sequence.
     (foo "abc
       xyz")
 

--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -10,9 +10,6 @@ def _initialize_env_var(env_var, default_val):
     return bool(os.environ.get(env_var, default_val))
 
 
-from hy.models import HyExpression, HyInteger, HyKeyword, HyComplex, HyString, HyFString, HyFComponent, HyBytes, HySymbol, HyFloat, HyDict, HyList, HySet  # NOQA
-
-
 import hy.importer  # NOQA
 hy.importer._inject_builtins()
 # we import for side-effects.

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -36,7 +36,7 @@ from hy.errors import (HyLanguageError, HyRequireError, HyMacroExpansionError,
 from hy.importer import runhy, HyLoader
 from hy.completer import completion, Completer
 from hy.macros import macro, require
-from hy.models import HyExpression, HyString, HySymbol
+from hy.models import Expression, String, Symbol
 from hy._compat import ast_unparse
 
 
@@ -395,8 +395,8 @@ class HyREPL(code.InteractiveConsole, object):
 
 @macro("koan")
 def koan_macro(ETname):
-    return HyExpression([HySymbol('print'),
-                         HyString("""
+    return Expression([Symbol('print'),
+                       String("""
   Ummon asked the head monk, "What sutra are you lecturing on?"
   "The Nirvana Sutra."
   "The Nirvana Sutra has the Four Virtues, hasn't it?"
@@ -413,8 +413,8 @@ def koan_macro(ETname):
 
 @macro("ideas")
 def ideas_macro(ETname):
-    return HyExpression([HySymbol('print'),
-                         HyString(r"""
+    return Expression([Symbol('print'),
+                       String(r"""
 
     => (import [sh [figlet]])
     => (figlet "Hi, Hy!")

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1820,7 +1820,15 @@ class HyASTCompiler(object):
         ret = Result()
         ret += asty.Call(
             obj,
-            func=asty.Name(obj, id="HyKeyword", ctx=ast.Load()),
+            func=asty.Attribute(obj,
+                                value=asty.Attribute(
+                                    obj,
+                                    value=asty.Name(obj, id="hy", ctx=ast.Load()),
+                                    attr="models",
+                                    ctx=ast.Load()
+                                ),
+                                attr="Keyword",
+                                ctx=ast.Load()),
             args=[asty.Str(obj, s=obj.name)],
             keywords=[])
         return ret

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -218,10 +218,10 @@ Iterator patterns are specified using round brackets. They are the same as list 
       (.append gsyms dcoll))
     (f dcoll result found binds gsyms))
   (ifp instance? binds
-       HySymbol [binds expr]
-       HyDict (dispatch dest-dict)
-       HyExpression (dispatch dest-iter)
-       HyList (dispatch dest-list)
+       hy.models.Symbol [binds expr]
+       hy.models.Dict (dispatch dest-dict)
+       hy.models.Expression (dispatch dest-iter)
+       hy.models.List (dispatch dest-list)
        (raise (SyntaxError (+ "Malformed destructure. Unknown binding form: "
                              (repr binds))))))
 
@@ -251,7 +251,8 @@ Iterator patterns are specified using round brackets. They are the same as list 
   (defn expand-lookup [target key]
     [target `(.get ~ddict
                    ~(if (keyword? key) `(quote ~key) key)
-                   ~(if (isinstance target HySymbol) (.get default target)))])
+                   ~(if (isinstance target hy.models.Symbol)
+                        (.get default target)))])
   (defn get-as [to-key targets]
     (lfor t targets
           sym (expand-lookup t (to-key t))
@@ -262,7 +263,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
                  ':or []
                  ':as [lookup ddict]
                  ':strs (get-as str lookup)
-                 ':keys (get-as (comp HyKeyword unmangle) lookup)
+                 ':keys (get-as (comp hy.models.Keyword unmangle) lookup)
                  (destructure #* (expand-lookup target lookup) gsyms))))
        ((fn [xs] (reduce + xs result)))))
 
@@ -306,7 +307,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
         mres (lfor [m t] magics
                (ifp found m
                  ':as [t dlist]
-                 ':& (destructure t (if (instance? HyDict t)
+                 ':& (destructure t (if (instance? hy.models.Dict t)
                                       `(dict (partition (cut ~dlist ~n)))
                                       `(cut ~dlist ~n))
                                   gsyms)
@@ -344,7 +345,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
   (macroexpand
     `(setv+ ~actual (chain ~args
                           (lfor [k v] (.items ~kwargs)
-                                s [(HyKeyword k) v]
+                                s [(hy.models.Keyword k) v]
                             s)))))
 
 (defmacro/g! defn+ [fn-name args #* doc+body]

--- a/hy/contrib/hy_repr.hy
+++ b/hy/contrib/hy_repr.hy
@@ -93,7 +93,8 @@ To make the Hy REPL use it for output, invoke Hy like so::
 
   (global _quoting)
   (setv started-quoting False)
-  (when (and (not _quoting) (instance? HyObject obj) (not (instance? HyKeyword obj)))
+  (when (and (not _quoting) (instance? hy.models.Object obj)
+             (not (instance? hy.models.Keyword obj)))
     (setv _quoting True)
     (setv started-quoting True))
 
@@ -124,14 +125,14 @@ To make the Hy REPL use it for output, invoke Hy like so::
     [k v] (.items x)
     (+ (hy-repr k) " " (hy-repr v)))))
   (+ "{" text "}")))
-(hy-repr-register HyDict :placeholder "{...}" (fn [x]
+(hy-repr-register hy.models.Dict :placeholder "{...}" (fn [x]
   (setv text (.join "  " (gfor
     [k v] (partition x)
     (+ (hy-repr k) " " (hy-repr v)))))
   (if (% (len x) 2)
     (+= text (+ "  " (hy-repr (get x -1)))))
   (+ "{" text "}")))
-(hy-repr-register HyExpression (fn [x]
+(hy-repr-register hy.models.Expression (fn [x]
   (setv syntax {
     'quote "'"
     'quasiquote "`"
@@ -143,7 +144,7 @@ To make the Hy REPL use it for output, invoke Hy like so::
     (+ (get syntax (first x)) (hy-repr (second x)))
     (+ "(" (_cat x) ")"))))
 
-(hy-repr-register [HySymbol HyKeyword] str)
+(hy-repr-register [hy.models.Symbol hy.models.Keyword] str)
 (hy-repr-register [str bytes] (fn [x]
   (setv r (.lstrip (_base-repr x) "ub"))
   (+
@@ -204,8 +205,8 @@ To make the Hy REPL use it for output, invoke Hy like so::
     (hy-repr (dict x)))))
 
 (for [[types fmt] (partition [
-    [list HyList] "[...]"
-    [set HySet] "#{...}"
+    [list hy.models.List] "[...]"
+    [set hy.models.Set] "#{...}"
     frozenset "(frozenset #{...})"
     dict-keys "(dict-keys [...])"
     dict-values "(dict-values [...])"
@@ -218,13 +219,13 @@ To make the Hy REPL use it for output, invoke Hy like so::
   (.join " " (map hy-repr obj)))
 
 (defn _base-repr [x]
-  (unless (instance? HyObject x)
+  (unless (instance? hy.models.Object x)
     (return (repr x)))
   ; Call (.repr x) using the first class of x that doesn't inherit from
-  ; HyObject.
+  ; hy.models.Object.
   (.__repr__
     (next (gfor
       t (. (type x) __mro__)
-      :if (not (issubclass t HyObject))
+      :if (not (issubclass t hy.models.Object))
       t))
     x))

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -71,7 +71,7 @@ tail-call optimization (TCO) in their Hy code.
 
 
 (defmacro defnr [name lambda-list #* body]
-  (if (not (= (type name) HySymbol))
+  (if (not (= (type name) hy.models.Symbol))
     (macro-error name "defnr takes a name as first argument"))
   `(do (require hy.contrib.loop)
        (setv ~name (hy.contrib.loop.fnr ~lambda-list ~@body))))

--- a/hy/contrib/slicing.hy
+++ b/hy/contrib/slicing.hy
@@ -38,13 +38,14 @@ or more manually using the tag macro as::
 
   (defn parse-indexing [sym]
     (if
-      (and (isinstance sym HyExpression) (= (get sym 0) :))
+      (and (isinstance sym hy.models.Expression) (= (get sym 0) :))
       `(slice ~@(cut sym 1))
 
       (and (symbol? sym) (= sym '...))
       'Ellipsis
 
-      (and (isinstance sym (, HyKeyword HySymbol)) (in ":" (str sym)))
+      (and (isinstance sym (, hy.models.Keyword hy.models.Symbol))
+           (in ":" (str sym)))
       (try `(slice ~@(parse-colon sym)) (except [ValueError] sym))
 
       sym)))
@@ -193,5 +194,5 @@ or more manually using the tag macro as::
        => #:(\"colname\" 1 2)
        (slice \"colname\" 1 2)
   "
-  (if (isinstance key HyExpression) (parse-indexing `(: ~@key))
+  (if (isinstance key hy.models.Expression) (parse-indexing `(: ~@key))
       (parse-indexing key)))

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -25,7 +25,7 @@
        => (import [hy.contrib.walk [walk]])
        => (setv a '(a b c d e f))
        => (walk ord identity a)
-       HyExpression([
+       hy.models.Expression([
          97,
          98,
          99,
@@ -39,10 +39,10 @@
        97
   "
   (cond
-   [(instance? HyExpression form)
-    (outer (HyExpression (map inner form)))]
-   [(or (instance? HySequence form) (list? form))
-    ((type form) (outer (HyExpression (map inner form))))]
+   [(instance? hy.models.Expression form)
+    (outer (hy.models.Expression (map inner form)))]
+   [(or (instance? hy.models.Sequence form) (list? form))
+    ((type form) (outer (hy.models.Expression (map inner form))))]
    [(coll? form)
     (walk inner outer (list form))]
    [True (outer form)]))
@@ -67,10 +67,10 @@
        Walking
        3
        Walking
-       HyExpression([
-         HyInteger(1),
-         HyInteger(2),
-         HyInteger(3)])
+       hy.models.Expression([
+         hy.models.Integer(1),
+         hy.models.Integer(2),
+         hy.models.Integer(3)])
        Walking
        4
        Walking
@@ -80,47 +80,47 @@
        Walking
        7
        Walking
-       HyExpression([
-         HyInteger(7)])
+       hy.models.Expression([
+         hy.models.Integer(7)])
        Walking
-       HyExpression([
-         HyInteger(5),
-         HyInteger(6),
-         HyList([
-           HyInteger(7)])])
+       hy.models.Expression([
+         hy.models.Integer(5),
+         hy.models.Integer(6),
+         hy.models.List([
+           hy.models.Integer(7)])])
        Walking
-       HyExpression([
-         HyInteger(4),
-         HyList([
-           HyInteger(5),
-           HyInteger(6),
-           HyList([
-             HyInteger(7)])])])
+       hy.models.Expression([
+         hy.models.Integer(4),
+         hy.models.List([
+           hy.models.Integer(5),
+           hy.models.Integer(6),
+           hy.models.List([
+             hy.models.Integer(7)])])])
        Walking
-       HyExpression([
-         HyList([
-           HyInteger(1),
-           HyInteger(2),
-           HyInteger(3)]),
-         HyList([
-           HyInteger(4),
-           HyList([
-             HyInteger(5),
-             HyInteger(6),
-             HyList([
-               HyInteger(7)])])])])
-       HyExpression([
-         HyList([
-           HyInteger(1),
-           HyInteger(2),
-           HyInteger(3)]),
-         HyList([
-           HyInteger(4),
-           HyList([
-             HyInteger(5),
-             HyInteger(6),
-             HyList([
-               HyInteger(7)])])])])
+       hy.models.Expression([
+         hy.models.List([
+           hy.models.Integer(1),
+           hy.models.Integer(2),
+           hy.models.Integer(3)]),
+         hy.models.List([
+           hy.models.Integer(4),
+           hy.models.List([
+             hy.models.Integer(5),
+             hy.models.Integer(6),
+             hy.models.List([
+               hy.models.Integer(7)])])])])
+       hy.models.Expression([
+         hy.models.List([
+           hy.models.Integer(1),
+           hy.models.Integer(2),
+           hy.models.Integer(3)]),
+         hy.models.List([
+           hy.models.Integer(4),
+           hy.models.List([
+             hy.models.Integer(5),
+             hy.models.Integer(6),
+             hy.models.List([
+               hy.models.Integer(7)])])])])
   "
   (walk (partial postwalk f) f form))
 
@@ -138,23 +138,23 @@
        ...  x)
        => (prewalk walking trail)
        Walking
-       HyExpression([
-         HyList([
-           HyInteger(1),
-           HyInteger(2),
-           HyInteger(3)]),
-         HyList([
-           HyInteger(4),
-           HyList([
-             HyInteger(5),
-             HyInteger(6),
-             HyList([
-               HyInteger(7)])])])])
+       hy.models.Expression([
+         hy.models.List([
+           hy.models.Integer(1),
+           hy.models.Integer(2),
+           hy.models.Integer(3)]),
+         hy.models.List([
+           hy.models.Integer(4),
+           hy.models.List([
+             hy.models.Integer(5),
+             hy.models.Integer(6),
+             hy.models.List([
+               hy.models.Integer(7)])])])])
        Walking
-       HyList([
-         HyInteger(1),
-         HyInteger(2),
-         HyInteger(3)])
+       hy.models.List([
+         hy.models.Integer(1),
+         hy.models.Integer(2),
+         hy.models.Integer(3)])
        Walking
        1
        Walking
@@ -162,48 +162,48 @@
        Walking
        3
        Walking
-       HyList([
-         HyInteger(4),
-         HyList([
-           HyInteger(5),
-           HyInteger(6),
-           HyList([
-             HyInteger(7)])])])
+       hy.models.List([
+         hy.models.Integer(4),
+         hy.models.List([
+           hy.models.Integer(5),
+           hy.models.Integer(6),
+           hy.models.List([
+             hy.models.Integer(7)])])])
        Walking
        4
        Walking
-       HyList([
-         HyInteger(5),
-         HyInteger(6),
-         HyList([
-           HyInteger(7)])])
+       hy.models.List([
+         hy.models.Integer(5),
+         hy.models.Integer(6),
+         hy.models.List([
+           hy.models.Integer(7)])])
        Walking
        5
        Walking
        6
        Walking
-       HyList([
-         HyInteger(7)])
+       hy.models.List([
+         hy.models.Integer(7)])
        Walking
        7
-       HyExpression([
-         HyList([
-           HyInteger(1),
-           HyInteger(2),
-           HyInteger(3)]),
-         HyList([
-           HyInteger(4),
-           HyList([
-             HyInteger(5),
-             HyInteger(6),
-             HyList([
-               HyInteger(7)])])])])
+       hy.models.Expression([
+         hy.models.List([
+           hy.models.Integer(1),
+           hy.models.Integer(2),
+           hy.models.Integer(3)]),
+         hy.models.List([
+           hy.models.Integer(4),
+           hy.models.List([
+             hy.models.Integer(5),
+             hy.models.Integer(6),
+             hy.models.List([
+               hy.models.Integer(7)])])])])
   "
   (walk (partial prewalk f) identity (f form)))
 
 (defn call? [form]
-  "Checks whether form is a non-empty HyExpression"
-  (and (instance? HyExpression form)
+  "Checks whether form is a non-empty hy.models.Expression"
+  (and (instance? hy.models.Expression form)
        form))
 
 (defn macroexpand-all [form [module-name None]]
@@ -237,7 +237,7 @@
                      [True (traverse form)])]
               [(= (first form) 'quote) form]
               [(= (first form) 'quasiquote) (+quote)]
-              [(= (first form) (HySymbol "require"))
+              [(= (first form) (hy.models.Symbol "require"))
                (ast-compiler.compile form)
                (return)]
               [True (traverse (mexpand form module ast-compiler))])
@@ -257,7 +257,8 @@
   "
   (setv headers ['unpack-iterable '* 'unpack-mapping]
         sections (OrderedDict [(, None [])])
-        vararg-types {'unpack-iterable (HySymbol "#*") 'unpack-mapping (HySymbol "#**")}
+        vararg-types {'unpack-iterable (hy.models.Symbol "#*")
+                      'unpack-mapping (hy.models.Symbol "#**")}
         header None)
   (for [arg form]
     (if
@@ -267,7 +268,7 @@
           ;; Don't use a header more than once. It's the compiler's problem.
           (.remove headers header))
 
-      (and (isinstance arg HyExpression) (in (first arg) headers))
+      (and (isinstance arg hy.models.Expression) (in (first arg) headers))
       (do (setv header (first arg))
           (assoc sections header [])
           ;; Don't use a header more than once. It's the compiler's problem.
@@ -380,7 +381,7 @@
 
   ;; convert dotted names to the standard special form
   (defn convert-dotted-symbol [self]
-    (self.expand-symbols `(. ~@(map HySymbol (.split self.form '.)))))
+    (self.expand-symbols `(. ~@(map hy.models.Symbol (.split self.form '.)))))
 
   (defn expand-symbol [self]
     (if (not-in self.form self.protected)
@@ -552,8 +553,8 @@
     replaced)
 
   (defn destructuring? [x]
-    (or (instance? HyList x)
-        (and (instance? HyExpression x)
+    (or (instance? hy.models.List x)
+        (and (instance? hy.models.Expression x)
              (= (first x) ',))))
 
   (for [[k v] (partition bindings)]
@@ -577,7 +578,8 @@
                        [(and (symbol? x) (in '. x))
                         (macro-error k "bind target may not contain a dot")]
 
-                       [(and (instance? HyExpression x) (-> x first (in #{', 'unpack-iterable}) not))
+                       [(and (instance? hy.models.Expression x)
+                             (-> x first (in #{', 'unpack-iterable}) not))
                         (macro-error k "cannot destructure non-iterable unpacking expression")]
 
                        [(and (symbol? x) (in x unpacked-syms))

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -48,7 +48,7 @@
      (if* (not (isinstance macro-name (, hy.models.Symbol hy.models.String)))
           (raise
             (hy.errors.HyTypeError
-              (% "received a `%s' instead of a symbol or string for macro name"
+              (% "received a `hy.models.%s' instead of a symbol or string for macro name"
                  (. (type macro-name) __name__))
               None __file__ None)))
      (if* (in "." macro-name)

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -45,7 +45,7 @@
           => foo
           3
      ]]
-     (if* (not (isinstance macro-name (, hy.models.HySymbol hy.models.HyString)))
+     (if* (not (isinstance macro-name (, hy.models.Symbol hy.models.String)))
           (raise
             (hy.errors.HyTypeError
               (% "received a `%s' instead of a symbol or string for macro name"
@@ -57,7 +57,7 @@
          None __file__ None)))
      (for [arg lambda-list]
        (if* (or (= arg '*)
-                (and (isinstance arg hy.models.HyExpression)
+                (and (isinstance arg hy.models.Expression)
                      (= (get arg 0) 'unpack-mapping)))
             (raise (hy.errors.HyTypeError "macros cannot use '*', or '#**'"
                                           macro-name __file__ None))))
@@ -271,7 +271,7 @@
        => (render-html-tag \"p\" \" --- \" (render-html-tag \"span\" \"\" :class \"fancy\" \"I'm fancy!\") \"I'm to the right of fancy\" \"I'm alone :(\")
        '<p><span class=\"fancy\">I\'m fancy!</span> --- I\'m to right right of fancy --- I\'m alone :(</p>'
   "
-  (if (not (= (type name) hy.HySymbol))
+  (if (not (= (type name) hy.models.Symbol))
     (macro-error name "defn takes a name as first argument"))
   `(setv ~name (fn* ~@args)))
 
@@ -287,8 +287,8 @@
 
        => (defn/a name [params] body)
   "
-  (if (not (= (type name) hy.HySymbol))
+  (if (not (= (type name) hy.models.Symbol))
     (macro-error name "defn/a takes a name as first argument"))
-  (if (not (isinstance lambda-list hy.HyList))
+  (if (not (isinstance lambda-list hy.models.List))
     (macro-error name "defn/a takes a parameter list as second argument"))
   `(setv ~name (fn/a ~lambda-list ~@body)))

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -12,9 +12,7 @@
 (import operator)  ; shadow not available yet
 (import sys)
 (import [collections.abc :as cabc])
-(import [hy.models [HyBytes HyComplex HyDict HyExpression HyFComponent
-                    HyFString HyFloat HyInteger HyKeyword HyList
-                    HyObject HySequence HySet HyString HySymbol]])
+(import [hy.models [Keyword Symbol]])
 (import [hy.lex [tokenize mangle unmangle read read-str]])
 (import [hy.lex.exceptions [LexException PrematureEndOfInput]])
 (import [hy.compiler [HyASTCompiler calling-module]])
@@ -163,7 +161,7 @@
 
   .. versionadded:: 0.10.1
 
-  Check whether *foo* is a :ref:`keyword<HyKeyword>`.
+  Check whether *foo* is a :ref:`keyword<hy.models.Keyword>`.
 
   Examples:
     ::
@@ -177,7 +175,7 @@
        => (keyword? foo)
        False
   "
-  (instance? HyKeyword k))
+  (instance? Keyword k))
 
 (defn dec [n]
   "Decrement `n` by 1.
@@ -524,7 +522,7 @@
        => (symbol? '[a b c])
        False
   "
-  (instance? HySymbol s))
+  (instance? Symbol s))
 
 (import [threading [Lock]])
 (setv _gensym_counter 0)
@@ -543,12 +541,12 @@
     ::
 
       => (gensym)
-      HySymbol('_G\uffff1')
+      hy.models.Symbol('_G\uffff1')
 
     ::
 
       => (gensym \"x\")
-      HySymbol('_x\uffff2')
+      hy.models.Symbol('_x\uffff2')
 
    "
   (setv new_symbol None)
@@ -556,7 +554,7 @@
   (global _gensym_lock)
   (.acquire _gensym_lock)
   (try (do (setv _gensym_counter (inc _gensym_counter))
-           (setv new_symbol (HySymbol (.format "_{}\uffff{}" g _gensym_counter))))
+           (setv new_symbol (Symbol (.format "_{}\uffff{}" g _gensym_counter))))
        (finally (.release _gensym_lock)))
   new_symbol)
 
@@ -864,25 +862,25 @@
     ::
 
        => (macroexpand '(-> (a b) (x y)))
-       HyExpression([
-         HySymbol('x'),
-         HyExpression([
-           HySymbol('a'),
-           HySymbol('b')]),
-         HySymbol('y')])
+       hy.models.Expression([
+         hy.models.Symbol('x'),
+         hy.models.Expression([
+           hy.models.Symbol('a'),
+           hy.models.Symbol('b')]),
+         hy.models.Symbol('y')])
 
     ::
 
        => (macroexpand '(-> (a b) (-> (c d) (e f))))
-       HyExpression([
-         HySymbol('e'),
-         HyExpression([
-           HySymbol('c'),
-           HyExpression([
-             HySymbol('a'),
-             HySymbol('b')]),
-           HySymbol('d')]),
-         HySymbol('f')])
+       hy.models.Expression([
+         hy.models.Symbol('e'),
+         hy.models.Expression([
+           hy.models.Symbol('c'),
+           hy.models.Expression([
+             hy.models.Symbol('a'),
+             hy.models.Symbol('b')]),
+           hy.models.Symbol('d')]),
+         hy.models.Symbol('f')])
   "
   (import hy.macros)
   (setv module (calling-module))
@@ -897,17 +895,17 @@
     ::
 
        => (macroexpand-1 '(-> (a b) (-> (c d) (e f))))
-       HyExpression([
-         HySymbol('_>'),
-         HyExpression([
-           HySymbol('a'),
-           HySymbol('b')]),
-         HyExpression([
-           HySymbol('c'),
-           HySymbol('d')]),
-         HyExpression([
-           HySymbol('e'),
-           HySymbol('f')])])
+       hy.models.Expression([
+         hy.models.Symbol('_>'),
+         hy.models.Expression([
+           hy.models.Symbol('a'),
+           hy.models.Symbol('b')]),
+         hy.models.Expression([
+           hy.models.Symbol('c'),
+           hy.models.Symbol('d')]),
+         hy.models.Expression([
+           hy.models.Symbol('e'),
+           hy.models.Symbol('f')])])
   "
   (import hy.macros)
   (setv module (calling-module))
@@ -1329,20 +1327,20 @@
     ::
 
        => (keyword \"foo\")
-       HyKeyword('foo')
+       hy.models.Keyword('foo')
 
     ::
 
        => (keyword 1)
-       HyKeyword('foo')
+       hy.models.Keyword('foo')
   "
   (if (keyword? value)
-      (HyKeyword (unmangle value.name))
+      (Keyword (unmangle value.name))
       (if (string? value)
-          (HyKeyword (unmangle value))
+          (Keyword (unmangle value))
           (try
             (unmangle (.__name__ value))
-            (except [] (HyKeyword (str value)))))))
+            (except [] (Keyword (str value)))))))
 
 (defn xor [a b]
   "Perform exclusive or between `a` and `b`.

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -1407,6 +1407,4 @@
       macroexpand-1 mangle merge-with multicombinations neg? none? nth
       numeric? odd? parse-args partition permutations pos? product read read-str
       remove repeat repeatedly rest reduce second some string? symbol?
-      take take-nth take-while tuple? unmangle xor tee zero? zip-longest
-      HyBytes HyComplex HyDict HyExpression HyFComponent HyFString HyFloat
-      HyInteger HyKeyword HyList HyObject HySequence HySet HyString HySymbol])))
+      take take-nth take-while tuple? unmangle xor tee zero? zip-longest])))

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -177,7 +177,7 @@
   `(if ~@(reduce + (gfor
     branch branches
     (if
-      (not (and (is (type branch) hy.HyList) branch))
+      (not (and (is (type branch) hy.models.List) branch))
         (macro-error branch "each cond branch needs to be a nonempty list")
       (= (len branch) 1) (do
         (setv g (gensym))
@@ -202,7 +202,7 @@
   "
   (setv ret head)
   (for [node args]
-    (setv ret (if (isinstance node HyExpression)
+    (setv ret (if (isinstance node hy.models.Expression)
                   `(~(first node) ~ret ~@(rest node))
                   `(~node ~ret))))
   ret)
@@ -232,7 +232,7 @@
   "
   (setv f (gensym))
   (defn build-form [expression]
-    (if (isinstance expression HyExpression)
+    (if (isinstance expression hy.models.Expression)
       `(~(first expression) ~f ~@(rest expression))
       `(~expression ~f)))
   `(do
@@ -257,7 +257,7 @@
   "
   (setv ret head)
   (for [node args]
-    (setv ret (if (isinstance node HyExpression)
+    (setv ret (if (isinstance node hy.models.Expression)
                   `(~@node ~ret)
                   `(~node ~ret))))
   ret)
@@ -567,10 +567,10 @@
   (defn extract-o!-sym [arg]
     (cond [(and (symbol? arg) (.startswith arg "o!"))
            arg]
-          [(and (instance? HyList arg) (.startswith (first arg) "o!"))
+          [(and (instance? hy.models.List arg) (.startswith (first arg) "o!"))
            (first arg)]))
   (setv os (list (filter identity (map extract-o!-sym args)))
-        gs (lfor s os (HySymbol (+ "g!" (cut s 2)))))
+        gs (lfor s os (hy.models.Symbol (+ "g!" (cut s 2)))))
 
   (setv [docstring body] (if (and (instance? str (first body))
                                   (> (len body) 1))

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -264,7 +264,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
                                (or (, 0))
                                max
                                inc))
-                (HySymbol (+ "%" (str i))))
+                (hy.models.Symbol (+ "%" (str i))))
         ;; generate the #* parameter only if '%* is present in expr
         ~@(if (in '%* %symbols)
               '(#* %*))
@@ -282,7 +282,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 (defn recur-sym-replace [d form]
   "Recursive symbol replacement."
   (cond
-    [(instance? HySymbol form)
+    [(instance? hy.models.Symbol form)
       (.get d form form)]
     [(coll? form)
       ((type form) (gfor  x form  (recur-sym-replace d x)))]

--- a/hy/lex/__init__.py
+++ b/hy/lex/__init__.py
@@ -10,7 +10,7 @@ import sys
 import unicodedata
 
 from hy.lex.exceptions import PrematureEndOfInput, LexException  # NOQA
-from hy.models import HyExpression, HySymbol
+from hy.models import Expression, Symbol
 
 try:
     from io import StringIO
@@ -26,10 +26,10 @@ def hy_parse(source, filename='<string>'):
       filename (string, optional): File name corresponding to source.  Defaults to "<string>".
 
     Returns:
-      out : HyExpression
+      out : hy.models.Expression
     """
     _source = re.sub(r'\A#!.*', '', source)
-    res = HyExpression([HySymbol("do")] +
+    res = Expression([Symbol("do")] +
                        tokenize(_source + "\n",
                                 filename=filename))
     res.source = source
@@ -235,10 +235,10 @@ def read(from_file=sys.stdin, eof=""):
 
          => (read)
          (+ 2 2)
-         HyExpression([
-           HySymbol('+'),
-           HyInteger(2),
-           HyInteger(2)])
+         hy.models.Expression([
+           hy.models.Symbol('+'),
+           hy.models.Integer(2),
+           hy.models.Integer(2)])
 
       ::
 
@@ -267,15 +267,15 @@ def read(from_file=sys.stdin, eof=""):
          ...         (hy.eval exp))
          ...       (except [e EOFError]
          ...         (print "EOF!"))))
-         OHY HyExpression([
-           HySymbol('print'),
-           HyExpression([
-             HySymbol('quote'),
-             HySymbol('hello')])])
+         OHY hy.models.Expression([
+           hy.models.Symbol('print'),
+           hy.models.Expression([
+             hy.models.Symbol('quote'),
+             hy.models.Symbol('hello')])])
          hello
-         OHY HyExpression([
-           HySymbol('print'),
-           HyString('hyfriends!')])
+         OHY hy.models.Expression([
+           hy.models.Symbol('print'),
+           hy.models.String('hyfriends!')])
          hyfriends!
          EOF!
     """
@@ -302,9 +302,9 @@ def read_str(input):
       ::
 
          => (read-str "(print 1)")
-         HyExpression([
-         HySymbol('print'),
-         HyInteger(1)]
+         hy.models.Expression([
+         hy.models.Symbol('print'),
+         hy.models.Integer(1)]
 
       ::
 

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -10,9 +10,8 @@ from functools import wraps
 
 from rply import ParserGenerator
 
-from hy.models import (HyBytes, HyComplex, HyDict, HyExpression, HyFComponent,
-                       HyFString, HyFloat, HyInteger, HyKeyword, HyList, HySet,
-                       HyString, HySymbol)
+from hy.models import (Bytes, Complex, Dict, Expression, FComponent, FString,
+                       Float, Integer, Keyword, List, Set, String, Symbol)
 from .lexer import lexer
 from .exceptions import LexException, PrematureEndOfInput
 
@@ -67,13 +66,13 @@ def main_empty(state, p):
 @pg.production("paren : LPAREN list_contents RPAREN")
 @set_boundaries
 def paren(state, p):
-    return HyExpression(p[1])
+    return Expression(p[1])
 
 
 @pg.production("paren : LPAREN RPAREN")
 @set_boundaries
 def empty_paren(state, p):
-    return HyExpression([])
+    return Expression([])
 
 
 @pg.production("list_contents : term list_contents")
@@ -115,31 +114,31 @@ def term_discard(state, p):
 @pg.production("term : QUOTE term")
 @set_quote_boundaries
 def term_quote(state, p):
-    return HyExpression([HySymbol("quote"), p[1]])
+    return Expression([Symbol("quote"), p[1]])
 
 
 @pg.production("term : QUASIQUOTE term")
 @set_quote_boundaries
 def term_quasiquote(state, p):
-    return HyExpression([HySymbol("quasiquote"), p[1]])
+    return Expression([Symbol("quasiquote"), p[1]])
 
 
 @pg.production("term : UNQUOTE term")
 @set_quote_boundaries
 def term_unquote(state, p):
-    return HyExpression([HySymbol("unquote"), p[1]])
+    return Expression([Symbol("unquote"), p[1]])
 
 
 @pg.production("term : UNQUOTESPLICE term")
 @set_quote_boundaries
 def term_unquote_splice(state, p):
-    return HyExpression([HySymbol("unquote-splice"), p[1]])
+    return Expression([Symbol("unquote-splice"), p[1]])
 
 
 @pg.production("term : ANNOTATION term")
 @set_quote_boundaries
 def term_annotation(state, p):
-    return HyExpression([HySymbol("annotate*"), p[1]])
+    return Expression([Symbol("annotate*"), p[1]])
 
 
 @pg.production("term : HASHSTARS term")
@@ -155,50 +154,50 @@ def term_hashstars(state, p):
             "Too many stars in `#*` construct (if you want to unpack a symbol "
             "beginning with a star, separate it with whitespace)",
             state, p[0])
-    return HyExpression([HySymbol(sym), p[1]])
+    return Expression([Symbol(sym), p[1]])
 
 
 @pg.production("term : HASHOTHER term")
 @set_quote_boundaries
 def hash_other(state, p):
     # p == [(Token('HASHOTHER', '#foo'), bar)]
-    return HyExpression([HySymbol(p[0].getstr()), p[1]])
+    return Expression([Symbol(p[0].getstr()), p[1]])
 
 
 @pg.production("set : HLCURLY list_contents RCURLY")
 @set_boundaries
 def t_set(state, p):
-    return HySet(p[1])
+    return Set(p[1])
 
 
 @pg.production("set : HLCURLY RCURLY")
 @set_boundaries
 def empty_set(state, p):
-    return HySet([])
+    return Set([])
 
 
 @pg.production("dict : LCURLY list_contents RCURLY")
 @set_boundaries
 def t_dict(state, p):
-    return HyDict(p[1])
+    return Dict(p[1])
 
 
 @pg.production("dict : LCURLY RCURLY")
 @set_boundaries
 def empty_dict(state, p):
-    return HyDict([])
+    return Dict([])
 
 
 @pg.production("list : LBRACKET list_contents RBRACKET")
 @set_boundaries
 def t_list(state, p):
-    return HyList(p[1])
+    return List(p[1])
 
 
 @pg.production("list : LBRACKET RBRACKET")
 @set_boundaries
 def t_empty_list(state, p):
-    return HyList([])
+    return List([])
 
 
 @pg.production("string : STRING")
@@ -217,7 +216,7 @@ def t_string(state, p):
                                       state, p[0])
     return (HyString(s)
         if isinstance(s, str)
-        else HyBytes(s))
+        else Bytes(s))
 
 def t_fstring(state, p):
     s = p[0].value
@@ -233,12 +232,12 @@ def t_fstring(state, p):
                                       state, p[0])
     # internal parser
     values = _format_string(state, p, s)
-    return HyFString(values)
+    return FString(values)
 
 def _format_string(state, p, rest, allow_recursion=True):
     """
     Produces a list of elements
-    where each element is either a HyString or a HyFComponent.
+    where each element is either a hy.models.String or a hy.models.FComponent.
     """
     values = []
 
@@ -260,7 +259,7 @@ def _format_string(state, p, rest, allow_recursion=True):
           literal_chars = rest
           rest = ""
        if literal_chars:
-           values.append(HyString(literal_chars))
+           values.append(String(literal_chars))
        if not rest:
            break
        if match.group() != '{':
@@ -294,7 +293,7 @@ def _format_string(state, p, rest, allow_recursion=True):
        # Check for '=' debugging syntax, reproduce whitespace in output
        eq_sign_match = re.match(r'\s*=\s*', item)
        if eq_sign_match:
-           values.append(HyString(f_expression + eq_sign_match.group()))
+           values.append(String(f_expression + eq_sign_match.group()))
            item = item[eq_sign_match.end():]
        else:
            item = item.lstrip()
@@ -313,7 +312,7 @@ def _format_string(state, p, rest, allow_recursion=True):
                                             allow_recursion=False)
                subnodes.extend(format_spec)
            else:
-               subnodes.append(HyString(item[1:]))
+               subnodes.append(String(item[1:]))
        elif item:
            raise LexException.from_lexer(
                "f-string: trailing junk in field",
@@ -322,7 +321,7 @@ def _format_string(state, p, rest, allow_recursion=True):
            # Python has a special default conversion in this case.
            conversion = "r"
 
-       values.append(HyFComponent(subnodes, conversion=conversion))
+       values.append(FComponent(subnodes, conversion=conversion))
 
     return values
 
@@ -341,10 +340,8 @@ def t_bracket_string(state, p):
     delim, content = m.groups()
     if delim == 'f' or delim.startswith('f-'):
         values = _format_string(state, p, content)
-        return HyFString(values, brackets=delim)
-    return HyString(
-        content,
-        brackets = delim)
+        return FString(values, brackets=delim)
+    return String(content, brackets = delim)
 
 
 @pg.production("identifier : IDENTIFIER")
@@ -364,38 +361,38 @@ def t_identifier(state, p):
             '`(. <expression> <attr>)` or `(.<attr> <expression>)`)',
             state, p[0])
 
-    return HySymbol(obj)
+    return Symbol(obj)
 
 
 def symbol_like(obj):
     "Try to interpret `obj` as a number or keyword."
 
     try:
-        return HyInteger(obj)
+        return Integer(obj)
     except ValueError:
         pass
 
     if '/' in obj:
         try:
             lhs, rhs = obj.split('/')
-            return HyExpression([HySymbol('fraction'), HyInteger(lhs),
-                                 HyInteger(rhs)])
+            return Expression([Symbol('fraction'), Integer(lhs),
+                               Integer(rhs)])
         except ValueError:
             pass
 
     try:
-        return HyFloat(obj)
+        return Float(obj)
     except ValueError:
         pass
 
     if obj not in ('j', 'J'):
         try:
-            return HyComplex(obj)
+            return Complex(obj)
         except ValueError:
             pass
 
     if obj.startswith(":") and "." not in obj:
-        return HyKeyword(obj[1:])
+        return Keyword(obj[1:])
 
 
 @pg.error

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -212,9 +212,12 @@ def t_string(state, p):
     try:
         s = eval(s.replace('"', '"""', 1)[:-1] + '"""')
     except SyntaxError:
-        raise LexException.from_lexer("Can't convert {} to a HyString".format(p[0].value),
-                                      state, p[0])
-    return (HyString(s)
+        raise LexException.from_lexer(
+            f"Can't convert {p[0].value} to a hy.models.String",
+            state,
+            p[0],
+        )
+    return (String(s)
         if isinstance(s, str)
         else Bytes(s))
 
@@ -228,8 +231,11 @@ def t_fstring(state, p):
     try:
         s = eval(s.replace('"', '"""', 1)[:-1] + '"""')
     except SyntaxError:
-        raise LexException.from_lexer("Can't convert {} to a HyFString".format(p[0].value),
-                                      state, p[0])
+        raise LexException.from_lexer(
+            f"Can't convert {p[0].value} to a hy.models.FString",
+            state,
+            p[0],
+        )
     # internal parser
     values = _format_string(state, p, s)
     return FString(values)

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -11,7 +11,7 @@ import traceback
 from contextlib import contextmanager
 
 from hy._compat import reraise, PY3_8
-from hy.models import replace_hy_obj, HyExpression, HySymbol, wrap_value
+from hy.models import replace_hy_obj, Expression, Symbol, wrap_value
 from hy.lex import mangle, unmangle
 from hy.errors import (HyLanguageError, HyMacroExpansionError, HyTypeError,
                        HyRequireError)
@@ -261,18 +261,18 @@ def macroexpand(tree, module, compiler=None, once=False):
     Load the macros from the given `module`, then expand the (top-level) macros
     in `tree` until we no longer can.
 
-    `HyExpression` resulting from macro expansions are assigned the module in
+    `Expression` resulting from macro expansions are assigned the module in
     which the macro function is defined (determined using `inspect.getmodule`).
-    If the resulting `HyExpression` is itself macro expanded, then the
-    namespace of the assigned module is checked first for a macro corresponding
-    to the expression's head/car symbol.  If the head/car symbol of such a
-    `HyExpression` is not found among the macros of its assigned module's
-    namespace, the outer-most namespace--e.g.  the one given by the `module`
-    parameter--is used as a fallback.
+    If the resulting `Expression` is itself macro expanded, then the namespace
+    of the assigned module is checked first for a macro corresponding to the
+    expression's head/car symbol.  If the head/car symbol of such a `Expression`
+    is not found among the macros of its assigned module's namespace, the
+    outer-most namespace--e.g.  the one given by the `module` parameter--is used
+    as a fallback.
 
     Parameters
     ----------
-    tree: HyObject or list
+    tree: hy.models.Object or list
         Hy AST tree.
 
     module: str or types.ModuleType
@@ -286,7 +286,7 @@ def macroexpand(tree, module, compiler=None, once=False):
 
     Returns
     ------
-    out: HyObject
+    out: hy.models.Object
         Returns a mutated tree with macros expanded.
     """
     if not inspect.ismodule(module):
@@ -294,10 +294,10 @@ def macroexpand(tree, module, compiler=None, once=False):
 
     assert not compiler or compiler.module == module
 
-    while isinstance(tree, HyExpression) and tree:
+    while isinstance(tree, Expression) and tree:
 
         fn = tree[0]
-        if fn in ("quote", "quasiquote") or not isinstance(fn, HySymbol):
+        if fn in ("quote", "quasiquote") or not isinstance(fn, Symbol):
             break
 
         fn = mangle(fn)
@@ -323,7 +323,7 @@ def macroexpand(tree, module, compiler=None, once=False):
         with macro_exceptions(module, tree, compiler):
             obj = m(module.__name__, *tree[1:], **opts)
 
-            if isinstance(obj, HyExpression):
+            if isinstance(obj, Expression):
                 obj.module = inspect.getmodule(m)
 
             tree = replace_hy_obj(obj, tree)

--- a/hy/model_patterns.py
+++ b/hy/model_patterns.py
@@ -4,7 +4,7 @@
 
 "Parser combinators for pattern-matching Hy model trees."
 
-from hy.models import HyExpression, HySymbol, HyKeyword, HyString, HyFString, HyList
+from hy.models import Expression, Symbol, Keyword, String, List
 from funcparserlib.parser import (
     some, skip, many, finished, a, Parser, NoParseError, State)
 from functools import reduce
@@ -14,15 +14,15 @@ from operator import add
 from math import isinf
 
 FORM = some(lambda _: True)
-SYM = some(lambda x: isinstance(x, HySymbol))
-KEYWORD = some(lambda x: isinstance(x, HyKeyword))
-STR = some(lambda x: isinstance(x, HyString))  # matches literal strings only!
+SYM = some(lambda x: isinstance(x, Symbol))
+KEYWORD = some(lambda x: isinstance(x, Keyword))
+STR = some(lambda x: isinstance(x, String))  # matches literal strings only!
 
 def sym(wanted):
     "Parse and skip the given symbol or keyword."
     if wanted.startswith(":"):
-        return skip(a(HyKeyword(wanted[1:])))
-    return skip(some(lambda x: isinstance(x, HySymbol) and x == wanted))
+        return skip(a(Keyword(wanted[1:])))
+    return skip(some(lambda x: isinstance(x, Symbol) and x == wanted))
 
 def whole(parsers):
     """Parse the parsers in the given list one after another, then
@@ -39,31 +39,31 @@ def _grouped(group_type, parsers): return (
 
 def brackets(*parsers):
     "Parse the given parsers inside square brackets."
-    return _grouped(HyList, parsers)
+    return _grouped(List, parsers)
 
 def pexpr(*parsers):
     "Parse the given parsers inside a parenthesized expression."
-    return _grouped(HyExpression, parsers)
+    return _grouped(Expression, parsers)
 
 def dolike(head):
     "Parse a `do`-like form."
     return pexpr(sym(head), many(FORM))
 
 def notpexpr(*disallowed_heads):
-    """Parse any object other than a HyExpression beginning with a
-    HySymbol equal to one of the disallowed_heads."""
+    """Parse any object other than a hy.models.Expression beginning with a
+    hy.models.Symbol equal to one of the disallowed_heads."""
     return some(lambda x: not (
-        isinstance(x, HyExpression) and
+        isinstance(x, Expression) and
         x and
-        isinstance(x[0], HySymbol) and
+        isinstance(x[0], Symbol) and
         x[0] in disallowed_heads))
 
 def unpack(kind):
     "Parse an unpacking form, returning it unchanged."
     return some(lambda x:
-        isinstance(x, HyExpression)
+        isinstance(x, Expression)
         and len(x) > 0
-        and isinstance(x[0], HySymbol)
+        and isinstance(x[0], Symbol)
         and x[0] == "unpack-" + kind)
 
 def times(lo, hi, parser):

--- a/hy/models.py
+++ b/hy/models.py
@@ -80,7 +80,8 @@ class Object(object):
         self._start_column = value
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, super(HyObject, self).__repr__())
+        return (f"hy.models.{self.__class__.__name__}"
+                f"({super(Object, self).__repr__()})")
 
 
 _wrappers = {}
@@ -156,7 +157,7 @@ class Keyword(Object):
         self.name = value
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.name)
+        return f"hy.models.{self.__class__.__name__}({self.name!r})"
 
     def __str__(self):
         return ":%s" % self.name
@@ -311,18 +312,14 @@ class Sequence(Object, tuple, _ColoredModel):
     def __str__(self):
         with pretty():
             if self:
-                return self._colored("{}{}\n  {}{}".format(
+                return self._colored("hy.models.{}{}\n  {}{}".format(
                     self._colored(self.__class__.__name__),
                     self._colored("(["),
                     self._colored(",\n  ").join(map(repr_indent, self)),
                     self._colored("])"),
                 ))
-                return self._colored("{}([\n  {}])".format(
-                    self.__class__.__name__,
-                    ','.join(repr_indent(e) for e in self),
-                ))
             else:
-                return self._colored(self.__class__.__name__ + "()")
+                return self._colored(f"hy.models.{self.__class__.__name__}()")
 
 
 class FComponent(Sequence):
@@ -387,11 +384,11 @@ class Dict(Sequence, _ColoredModel):
                     pairs.append("{}  {}\n".format(
                         repr_indent(self[-1]), self._colored("# odd")))
                 return "{}\n  {}{}".format(
-                    self._colored("HyDict(["),
+                    self._colored("hy.models.Dict(["),
                     "{c}\n  ".format(c=self._colored(',')).join(pairs),
                     self._colored("])"))
             else:
-                return self._colored("HyDict()")
+                return self._colored("hy.models.Dict()")
 
     def keys(self):
         return list(self[0::2])

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -5,7 +5,6 @@
 
 from __future__ import unicode_literals
 
-from hy import HyString
 from hy.compiler import hy_compile, hy_eval
 from hy.errors import HyLanguageError, HyError
 from hy.lex import hy_parse

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -475,7 +475,7 @@ def test_ast_unicode_strings():
     """Ensure we handle unicode strings correctly"""
 
     def _compile_string(s):
-        hy_s = HyString(s)
+        hy_s = hy.models.String(s)
 
         code = hy_compile([hy_s], __name__, filename='<string>', source=s, import_stdlib=False)
         # We put hy_s in a list so it isn't interpreted as a docstring.
@@ -656,9 +656,9 @@ def test_bad_tag_macros():
 
 def test_models_accessible():
     # https://github.com/hylang/hy/issues/1045
-    can_eval('HySymbol')
-    can_eval('HyList')
-    can_eval('HyDict')
+    can_eval('hy.models.Symbol')
+    can_eval('hy.models.List')
+    can_eval('hy.models.Dict')
 
 
 def test_module_prelude():
@@ -668,7 +668,8 @@ def test_module_prelude():
     assert isinstance(hy_ast.body[0], ast.Import)
     assert hy_ast.body[0].module == 'hy'
 
-    hy_ast = can_compile('(setv flag (keyword? HySymbol))', import_stdlib=True)
+    hy_ast = can_compile('(setv flag (keyword? hy.models.Symbol))',
+                         import_stdlib=True)
     assert len(hy_ast.body) == 2
     assert isinstance(hy_ast.body[0], ast.Import)
     assert hy_ast.body[0].module == 'hy'

--- a/tests/compilers/test_compiler.py
+++ b/tests/compilers/test_compiler.py
@@ -5,12 +5,12 @@
 import ast
 
 from hy import compiler
-from hy.models import HyExpression, HyList, HySymbol, HyInteger
+from hy.models import Expression, List, Symbol, Integer
 import types
 
 
 def make_expression(*args):
-    h = HyExpression(args)
+    h = Expression(args)
     h.start_line = 1
     h.end_line = 1
     h.start_column = 1
@@ -22,10 +22,10 @@ def test_compiler_bare_names():
     """
     Check that the compiler doesn't drop bare names from code branches
     """
-    e = make_expression(HySymbol("do"),
-                        HySymbol("a"),
-                        HySymbol("b"),
-                        HySymbol("c"))
+    e = make_expression(Symbol("do"),
+                        Symbol("a"),
+                        Symbol("b"),
+                        Symbol("c"))
     ret = compiler.HyASTCompiler(types.ModuleType('test')).compile(e)
 
     # We expect two statements and a final expr.
@@ -48,13 +48,13 @@ def test_compiler_yield_return():
     should not generate a return statement. From 3.3 onwards a return
     value should be generated.
     """
-    e = make_expression(HySymbol("fn"),
-                        HyList(),
-                        HyExpression([HySymbol("yield"),
-                                      HyInteger(2)]),
-                        HyExpression([HySymbol("+"),
-                                      HyInteger(1),
-                                      HyInteger(1)]))
+    e = make_expression(Symbol("fn"),
+                        List(),
+                        Expression([Symbol("yield"),
+                                    Integer(2)]),
+                        Expression([Symbol("+"),
+                                    Integer(1),
+                                    Integer(1)]))
     ret = compiler.HyASTCompiler(types.ModuleType('test')).compile_atom(e)
 
     assert len(ret.stmts) == 1

--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -5,7 +5,7 @@
 from hy.macros import macro, macroexpand
 from hy.lex import tokenize
 
-from hy.models import HyString, HyList, HySymbol, HyExpression, HyFloat
+from hy.models import String, List, Symbol, Expression, Float
 from hy.errors import HyMacroExpansionError
 
 from hy.compiler import HyASTCompiler, mangle
@@ -16,7 +16,7 @@ import pytest
 @macro("test")
 def tmac(ETname, *tree):
     """ Turn an expression into a list """
-    return HyList(tree)
+    return List(tree)
 
 
 def test_preprocessor_simple():
@@ -24,8 +24,8 @@ def test_preprocessor_simple():
     obj = macroexpand(tokenize('(test "one" "two")')[0],
                       __name__,
                       HyASTCompiler(__name__))
-    assert obj == HyList(["one", "two"])
-    assert type(obj) == HyList
+    assert obj == List(["one", "two"])
+    assert type(obj) == List
 
 
 def test_preprocessor_expression():
@@ -34,14 +34,14 @@ def test_preprocessor_expression():
                       __name__,
                       HyASTCompiler(__name__))
 
-    assert type(obj) == HyList
-    assert type(obj[0]) == HyExpression
+    assert type(obj) == List
+    assert type(obj[0]) == Expression
 
-    assert obj[0] == HyExpression([HySymbol("test"),
-                                   HyString("one"),
-                                   HyString("two")])
+    assert obj[0] == Expression([Symbol("test"),
+                                 String("one"),
+                                 String("two")])
 
-    obj = HyList([HyString("one"), HyString("two")])
+    obj = List([String("one"), String("two")])
     obj = tokenize('(shill ["one" "two"])')[0][1]
     assert obj == macroexpand(obj, __name__, HyASTCompiler(__name__))
 
@@ -57,13 +57,13 @@ def test_macroexpand_nan():
    # https://github.com/hylang/hy/issues/1574
    import math
    NaN = float('nan')
-   x = macroexpand(HyFloat(NaN), __name__, HyASTCompiler(__name__))
-   assert type(x) is HyFloat
+   x = macroexpand(Float(NaN), __name__, HyASTCompiler(__name__))
+   assert type(x) is Float
    assert math.isnan(x)
 
 def test_macroexpand_source_data():
     # https://github.com/hylang/hy/issues/1944
-    ast = HyExpression([HySymbol('#@'), HyString('a')])
+    ast = Expression([Symbol('#@'), String('a')])
     ast.start_line = 3
     ast.start_column = 5
     bad = macroexpand(ast, "hy.core.macros")

--- a/tests/native_tests/comprehensions.hy
+++ b/tests/native_tests/comprehensions.hy
@@ -83,7 +83,8 @@
   (for [[expr answer] cases]
     ; Mutate the case as appropriate for the operator before
     ; evaluating it.
-    (setv expr (+ (HyExpression [(HySymbol specialop)]) (cut expr 1)))
+    (setv expr (+ (hy.models.Expression
+                    [(hy.models.Symbol specialop)]) (cut expr 1)))
     (when (= specialop "dfor")
       (setv expr (+ (cut expr 0 -1) `([~(get expr -1) 1]))))
     (when (= specialop "for")

--- a/tests/native_tests/contrib/hy_repr.hy
+++ b/tests/native_tests/contrib/hy_repr.hy
@@ -68,8 +68,8 @@
 
 (defn test-hy-repr-no-roundtrip []
   ; Test one of the corner cases in which hy-repr doesn't
-  ; round-trip: when a HyObject contains a non-HyObject, we
-  ; promote the constituent to a HyObject.
+  ; round-trip: when a Hy Object contains a non-Hy Object, we
+  ; promote the constituent to a Hy Object.
 
   (setv orig `[a ~5.0])
   (setv reprd (hy-repr orig))
@@ -77,7 +77,7 @@
   (setv result (hy.eval (read-str reprd)))
 
   (assert (is (type (get orig 1)) float))
-  (assert (is (type (get result 1)) HyFloat)))
+  (assert (is (type (get result 1)) hy.models.Float)))
 
 (defn test-dict-views []
   (assert (= (hy-repr (.keys {1 2})) "(dict-keys [1])"))
@@ -121,10 +121,10 @@
     "(Fooey :cd 11 :a_b 12)")))
 
 (defn test-hy-model-constructors []
-  (assert (= (hy-repr (HyInteger 7)) "'7"))
-  (assert (= (hy-repr (HyString "hello")) "'\"hello\""))
-  (assert (= (hy-repr (HyList [1 2 3])) "'[1 2 3]"))
-  (assert (= (hy-repr (HyDict [1 2 3])) "'{1 2  3}")))
+  (assert (= (hy-repr (hy.models.Integer 7)) "'7"))
+  (assert (= (hy-repr (hy.models.String "hello")) "'\"hello\""))
+  (assert (= (hy-repr (hy.models.List [1 2 3])) "'[1 2 3]"))
+  (assert (= (hy-repr (hy.models.Dict [1 2 3])) "'{1 2  3}")))
 
 (defn test-hy-repr-self-reference []
 

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -177,7 +177,7 @@
                '(foo `(bar a ~a ~"x"))))
     (assert (= `(foo ~@[a])
                '(foo "x")))
-    (assert (= `(foo `(bar [a] ~@[a] ~@~(HyList [a 'a `a]) ~~@[a]))
+    (assert (= `(foo `(bar [a] ~@[a] ~@~(hy.models.List [a 'a `a]) ~~@[a]))
                '(foo `(bar [a] ~@[a] ~@["x" a a] ~"x"))))))
 
 (defn test-let-except []

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -278,9 +278,8 @@ result['y in globals'] = 'y' in globals()")
 
 (defn test-gensym []
   "NATIVE: testing the gensym function"
-  (import [hy.models [HySymbol]])
   (setv s1 (gensym))
-  (assert (isinstance s1 HySymbol))
+  (assert (isinstance s1 hy.models.Symbol))
   (assert (= 0 (.find s1 "_G\uffff")))
   (setv s2 (gensym "xx"))
   (setv s3 (gensym "xx"))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1206,7 +1206,7 @@
   (assert (= (get (hy.eval `[~kw]) 0) kw))
   (assert (= (hy.eval kw) kw))
 
-  ; Tuples wrap to HyLists, not HyExpressions.
+  ; Tuples wrap to hy.models.Lists, not hy.models.Expressions.
   (assert (= (hy.eval (,)) []))
   (assert (= (hy.eval (, 1 2 3)) [1 2 3]))
 
@@ -1290,7 +1290,7 @@ cee\"} dee" "ey bee\ncee dee"))
   ; Quoting shouldn't evaluate the f-string immediately
   ; https://github.com/hylang/hy/issues/1844
   (setv quoted 'f"hello {world}")
-  (assert (isinstance quoted HyFString))
+  (assert (isinstance quoted hy.models.FString))
   (with [(pytest.raises NameError)]
     (hy.eval quoted))
   (setv world "goodbye")
@@ -1645,11 +1645,10 @@ cee\"} dee" "ey bee\ncee dee"))
 (defn test-read []
   "NATIVE: test that read takes something for stdin and reads"
   (import [io [StringIO]])
-  (import [hy.models [HyExpression]])
 
   (setv stdin-buffer (StringIO "(+ 2 2)\n(- 2 2)"))
   (assert (= (hy.eval (read stdin-buffer)) 4))
-  (assert (isinstance (read stdin-buffer) HyExpression))
+  (assert (isinstance (read stdin-buffer) hy.models.Expression))
 
   "Multiline test"
   (setv stdin-buffer (StringIO "(\n+\n41\n1\n)\n(-\n2\n1\n)"))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -80,7 +80,7 @@
 (defn test-macro-bad-name []
   (with [excinfo (pytest.raises HyTypeError)]
     (hy.eval '(defmacro :kw [])))
-  (assert (= (. excinfo value msg) "received a `HyKeyword' instead of a symbol or string for macro name"))
+  (assert (= (. excinfo value msg) "received a `hy.models.Keyword' instead of a symbol or string for macro name"))
   (with [excinfo (pytest.raises HyTypeError)]
     (hy.eval '(defmacro "foo.bar" [])))
   (assert (= (. excinfo value msg) "periods are not allowed in macro names")))

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -10,7 +10,7 @@
   ;
   ; `op` can also be a list of operators, in which case two tests are
   ; created for each operator.
-  (import [hy [HySymbol HyString]] [hy.contrib.walk [prewalk]])
+  (import [hy.contrib.walk [prewalk]])
   (setv defns [])
   (for [o (if (coll? op) op [op])]
     (.append defns `(defn ~(HySymbol (+ "test_operator_" o "_real")) []

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -13,12 +13,12 @@
   (import [hy.contrib.walk [prewalk]])
   (setv defns [])
   (for [o (if (coll? op) op [op])]
-    (.append defns `(defn ~(HySymbol (+ "test_operator_" o "_real")) []
-      (setv f-name ~(HyString o))
+    (.append defns `(defn ~(hy.models.Symbol (+ "test_operator_" o "_real")) []
+      (setv f-name ~(hy.models.String o))
       ~@(prewalk :form body :f (fn [x]
         (if (and (symbol? x) (= x "f")) o x)))))
-    (.append defns `(defn ~(HySymbol (+ "test_operator_" o "_shadow")) []
-      (setv f-name ~(HyString o))
+    (.append defns `(defn ~(hy.models.Symbol (+ "test_operator_" o "_shadow")) []
+      (setv f-name ~(hy.models.String o))
       (setv f ~o)
       ~@body)))
   `(do ~@defns))

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -7,14 +7,14 @@
   "NATIVE: test for quoting functionality"
   (setv q (quote (a b c)))
   (assert (= (len q) 3))
-  (assert (= q (HyExpression [(quote a) (quote b) (quote c)]))))
+  (assert (= q (hy.models.Expression [(quote a) (quote b) (quote c)]))))
 
 
 (defn test-basic-quoting []
-  (assert (= (type (quote (foo bar))) HyExpression))
-  (assert (= (type (quote foo)) HySymbol))
-  (assert (= (type (quote "string")) HyString))
-  (assert (= (type (quote b"string")) HyBytes)))
+  (assert (= (type (quote (foo bar))) hy.models.Expression))
+  (assert (= (type (quote foo)) hy.models.Symbol))
+  (assert (= (type (quote "string")) hy.models.String))
+  (assert (= (type (quote b"string")) hy.models.Bytes)))
 
 
 (defn test-quoted-hoistable []
@@ -41,7 +41,7 @@
   (assert (= (get q 1) (quote bar)))
   (assert (= (get q 2) (quote baz)))
   (assert (= (get q 3) (quote quux)))
-  (assert (= (type q) HyDict)))
+  (assert (= (type q) hy.models.Dict)))
 
 
 (defn test-quote-expr-in-dict []

--- a/tests/resources/macros.hy
+++ b/tests/resources/macros.hy
@@ -2,12 +2,12 @@
 
 (defmacro thread-set-ab []
   (defn f [#* args] (.join "" (+ (, "a") args)))
-  (setv variable (HySymbol (-> "b" (f))))
+  (setv variable (hy.models.Symbol (-> "b" (f))))
   `(setv ~variable 2))
 
 (defmacro threadtail-set-cd []
   (defn f [#* args] (.join "" (+ (, "c") args)))
-  (setv variable (HySymbol (->> "d" (f))))
+  (setv variable (hy.models.Symbol (->> "d" (f))))
   `(setv ~variable 5))
 
 (defmacro test-macro []

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -109,7 +109,7 @@ def test_lex_strings_exception():
         '  File "<string>", line 1',
         '    "\\x8"',
         '    ^',
-        'hy.lex.exceptions.LexException: Can\'t convert "\\x8" to a HyString'])
+        'hy.lex.exceptions.LexException: Can\'t convert "\\x8" to a hy.models.String'])
 
 
 def test_lex_bracket_strings():

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -7,8 +7,8 @@ import traceback
 import pytest
 
 from math import isnan
-from hy.models import (HyExpression, HyInteger, HyFloat, HyComplex, HySymbol,
-                       HyString, HyDict, HyList, HySet, HyKeyword)
+from hy.models import (Expression, Integer, Float, Complex, Symbol,
+                       String, Dict, List, Set, Keyword)
 from hy.lex import tokenize
 from hy.lex.exceptions import LexException, PrematureEndOfInput
 from hy.errors import hy_exc_handler
@@ -68,37 +68,37 @@ def test_lex_single_quote_err():
 def test_lex_expression_symbols():
     """ Make sure that expressions produce symbols """
     objs = tokenize("(foo bar)")
-    assert objs == [HyExpression([HySymbol("foo"), HySymbol("bar")])]
+    assert objs == [Expression([Symbol("foo"), Symbol("bar")])]
 
 
 def test_lex_expression_strings():
     """ Test that expressions can produce strings """
     objs = tokenize("(foo \"bar\")")
-    assert objs == [HyExpression([HySymbol("foo"), HyString("bar")])]
+    assert objs == [Expression([Symbol("foo"), String("bar")])]
 
 
 def test_lex_expression_integer():
     """ Make sure expressions can produce integers """
     objs = tokenize("(foo 2)")
-    assert objs == [HyExpression([HySymbol("foo"), HyInteger(2)])]
+    assert objs == [Expression([Symbol("foo"), Integer(2)])]
 
 
 def test_lex_symbols():
     """ Make sure that symbols are valid expressions"""
     objs = tokenize("foo ")
-    assert objs == [HySymbol("foo")]
+    assert objs == [Symbol("foo")]
 
 
 def test_lex_strings():
     """ Make sure that strings are valid expressions"""
     objs = tokenize('"foo"')
-    assert objs == [HyString("foo")]
+    assert objs == [String("foo")]
     # Make sure backslash-escaped newlines work (see issue #831)
     objs = tokenize(r"""
 "a\
 bc"
 """)
-    assert objs == [HyString("abc")]
+    assert objs == [String("abc")]
 
 
 def test_lex_strings_exception():
@@ -115,57 +115,56 @@ def test_lex_strings_exception():
 def test_lex_bracket_strings():
 
     objs = tokenize("#[my delim[hello world]my delim]")
-    assert objs == [HyString("hello world")]
+    assert objs == [String("hello world")]
     assert objs[0].brackets == "my delim"
 
     objs = tokenize("#[[squid]]")
-    assert objs == [HyString("squid")]
+    assert objs == [String("squid")]
     assert objs[0].brackets == ""
 
 
 def test_lex_integers():
     """ Make sure that integers are valid expressions"""
     objs = tokenize("42 ")
-    assert objs == [HyInteger(42)]
+    assert objs == [Integer(42)]
 
 
 def test_lex_fractions():
     """ Make sure that fractions are valid expressions"""
     objs = tokenize("1/2")
-    assert objs == [HyExpression([HySymbol("fraction"), HyInteger(1),
-                                  HyInteger(2)])]
+    assert objs == [Expression([Symbol("fraction"), Integer(1), Integer(2)])]
 
 
 def test_lex_expression_float():
     """ Make sure expressions can produce floats """
     objs = tokenize("(foo 2.)")
-    assert objs == [HyExpression([HySymbol("foo"), HyFloat(2.)])]
+    assert objs == [Expression([Symbol("foo"), Float(2.)])]
     objs = tokenize("(foo -0.5)")
-    assert objs == [HyExpression([HySymbol("foo"), HyFloat(-0.5)])]
+    assert objs == [Expression([Symbol("foo"), Float(-0.5)])]
     objs = tokenize("(foo 1.e7)")
-    assert objs == [HyExpression([HySymbol("foo"), HyFloat(1.e7)])]
+    assert objs == [Expression([Symbol("foo"), Float(1.e7)])]
 
 
 def test_lex_big_float():
     # https://github.com/hylang/hy/issues/1448
-    assert tokenize("1e900") == [HyFloat(1e900)]
-    assert tokenize("1e900-1e900j") == [HyComplex(1e900, -1e900)]
+    assert tokenize("1e900") == [Float(1e900)]
+    assert tokenize("1e900-1e900j") == [Complex(1e900, -1e900)]
 
 
 def test_lex_nan_and_inf():
 
     assert isnan(tokenize("NaN")[0])
-    assert tokenize("Nan") == [HySymbol("Nan")]
-    assert tokenize("nan") == [HySymbol("nan")]
-    assert tokenize("NAN") == [HySymbol("NAN")]
+    assert tokenize("Nan") == [Symbol("Nan")]
+    assert tokenize("nan") == [Symbol("nan")]
+    assert tokenize("NAN") == [Symbol("NAN")]
 
-    assert tokenize("Inf") == [HyFloat(float("inf"))]
-    assert tokenize("inf") == [HySymbol("inf")]
-    assert tokenize("INF") == [HySymbol("INF")]
+    assert tokenize("Inf") == [Float(float("inf"))]
+    assert tokenize("inf") == [Symbol("inf")]
+    assert tokenize("INF") == [Symbol("INF")]
 
-    assert tokenize("-Inf") == [HyFloat(float("-inf"))]
-    assert tokenize("-inf") == [HySymbol("-inf")]
-    assert tokenize("-INF") == [HySymbol("-INF")]
+    assert tokenize("-Inf") == [Float(float("-inf"))]
+    assert tokenize("-inf") == [Symbol("-inf")]
+    assert tokenize("-INF") == [Symbol("-INF")]
 
 
 def test_lex_expression_complex():
@@ -173,46 +172,45 @@ def test_lex_expression_complex():
 
     def t(x): return tokenize("(foo {})".format(x))
 
-    def f(x): return [HyExpression([HySymbol("foo"), x])]
+    def f(x): return [Expression([Symbol("foo"), x])]
 
-    assert t("2.j") == f(HyComplex(2.j))
-    assert t("-0.5j") == f(HyComplex(-0.5j))
-    assert t("1.e7j") == f(HyComplex(1e7j))
-    assert t("j") == f(HySymbol("j"))
-    assert t("J") == f(HySymbol("J"))
+    assert t("2.j") == f(Complex(2.j))
+    assert t("-0.5j") == f(Complex(-0.5j))
+    assert t("1.e7j") == f(Complex(1e7j))
+    assert t("j") == f(Symbol("j"))
+    assert t("J") == f(Symbol("J"))
     assert isnan(t("NaNj")[0][1].imag)
-    assert t("nanj") == f(HySymbol("nanj"))
-    assert t("Inf+Infj") == f(HyComplex(complex(float("inf"), float("inf"))))
-    assert t("Inf-Infj") == f(HyComplex(complex(float("inf"), float("-inf"))))
-    assert t("Inf-INFj") == f(HySymbol("Inf-INFj"))
+    assert t("nanj") == f(Symbol("nanj"))
+    assert t("Inf+Infj") == f(Complex(complex(float("inf"), float("inf"))))
+    assert t("Inf-Infj") == f(Complex(complex(float("inf"), float("-inf"))))
+    assert t("Inf-INFj") == f(Symbol("Inf-INFj"))
 
 
 def test_lex_digit_separators():
 
-    assert tokenize("1_000_000") == [HyInteger(1000000)]
-    assert tokenize("1,000,000") == [HyInteger(1000000)]
-    assert tokenize("1,000_000") == [HyInteger(1000000)]
-    assert tokenize("1_000,000") == [HyInteger(1000000)]
+    assert tokenize("1_000_000") == [Integer(1000000)]
+    assert tokenize("1,000,000") == [Integer(1000000)]
+    assert tokenize("1,000_000") == [Integer(1000000)]
+    assert tokenize("1_000,000") == [Integer(1000000)]
 
-    assert tokenize("0x_af") == [HyInteger(0xaf)]
-    assert tokenize("0x,af") == [HyInteger(0xaf)]
-    assert tokenize("0b_010") == [HyInteger(0b010)]
-    assert tokenize("0b,010") == [HyInteger(0b010)]
-    assert tokenize("0o_373") == [HyInteger(0o373)]
-    assert tokenize("0o,373") == [HyInteger(0o373)]
+    assert tokenize("0x_af") == [Integer(0xaf)]
+    assert tokenize("0x,af") == [Integer(0xaf)]
+    assert tokenize("0b_010") == [Integer(0b010)]
+    assert tokenize("0b,010") == [Integer(0b010)]
+    assert tokenize("0o_373") == [Integer(0o373)]
+    assert tokenize("0o,373") == [Integer(0o373)]
 
-    assert tokenize('1_2.3,4') == [HyFloat(12.34)]
-    assert tokenize('1_2e3,4') == [HyFloat(12e34)]
+    assert tokenize('1_2.3,4') == [Float(12.34)]
+    assert tokenize('1_2e3,4') == [Float(12e34)]
     assert (tokenize("1,2/3_4") ==
-            [HyExpression([HySymbol("fraction"),
-             HyInteger(12), HyInteger(34)])])
-    assert tokenize("1,0_00j") == [HyComplex(1000j)]
+            [Expression([Symbol("fraction"), Integer(12), Integer(34)])])
+    assert tokenize("1,0_00j") == [Complex(1000j)]
 
-    assert tokenize("1,,,,___,____,,__,,2__,,,__") == [HyInteger(12)]
+    assert tokenize("1,,,,___,____,,__,,2__,,,__") == [Integer(12)]
     assert (tokenize("_1,,,,___,____,,__,,2__,,,__") ==
-            [HySymbol("_1,,,,___,____,,__,,2__,,,__")])
+            [Symbol("_1,,,,___,____,,__,,2__,,,__")])
     assert (tokenize("1,,,,___,____,,__,,2__,q,__") ==
-            [HySymbol("1,,,,___,____,,__,,2__,q,__")])
+            [Symbol("1,,,,___,____,,__,,2__,q,__")])
 
 
 def test_lex_bad_attrs():
@@ -314,43 +312,43 @@ def test_lex_line_counting_multi_inner():
 def test_dicts():
     """ Ensure that we can tokenize a dict. """
     objs = tokenize("{foo bar bar baz}")
-    assert objs == [HyDict(["foo", "bar", "bar", "baz"])]
+    assert objs == [Dict(["foo", "bar", "bar", "baz"])]
 
     objs = tokenize("(bar {foo bar bar baz})")
-    assert objs == [HyExpression([HySymbol("bar"),
-                                  HyDict(["foo", "bar",
-                                          "bar", "baz"])])]
+    assert objs == [Expression([Symbol("bar"),
+                                Dict(["foo", "bar",
+                                      "bar", "baz"])])]
 
     objs = tokenize("{(foo bar) (baz quux)}")
-    assert objs == [HyDict([
-        HyExpression([HySymbol("foo"), HySymbol("bar")]),
-        HyExpression([HySymbol("baz"), HySymbol("quux")])
+    assert objs == [Dict([
+        Expression([Symbol("foo"), Symbol("bar")]),
+        Expression([Symbol("baz"), Symbol("quux")])
     ])]
 
 
 def test_sets():
     """ Ensure that we can tokenize a set. """
     objs = tokenize("#{1 2}")
-    assert objs == [HySet([HyInteger(1), HyInteger(2)])]
+    assert objs == [Set([Integer(1), Integer(2)])]
     objs = tokenize("(bar #{foo bar baz})")
-    assert objs == [HyExpression([HySymbol("bar"),
-                                  HySet(["foo", "bar", "baz"])])]
+    assert objs == [Expression([Symbol("bar"),
+                                Set(["foo", "bar", "baz"])])]
 
     objs = tokenize("#{(foo bar) (baz quux)}")
-    assert objs == [HySet([
-        HyExpression([HySymbol("foo"), HySymbol("bar")]),
-        HyExpression([HySymbol("baz"), HySymbol("quux")])
+    assert objs == [Set([
+        Expression([Symbol("foo"), Symbol("bar")]),
+        Expression([Symbol("baz"), Symbol("quux")])
     ])]
 
     # Duplicate items in a literal set should be okay (and should
     # be preserved).
     objs = tokenize("#{1 2 1 1 2 1}")
-    assert objs == [HySet([HyInteger(n) for n in [1, 2, 1, 1, 2, 1]])]
+    assert objs == [Set([Integer(n) for n in [1, 2, 1, 1, 2, 1]])]
     assert len(objs[0]) == 6
 
     # https://github.com/hylang/hy/issues/1120
     objs = tokenize("#{a 1}")
-    assert objs == [HySet([HySymbol("a"), HyInteger(1)])]
+    assert objs == [Set([Symbol("a"), Integer(1)])]
 
 
 def test_nospace():
@@ -393,26 +391,26 @@ def test_complex():
     """Ensure we tokenize complex numbers properly"""
     # This is a regression test for #143
     entry = tokenize("(1j)")[0][0]
-    assert entry == HyComplex("1.0j")
+    assert entry == Complex("1.0j")
     entry = tokenize("(1J)")[0][0]
-    assert entry == HyComplex("1.0j")
+    assert entry == Complex("1.0j")
     entry = tokenize("(j)")[0][0]
-    assert entry == HySymbol("j")
+    assert entry == Symbol("j")
     entry = tokenize("(J)")[0][0]
-    assert entry == HySymbol("J")
+    assert entry == Symbol("J")
 
 
 def test_tag_macro():
     """Ensure tag macros are handled properly"""
     entry = tokenize("#^()")
-    assert entry[0][0] == HySymbol("#^")
+    assert entry[0][0] == Symbol("#^")
     assert len(entry[0]) == 2
 
 
 def test_lex_comment_382():
     """Ensure that we can tokenize sources with a comment at the end"""
     entry = tokenize("foo ;bar\n;baz")
-    assert entry == [HySymbol("foo")]
+    assert entry == [Symbol("foo")]
 
 
 def test_discard():
@@ -443,46 +441,46 @@ def test_discard():
     assert tokenize("0 #_1 2") == [0, 2]
     assert tokenize("0 #_1 #_2 3") == [0, 3]
     assert tokenize("0 #_ #_1 2 3") == [0, 3]
-    # in HyList
-    assert tokenize("[]") == [HyList([])]
-    assert tokenize("[#_1]") == [HyList([])]
-    assert tokenize("[#_1 #_2]") == [HyList([])]
-    assert tokenize("[#_ #_1 2]") == [HyList([])]
-    assert tokenize("[0]") == [HyList([HyInteger(0)])]
-    assert tokenize("[0 #_1]") == [HyList([HyInteger(0)])]
-    assert tokenize("[0 #_1 #_2]") == [HyList([HyInteger(0)])]
-    assert tokenize("[2]") == [HyList([HyInteger(2)])]
-    assert tokenize("[#_1 2]") == [HyList([HyInteger(2)])]
-    assert tokenize("[#_0 #_1 2]") == [HyList([HyInteger(2)])]
-    assert tokenize("[#_ #_0 1 2]") == [HyList([HyInteger(2)])]
-    # in HySet
-    assert tokenize("#{}") == [HySet()]
-    assert tokenize("#{#_1}") == [HySet()]
-    assert tokenize("#{0 #_1}") == [HySet([HyInteger(0)])]
-    assert tokenize("#{#_1 0}") == [HySet([HyInteger(0)])]
-    # in HyDict
-    assert tokenize("{}") == [HyDict()]
-    assert tokenize("{#_1}") == [HyDict()]
-    assert tokenize("{#_0 1 2}") == [HyDict([HyInteger(1), HyInteger(2)])]
-    assert tokenize("{1 #_0 2}") == [HyDict([HyInteger(1), HyInteger(2)])]
-    assert tokenize("{1 2 #_0}") == [HyDict([HyInteger(1), HyInteger(2)])]
-    # in HyExpression
-    assert tokenize("()") == [HyExpression()]
-    assert tokenize("(#_foo)") == [HyExpression()]
-    assert tokenize("(#_foo bar)") == [HyExpression([HySymbol("bar")])]
-    assert tokenize("(foo #_bar)") == [HyExpression([HySymbol("foo")])]
-    assert tokenize("(foo :bar 1)") == [HyExpression([HySymbol("foo"), HyKeyword("bar"), HyInteger(1)])]
-    assert tokenize("(foo #_:bar 1)") == [HyExpression([HySymbol("foo"), HyInteger(1)])]
-    assert tokenize("(foo :bar #_1)") == [HyExpression([HySymbol("foo"), HyKeyword("bar")])]
+    # in List
+    assert tokenize("[]") == [List([])]
+    assert tokenize("[#_1]") == [List([])]
+    assert tokenize("[#_1 #_2]") == [List([])]
+    assert tokenize("[#_ #_1 2]") == [List([])]
+    assert tokenize("[0]") == [List([Integer(0)])]
+    assert tokenize("[0 #_1]") == [List([Integer(0)])]
+    assert tokenize("[0 #_1 #_2]") == [List([Integer(0)])]
+    assert tokenize("[2]") == [List([Integer(2)])]
+    assert tokenize("[#_1 2]") == [List([Integer(2)])]
+    assert tokenize("[#_0 #_1 2]") == [List([Integer(2)])]
+    assert tokenize("[#_ #_0 1 2]") == [List([Integer(2)])]
+    # in Set
+    assert tokenize("#{}") == [Set()]
+    assert tokenize("#{#_1}") == [Set()]
+    assert tokenize("#{0 #_1}") == [Set([Integer(0)])]
+    assert tokenize("#{#_1 0}") == [Set([Integer(0)])]
+    # in Dict
+    assert tokenize("{}") == [Dict()]
+    assert tokenize("{#_1}") == [Dict()]
+    assert tokenize("{#_0 1 2}") == [Dict([Integer(1), Integer(2)])]
+    assert tokenize("{1 #_0 2}") == [Dict([Integer(1), Integer(2)])]
+    assert tokenize("{1 2 #_0}") == [Dict([Integer(1), Integer(2)])]
+    # in Expression
+    assert tokenize("()") == [Expression()]
+    assert tokenize("(#_foo)") == [Expression()]
+    assert tokenize("(#_foo bar)") == [Expression([Symbol("bar")])]
+    assert tokenize("(foo #_bar)") == [Expression([Symbol("foo")])]
+    assert tokenize("(foo :bar 1)") == [Expression([Symbol("foo"), Keyword("bar"), Integer(1)])]
+    assert tokenize("(foo #_:bar 1)") == [Expression([Symbol("foo"), Integer(1)])]
+    assert tokenize("(foo :bar #_1)") == [Expression([Symbol("foo"), Keyword("bar")])]
     # discard term with nesting
     assert tokenize("[1 2 #_[a b c [d e [f g] h]] 3 4]") == [
-        HyList([HyInteger(1), HyInteger(2), HyInteger(3), HyInteger(4)])
+        List([Integer(1), Integer(2), Integer(3), Integer(4)])
     ]
     # discard with other prefix syntax
-    assert tokenize("a #_'b c") == [HySymbol("a"), HySymbol("c")]
-    assert tokenize("a '#_b c") == [HySymbol("a"), HyExpression([HySymbol("quote"), HySymbol("c")])]
-    assert tokenize("a '#_b #_c d") == [HySymbol("a"), HyExpression([HySymbol("quote"), HySymbol("d")])]
-    assert tokenize("a '#_ #_b c d") == [HySymbol("a"), HyExpression([HySymbol("quote"), HySymbol("d")])]
+    assert tokenize("a #_'b c") == [Symbol("a"), Symbol("c")]
+    assert tokenize("a '#_b c") == [Symbol("a"), Expression([Symbol("quote"), Symbol("c")])]
+    assert tokenize("a '#_b #_c d") == [Symbol("a"), Expression([Symbol("quote"), Symbol("d")])]
+    assert tokenize("a '#_ #_b c d") == [Symbol("a"), Expression([Symbol("quote"), Symbol("d")])]
 
 
 def test_lex_exception_filtering(capsys):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -112,70 +112,70 @@ def test_number_model_copy():
 PRETTY_STRINGS = {
     k % ('[1.0] {1.0} (1.0) #{1.0}',):
         v.format("""
-  HyList([
-    HyFloat(1.0)]),
-  HyDict([
-    HyFloat(1.0)  # odd
+  hy.models.List([
+    hy.models.Float(1.0)]),
+  hy.models.Dict([
+    hy.models.Float(1.0)  # odd
   ]),
-  HyExpression([
-    HyFloat(1.0)]),
-  HySet([
-    HyFloat(1.0)])""")
-    for k, v in {'[%s]': 'HyList([{}])',
-                 '#{%s}': 'HySet([{}])'}.items()}
+  hy.models.Expression([
+    hy.models.Float(1.0)]),
+  hy.models.Set([
+    hy.models.Float(1.0)])""")
+    for k, v in {'[%s]': 'hy.models.List([{}])',
+                 '#{%s}': 'hy.models.Set([{}])'}.items()}
 
 PRETTY_STRINGS.update({
     '{[1.0] {1.0} (1.0) #{1.0}}':
-    """HyDict([
-  HyList([
-    HyFloat(1.0)]),
-  HyDict([
-    HyFloat(1.0)  # odd
+    """hy.models.Dict([
+  hy.models.List([
+    hy.models.Float(1.0)]),
+  hy.models.Dict([
+    hy.models.Float(1.0)  # odd
   ])
   ,
-  HyExpression([
-    HyFloat(1.0)]),
-  HySet([
-    HyFloat(1.0)])
+  hy.models.Expression([
+    hy.models.Float(1.0)]),
+  hy.models.Set([
+    hy.models.Float(1.0)])
   ])"""
     ,
     '[1.0 1j [] {} () #{}]':
-        """HyList([
-  HyFloat(1.0),
-  HyComplex(1j),
-  HyList(),
-  HyDict(),
-  HyExpression(),
-  HySet()])"""
+        """hy.models.List([
+  hy.models.Float(1.0),
+  hy.models.Complex(1j),
+  hy.models.List(),
+  hy.models.Dict(),
+  hy.models.Expression(),
+  hy.models.Set()])"""
     ,
     '{{1j 2j} {1j 2j [][1j]} {[1j][] 1j 2j} {[1j][1j]}}':
-        """HyDict([
-  HyDict([
-    HyComplex(1j), HyComplex(2j)]),
-  HyDict([
-    HyComplex(1j), HyComplex(2j),
-    HyList(),
-    HyList([
-      HyComplex(1j)])
+        """hy.models.Dict([
+  hy.models.Dict([
+    hy.models.Complex(1j), hy.models.Complex(2j)]),
+  hy.models.Dict([
+    hy.models.Complex(1j), hy.models.Complex(2j),
+    hy.models.List(),
+    hy.models.List([
+      hy.models.Complex(1j)])
     ])
   ,
-  HyDict([
-    HyList([
-      HyComplex(1j)]),
-    HyList()
+  hy.models.Dict([
+    hy.models.List([
+      hy.models.Complex(1j)]),
+    hy.models.List()
     ,
-    HyComplex(1j), HyComplex(2j)]),
-  HyDict([
-    HyList([
-      HyComplex(1j)]),
-    HyList([
-      HyComplex(1j)])
+    hy.models.Complex(1j), hy.models.Complex(2j)]),
+  hy.models.Dict([
+    hy.models.List([
+      hy.models.Complex(1j)]),
+    hy.models.List([
+      hy.models.Complex(1j)])
     ])
   ])"""})
 
 
 def test_compound_model_repr():
-    HY_LIST_MODELS = (HyExpression, HyDict, HySet, HyList)
+    HY_LIST_MODELS = (Expression, Dict, Set, List)
     with pretty(False):
         for model in HY_LIST_MODELS:
             assert eval(repr(model())).__class__ is model

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,8 +4,8 @@
 
 import copy
 import hy
-from hy.models import (wrap_value, replace_hy_obj, HyString, HyInteger, HyList,
-                       HyDict, HySet, HyExpression, HyComplex, HyFloat, pretty)
+from hy.models import (wrap_value, replace_hy_obj, String, Integer, List,
+                       Dict, Set, Expression, Complex, Float, pretty)
 
 hy.models.COLORED = False
 
@@ -13,67 +13,67 @@ hy.models.COLORED = False
 def test_wrap_int():
     """ Test conversion of integers."""
     wrapped = wrap_value(0)
-    assert type(wrapped) == HyInteger
+    assert type(wrapped) == Integer
 
 
 def test_wrap_tuple():
     """ Test conversion of tuples."""
-    wrapped = wrap_value((HyInteger(0),))
-    assert type(wrapped) == HyList
-    assert type(wrapped[0]) == HyInteger
-    assert wrapped == HyList([HyInteger(0)])
+    wrapped = wrap_value((Integer(0),))
+    assert type(wrapped) == List
+    assert type(wrapped[0]) == Integer
+    assert wrapped == List([Integer(0)])
 
 
 def test_wrap_nested_expr():
-    """ Test conversion of HyExpressions with embedded non-HyObjects."""
-    wrapped = wrap_value(HyExpression([0]))
-    assert type(wrapped) == HyExpression
-    assert type(wrapped[0]) == HyInteger
-    assert wrapped == HyExpression([HyInteger(0)])
+    """ Test conversion of Expressions with embedded non-HyObjects."""
+    wrapped = wrap_value(Expression([0]))
+    assert type(wrapped) == Expression
+    assert type(wrapped[0]) == Integer
+    assert wrapped == Expression([Integer(0)])
 
 
 def test_replace_int():
     """ Test replacing integers."""
-    replaced = replace_hy_obj(0, HyInteger(13))
-    assert replaced == HyInteger(0)
+    replaced = replace_hy_obj(0, Integer(13))
+    assert replaced == Integer(0)
 
 
 def test_replace_string_type():
     """Test replacing python string"""
-    replaced = replace_hy_obj("foo", HyString("bar"))
-    assert replaced == HyString("foo")
+    replaced = replace_hy_obj("foo", String("bar"))
+    assert replaced == String("foo")
 
 
 def test_replace_tuple():
     """ Test replacing tuples."""
-    replaced = replace_hy_obj((0, ), HyInteger(13))
-    assert type(replaced) == HyList
-    assert type(replaced[0]) == HyInteger
-    assert replaced == HyList([HyInteger(0)])
+    replaced = replace_hy_obj((0, ), Integer(13))
+    assert type(replaced) == List
+    assert type(replaced[0]) == Integer
+    assert replaced == List([Integer(0)])
 
 
 def test_list_add():
-    """Check that adding two HyLists generates a HyList"""
-    a = HyList([1, 2, 3])
-    b = HyList([3, 4, 5])
+    """Check that adding two Lists generates a List"""
+    a = List([1, 2, 3])
+    b = List([3, 4, 5])
     c = a + b
-    assert c == HyList([1, 2, 3, 3, 4, 5])
-    assert type(c) is HyList
+    assert c == List([1, 2, 3, 3, 4, 5])
+    assert type(c) is List
 
 
 def test_list_slice():
-    """Check that slicing a HyList produces a HyList"""
-    a = HyList([1, 2, 3, 4])
+    """Check that slicing a List produces a List"""
+    a = List([1, 2, 3, 4])
     sl1 = a[1:]
     sl5 = a[5:]
 
-    assert type(sl1) == HyList
-    assert sl1 == HyList([2, 3, 4])
-    assert type(sl5) == HyList
-    assert sl5 == HyList([])
+    assert type(sl1) == List
+    assert sl1 == List([2, 3, 4])
+    assert type(sl5) == List
+    assert sl5 == List([])
 
 
-hydict = HyDict(["a", 1, "b", 2, "c", 3])
+hydict = Dict(["a", 1, "b", 2, "c", 3])
 
 
 def test_dict_items():
@@ -88,7 +88,7 @@ def test_dict_values():
     assert hydict.values() == [1, 2, 3]
 
 
-hyset = HySet([3, 1, 2, 2])
+hyset = Set([3, 1, 2, 2])
 
 
 def test_set():
@@ -96,15 +96,15 @@ def test_set():
 
 
 def test_number_model_copy():
-    i = HyInteger(42)
+    i = Integer(42)
     assert (i == copy.copy(i))
     assert (i == copy.deepcopy(i))
 
-    f = HyFloat(42.)
+    f = Float(42.)
     assert (f == copy.copy(f))
     assert (f == copy.deepcopy(f))
 
-    c = HyComplex(42j)
+    c = Complex(42j)
     assert (c == copy.copy(c))
     assert (c == copy.deepcopy(c))
 


### PR DESCRIPTION
Closes #1644.

All hy models have `Hy` removed from their name, so `HyString` -> `String`, `HyList` -> `List` etc.

Also, `hy.models` has been prepended to the repr of all the models.

There are still objects which include `Hy` in their name, such as all the hy errors, `HyASTCompiler`, `HyREPL` and maybe some others. It would be nice to rename those as well, if everyone agrees.