### PR TITLE
Fix version number of new release

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,7 +1,9 @@
 .. default-role:: code
 
-1.0a1 (released 2021-04-12)
+0.21.0 (released ???)
 ==============================
+
+This version was also mistakenly released as 1.0a1 on 2021-04-12.
 
 Removals
 ------------------------------


### PR DESCRIPTION
Just my luck: I completed the release of 1.0a1 only to find that it will not be installed by default by `pip install hy`, and PyPI still considers 0.20.0 to be the latest version (https://pypi.org/project/hy/). This turns out to be because, quoting from pip's documentation:

> pip will only install stable versions as specified by pre-releases by default. If a version cannot be parsed as a compliant PEP 440 version then it is assumed to be a pre-release.

So we should change back to the version number I originally proposed, 0.21.0, or if you guys are still against that, something ~~PEP 440-compliant~~ that pip considers to be stable.

@allison-casey @scauligi I would be grateful if we could clean this up today.