### PR TITLE
Register `hy.models.FString` with `hy-repr` + tests.

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -74,6 +74,7 @@ Bug Fixes
 * `with*` has been removed and now `with` is now a special form. It compiles to
   a Python `with` statement with multiple context managers and `_` is used to
   signify an unnamed context manager.
+* Corrected `hy-repr` for f-strings.
 
 Misc. Improvements
 ------------------------------

--- a/hy/contrib/hy_repr.hy
+++ b/hy/contrib/hy_repr.hy
@@ -168,6 +168,21 @@ To make the Hy REPL use it for output, invoke Hy like so::
 (hy-repr-register fraction (fn [x]
   (.format "{}/{}" (hy-repr x.numerator) (hy-repr x.denominator))))
 
+(hy-repr-register
+  hy.models.FComponent
+  (fn [x] (-> x first hy-repr (.join ["{" "}"]))))
+
+(hy-repr-register
+  hy.models.FString
+  (fn [fstring]
+    (+ "f\""
+       #* (lfor component fstring
+                :setv s (hy-repr component)
+                (if (instance? hy.models.String component)
+                    (-> s (cut 1 -1) (.replace "{" "{{") (.replace "}" "}}"))
+                    s))
+       "\"")))
+
 (setv _matchobject-type (type (re.match "" "")))
 (hy-repr-register _matchobject-type (fn [x]
   (.format "<{}.{} object; :span {} :match {}>"

--- a/tests/native_tests/contrib/hy_repr.hy
+++ b/tests/native_tests/contrib/hy_repr.hy
@@ -124,7 +124,9 @@
   (assert (= (hy-repr (hy.models.Integer 7)) "'7"))
   (assert (= (hy-repr (hy.models.String "hello")) "'\"hello\""))
   (assert (= (hy-repr (hy.models.List [1 2 3])) "'[1 2 3]"))
-  (assert (= (hy-repr (hy.models.Dict [1 2 3])) "'{1 2  3}")))
+  (assert (= (hy-repr (hy.models.Dict [1 2 3])) "'{1 2  3}"))
+  (assert (= (hy-repr 'f"a{:a}") "'f\"a{:a}\""))
+  (assert (= (hy-repr 'f"a{{{{(+ 1 1)}}}}") "'f\"a{{{{(+ 1 1)}}}}\"")))
 
 (defn test-hy-repr-self-reference []
 


### PR DESCRIPTION
Currently `hy-repr` treats f-strings as a sequence, which produces unexpected results:
```hy
=> (hy-repr 'f"a{:a}")
'\'(, "a" (, :a))'
```
This makes it so that 
```hy
=> (hy-repr 'f"a{:a}")
'\'f"a{:a}"'
```