### PR TITLE
Fix: hystartup affects tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,9 @@ NATIVE_TESTS = os.path.join("", "tests", "native_tests", "")
 
 _fspath_pyimport = py.path.local.pyimport
 
+# https://github.com/hylang/hy/issues/2029
+os.environ.pop("HYSTARTUP", None)
+
 
 def pytest_ignore_collect(path, config):
     return (("py3_8_only" in path.basename and not PY3_8) or None)

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -248,6 +248,7 @@ class HyREPL(code.InteractiveConsole, object):
                 loader = HyLoader("__hystartup__", os.environ.get("HYSTARTUP"))
                 spec = importlib.util.spec_from_loader(loader.name, loader)
                 mod = importlib.util.module_from_spec(spec)
+                sys.modules.setdefault(mod.__name__, mod)
                 loader.exec_module(mod)
                 imports = mod.__dict__.get(
                     '__all__',

--- a/tests/resources/hystartup.hy
+++ b/tests/resources/hystartup.hy
@@ -1,0 +1,8 @@
+(import [hy.contrib.hy-repr [hy-repr]]
+        os)
+
+(setv repl-spy True
+      repl-output-fn hy-repr)
+
+(defmacro hello-world []
+  `(+ 1 1))

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -599,3 +599,15 @@ def test_bin_hy_tracebacks():
     error_lines = error.splitlines()
     assert error_lines[-2] == '  File "<string>", line 1, in <module>'
     assert error_lines[-1].startswith('TypeError')
+
+
+def test_hystartup():
+    os.environ["HYSTARTUP"] = "tests/resources/hystartup.hy"
+    output, _ = run_cmd("hy", "[1 2]")
+    assert "[1 2]" in output
+    assert "[1, 2]" in output
+
+    output, _ = run_cmd("hy", "(hello-world)")
+    assert "(hello-world)" not in output
+    assert "1 + 1" in output
+    assert "2" in output


### PR DESCRIPTION
closes #2029 also fixes macros not being able to find the hystartup module causing it to error out. 