### PR TITLE
Properly handle/display SyntaxError in Hy REPL

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,6 +18,10 @@ Removals
   * From `functools`: `reduce`
   * From `fractions`: `Fraction` (formerly `fraction`)
 
+Bug Fixes
+------------------------------
+* REPL now properly displays SyntaxErrors.
+
 1.0a1 (released 2021-04-12)
 ==============================
 

--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -10,13 +10,6 @@ PY3_9 = sys.version_info >= (3, 9)
 PY3_10 = sys.version_info >= (3, 10)
 
 
-def reraise(exc_type, value, traceback=None):
-    try:
-        raise value.with_traceback(traceback)
-    finally:
-        traceback = None
-
-
 if PY3_9:
 
     import ast

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -203,6 +203,14 @@ class HyCompile(codeop.Compile, object):
                 name, symbol)
             eval_code = super(HyCompile, self).__call__('None', name, 'eval')
 
+        except SyntaxError:
+            # Capture and save the error before we get to the superclass handler
+            sys.last_type, sys.last_value, sys.last_traceback = sys.exc_info()
+            # Per the python REPL, SyntaxErrors should not display a traceback
+            sys.last_traceback = None
+            self._update_exc_info()
+            raise
+
         return exec_code, eval_code
 
 

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -199,8 +199,7 @@ class HyCompile(codeop.Compile, object):
             sys.last_type, sys.last_value, sys.last_traceback = sys.exc_info()
             self._update_exc_info()
             exec_code = super(HyCompile, self).__call__(
-                'import hy._compat; hy._compat.reraise('
-                '_hy_last_type, _hy_last_value, _hy_last_traceback)',
+                'raise _hy_last_value.with_traceback(_hy_last_traceback)',
                 name, symbol)
             eval_code = super(HyCompile, self).__call__('None', name, 'eval')
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -15,7 +15,7 @@ from hy.errors import (HyCompileError, HyTypeError, HyLanguageError,
 
 from hy.lex import mangle, unmangle, hy_parse, parse_one_thing, LexException
 
-from hy._compat import (PY3_8, reraise)
+from hy._compat import PY3_8
 from hy.macros import require, macroexpand
 
 import textwrap
@@ -376,13 +376,13 @@ class HyASTCompiler(object):
             raise
         except HyLanguageError as e:
             # These are expected errors that should be passed to the user.
-            reraise(type(e), e, sys.exc_info()[2])
+            raise e
         except Exception as e:
             # These are unexpected errors that will--hopefully--never be seen
             # by the user.
             f_exc = traceback.format_exc()
             exc_msg = "Internal Compiler Bug 😱\n⤷ {}".format(f_exc)
-            reraise(HyCompileError, HyCompileError(exc_msg), sys.exc_info()[2])
+            raise HyCompileError(exc_msg)
 
     def _syntax_error(self, expr, message):
         return HySyntaxError(message, expr, self.filename, self.source)
@@ -1656,12 +1656,7 @@ class HyASTCompiler(object):
             # the compilation *process* (although compilation did technically
             # fail).
             # We wrap these exceptions and pass them through.
-            reraise(HyEvalError,
-                    HyEvalError(str(e),
-                                self.filename,
-                                body,
-                                self.source),
-                    sys.exc_info()[2])
+            raise HyEvalError(str(e), self.filename, body, self.source)
 
         return (self._compile_branch(body)
                 if mangle(root) == "eval_and_compile"

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -10,7 +10,7 @@ import traceback
 
 from contextlib import contextmanager
 
-from hy._compat import reraise, PY3_8
+from hy._compat import PY3_8
 from hy.models import replace_hy_obj, Expression, Symbol, wrap_value
 from hy.lex import mangle, unmangle
 from hy.errors import (HyLanguageError, HyMacroExpansionError, HyTypeError,
@@ -166,7 +166,7 @@ def require(source_module, target_module, assignments, prefix=""):
                 package = None
             source_module = importlib.import_module(source_module, package)
         except ImportError as e:
-            reraise(HyRequireError, HyRequireError(e.args[0]), None)
+            raise HyRequireError(e.args[0]).with_traceback(None)
 
     source_macros = source_module.__dict__.setdefault('__macros__', {})
 
@@ -233,7 +233,7 @@ def macro_exceptions(module, macro_tree, compiler=None):
     except HyLanguageError as e:
         # These are user-level Hy errors occurring in the macro.
         # We want to pass them up to the user.
-        reraise(type(e), e, sys.exc_info()[2])
+        raise
     except Exception as e:
 
         if compiler:
@@ -249,10 +249,7 @@ def macro_exceptions(module, macro_tree, compiler=None):
         msg = "expanding macro {}\n  ".format(str(macro_tree[0]))
         msg += exc_msg
 
-        reraise(HyMacroExpansionError,
-                HyMacroExpansionError(
-                    msg, macro_tree, filename, source),
-                sys.exc_info()[2])
+        raise HyMacroExpansionError(msg, macro_tree, filename, source)
 
 
 def macroexpand(tree, module, compiler=None, once=False):

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -216,6 +216,17 @@ def test_bin_hy_error_parts_length():
     assert err_parts[2] == '    ^----^'
 
 
+def test_bin_hy_syntax_errors():
+    # https://github.com/hylang/hy/issues/2004
+    _, err = run_cmd("hy", "(defn foo [/])\n(defn bar [a a])")
+    assert 'SyntaxError: duplicate argument' in err
+
+    # https://github.com/hylang/hy/issues/2014
+    _, err = run_cmd("hy", "(defn foo []\n(import [re [*]]))")
+    assert 'SyntaxError: import * only allowed' in err
+    assert 'PrematureEndOfInput' not in err
+
+
 def test_bin_hy_stdin_bad_repr():
     # https://github.com/hylang/hy/issues/1389
     output, err = run_cmd("hy", """


### PR DESCRIPTION
Fixes #2004 (and #2014).

The Hy REPL saves exceptions locally so that it can remove internal stack frames.
SyntaxErrors weren't getting saved, and so the REPL would instead
should the previous saved error.
This is now fixed.

Also removes `reraise()` from `hy._compat` since we're no longer supporting Python 2,
which simplifies some of the exception handling code throughout.
