### PR TITLE
Docs: Migrate to github discussions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,7 +11,7 @@ helps in making Hy better. Potential contributions include:
   - You can mark tests that Hy can't pass yet as xfail_.
 - Cleaning up the code.
 - Improving the documentation.
-- Answering questions on `the IRC channel`_, `the mailing list`_, or
+- Answering questions on `the Github Discussions page`_ or
   `Stack Overflow`_.
 - Evangelizing for Hy in your organization, user group, conference, or
   bus stop.
@@ -193,7 +193,6 @@ http://contributor-covenant.org/version/1/1/0/.
 .. _GitHub: https://github.com/hylang/hy
 .. _This getting-started guide: http://rogerdudler.github.io/git-guide/
 .. _good-first-bug: https://github.com/hylang/hy/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-bug
-.. _the IRC channel: irc://freenode.net/hy
-.. _the mailing list: https://groups.google.com/forum/#!forum/hylang-discuss
+.. _the Github Discussions page: https://github.com/hylang/hy/discussions
 .. _Stack Overflow: https://stackoverflow.com/questions/tagged/hy
 .. _xfail: https://docs.pytest.org/en/latest/skipping.html#mark-a-test-function-as-expected-to-fail

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Project
 * [Hacking on Hy](http://docs.hylang.org/en/master/hacking.html)
   * [Contributor Guidelines](http://docs.hylang.org/en/master/hacking.html#contributor-guidelines)
   * [Code of Conduct](http://docs.hylang.org/en/master/hacking.html#contributor-code-of-conduct)
-* IRC: Join #hy on [freenode](https://webchat.freenode.net/)
+* Community: Join us on [Github Discussions](https://github.com/hylang/hy/discussions)!
 * [Stack Overflow: The [hy] tag](https://stackoverflow.com/questions/tagged/hy)
 
 ![Cuddles the Hacker](https://i.imgur.com/QbPMXTN.png)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,8 +7,7 @@ The Hy Manual
 
 :PyPI: https://pypi.python.org/pypi/hy
 :Source: https://github.com/hylang/hy
-:List: `hylang-discuss <https://groups.google.com/forum/#!forum/hylang-discuss>`_
-:IRC: irc://chat.freenode.net/hy
+:Discussions: `https://github.com/hylang/hy/discussions`_
 :Stack Overflow: `The [hy] tag <https://stackoverflow.com/questions/tagged/hy>`_
 
 Hy is a Lisp dialect that's embedded in Python. Since Hy transforms its Lisp

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,6 +1,6 @@
 Hy's issue list is for bugs, complaints, and feature requests.
 
-For help with Hy, ask on our IRC channel (may take up to a day), Stack Overflow with the `[hy]` tag, or on our mailing list.
+For help with Hy, ask on our Github Discussions page or Stack Overflow with the `[hy]` tag.
 
 If you're reporting a bug, make sure you can reproduce it with the very latest, bleeding-edge version of Hy from the `master` branch on GitHub. Bugs in stable versions of Hy are fixed on `master` before the fix makes it into a new stable release.
 


### PR DESCRIPTION
We won't be able to close issue #1778 until we actually archive the channels, but lets update the docs and give it another month to let people filter over. 