### PR TITLE
Make unary `cut` consistent with `slice`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -27,6 +27,12 @@ Removals
   * From `functools`: `reduce`
   * From `fractions`: `Fraction` (formerly `fraction`)
 
+Other Breaking Changes
+------------------------------
+* Unary `cut` is now consistent with `slice`: A single index specifies
+  the stop index. Thus `(cut x n)` is translated to `x[:n]` instead of
+  `x[n:]`.
+
 Bug Fixes
 ------------------------------
 * REPL now properly displays SyntaxErrors.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -869,8 +869,8 @@ Special Forms
    ``cut`` can be used to take a subset of a list and create a new list from it.
    The form takes at least one parameter specifying the list to cut. Two
    optional parameters can be used to give the start and end position of the
-   subset. If they are not supplied, the default value of ``None`` will be used
-   instead. The third optional parameter is used to control step between the elements.
+   subset. If only one is given, it is taken as the ``stop`` value.
+   The third optional parameter is used to control the step stride between the elements.
 
    ``cut`` follows the same rules as its Python counterpart. Negative indices are
    counted starting from the end of the list. Some example usage:
@@ -884,7 +884,7 @@ Special Forms
        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
        => (cut collection 5)
-       [5, 6, 7, 8, 9]
+       [0, 1, 2, 3, 4]
 
        => (cut collection 2 8)
        [2, 3, 4, 5, 6, 7]

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -865,6 +865,12 @@ class HyASTCompiler(object):
             ret[0] += self.compile(e)
             return ret[0].force_expr
 
+        if upper is None:
+            # cut with single index is an upper bound,
+            # this is consistent with slice and islice
+            upper = lower
+            lower = Symbol('None')
+
         s = asty.Subscript(
             expr,
             value=c(obj),

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -143,7 +143,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
   "
   (defn emit [pred expr args]
     (setv n (if (and (> (len args) 1) (= :>> (get args 1))) 3 2)
-          [clause more] [(cut args 0 n) (cut args n)]
+          [clause more] [(cut args n) (cut args n None)]
           n (len clause)
           test (gensym))
     (if
@@ -284,10 +284,10 @@ Iterator patterns are specified using round brackets. They are the same as list 
         (if as?
           (raise
             (SyntaxError ":as must be final magic in sequential destructure"))
-          (map + [[] [[x y]]] (find-magics (cut bs 2) True (= ':as x)))))
+          (map + [[] [[x y]]] (find-magics (cut bs 2 None) True (= ':as x)))))
       (if keys?
         (raise (SyntaxError f"Non-keyword argument {x} after keyword"))
-        (map + [[x] []] (find-magics (cut bs 1)))))))
+        (map + [[x] []] (find-magics (cut bs 1 None)))))))
 
 (defn dest-list [dlist result found binds gsyms]
   "
@@ -315,7 +315,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
                                       `(dict (zip
                                         (cut ~dlist ~n None 2)
                                         (cut ~dlist ~(+ n 1) None 2)))
-                                      `(cut ~dlist ~n))
+                                      `(cut ~dlist ~n None))
                                   gsyms)
                  (raise (SyntaxError (.format err-msg m.name))))))
   (reduce + (chain bres mres) result))

--- a/hy/contrib/sequences.hy
+++ b/hy/contrib/sequences.hy
@@ -58,7 +58,7 @@ This results in the sequence ``[0 1 1 2 3 5 8 13 21 34 ...]``.
   (defn __getitem__ [self n]
     "get nth item of sequence"
     (if (hasattr n "start")
-    (gfor x (range n.start n.stop (or n.step 1))
+    (gfor x (range (or n.start 0) n.stop (or n.step 1))
          (get self x))
     (do (when (neg? n)
          ; Call (len) to force the whole

--- a/hy/contrib/slicing.hy
+++ b/hy/contrib/slicing.hy
@@ -39,7 +39,7 @@ or more manually using the tag macro as::
   (defn parse-indexing [sym]
     (if
       (and (isinstance sym hy.models.Expression) (= (get sym 0) :))
-      `(slice ~@(cut sym 1))
+      `(slice ~@(cut sym 1 None))
 
       (and (symbol? sym) (= sym '...))
       'Ellipsis

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -236,7 +236,7 @@
       (+= quote-level x)
       (when (neg? quote-level)
         (raise (TypeError "unquote outside of quasiquote")))
-      (setv res (traverse (cut form 1)))
+      (setv res (traverse (cut form 1 None)))
       (-= quote-level x)
       `(~head ~@res))
     (if (call? form)
@@ -333,14 +333,13 @@
                       form  ; don't expand attrs
                       (self.expand-symbols form)))
                 (fn [x] x)
-                (cut (self.tail)
-                     1))))
+                (cut (self.tail) 1 None))))
 
   (defn head [self]
     (get self.form 0))
 
   (defn tail [self]
-    (cut self.form 1))
+    (cut self.form 1 None))
 
   (defn handle-except [self]
     (setv tail (self.tail))
@@ -373,7 +372,7 @@
   (defn handle-fn [self]
     (setv [protected argslist] (self.handle-args-list))
     `(~(self.head) ~argslist
-       ~@(self.traverse (cut (self.tail) 1)(| protected self.protected))))
+       ~@(self.traverse (cut (self.tail) 1 None)(| protected self.protected))))
 
   ;; don't expand symbols in quotations
   (defn handle-quoted [self]
@@ -408,7 +407,7 @@
   (defn handle-defclass [self]
     ;; don't expand the name of the class
     `(~(self.head) ~(get (self.tail) 0)
-      ~@(self.traverse (cut (self.tail) 1))))
+      ~@(self.traverse (cut (self.tail) 1 None))))
 
   (defn handle-special-form [self]
     ;; don't expand other special form symbols in head position

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -106,7 +106,7 @@
             (get args 0)
             `(if* ~(get args 0)
                   ~(get args 1)
-                  (if ~@(cut args 2))))))
+                  (if ~@(cut args 2 None))))))
 
 (defmacro macro-error [expression reason [filename '__name__]]
   `(raise (hy.errors.HyMacroExpansionError ~reason ~filename ~expression None)))

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -74,7 +74,7 @@
        ...      (.read it)
        ...      (.decode it \"utf-8\")
        ...      (lfor  x it  :if (!= it \"Welcome\")  it)
-       ...      (cut it 0 30)
+       ...      (cut it 30)
        ...      (.join \"\" it))
        \"Welcome to Hy’s documentation!\"
 
@@ -182,7 +182,7 @@
           (setv g (gensym))
           [`(do (setv ~g ~(get branch 0)) ~g) g])
         True
-          [(get branch 0) `(do ~@(cut branch 1))]))
+          [(get branch 0) `(do ~@(cut branch 1 None))]))
     [])))
 
 
@@ -370,7 +370,7 @@
             (get args 0)
             `(if* (is-not ~(get args 0) None)
                   ~(get args 1)
-                  (lif ~@(cut args 2))))))
+                  (lif ~@(cut args 2 None))))))
 
 
 (defmacro lif-not [test not-branch [yes-branch None]]
@@ -521,7 +521,7 @@
                        (flatten body))))
         gensyms [])
   (for [sym syms]
-    (.extend gensyms [sym `(gensym ~(cut sym 2))]))
+    (.extend gensyms [sym `(gensym ~(cut sym 2 None))]))
 
   (setv [docstring body] (if (and (instance? str (get body 0))
                                   (> (len body) 1))
@@ -570,7 +570,7 @@
           [(and (instance? hy.models.List arg) (.startswith (get arg 0) "o!"))
            (get arg 0)]))
   (setv os (lfor  x (map extract-o!-sym args)  :if x  x)
-        gs (lfor s os (hy.models.Symbol (+ "g!" (cut s 2)))))
+        gs (lfor s os (hy.models.Symbol (+ "g!" (cut s 2 None)))))
 
   (setv [docstring body] (if (and (instance? str (get body 0))
                                   (> (len body) 1))
@@ -647,7 +647,7 @@
   "with-decorator tag macro"
   (if (empty? expr)
       (macro-error expr "missing function argument"))
-  (setv decorators (cut expr None -1)
+  (setv decorators (cut expr -1)
         fndef (get expr -1))
   `(with-decorator ~@decorators ~fndef))
 

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -259,8 +259,8 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
                        a))
   `(fn [;; generate all %i symbols up to the maximum found in expr
         ~@(gfor i (range 1 (-> (lfor a %symbols
-                                     :if (.isdigit (cut a 1))
-                                     (int (cut a 1)))
+                                     :if (.isdigit (cut a 1 None))
+                                     (int (cut a 1 None)))
                                (or (, 0))
                                max
                                inc))

--- a/tests/native_tests/comprehensions.hy
+++ b/tests/native_tests/comprehensions.hy
@@ -84,9 +84,9 @@
     ; Mutate the case as appropriate for the operator before
     ; evaluating it.
     (setv expr (+ (hy.models.Expression
-                    [(hy.models.Symbol specialop)]) (cut expr 1)))
+                    [(hy.models.Symbol specialop)]) (cut expr 1 None)))
     (when (= specialop "dfor")
-      (setv expr (+ (cut expr 0 -1) `([~(get expr -1) 1]))))
+      (setv expr (+ (cut expr -1) `([~(get expr -1) 1]))))
     (when (= specialop "for")
       (setv expr `(do
         (setv out [])

--- a/tests/native_tests/contrib/sequences.hy
+++ b/tests/native_tests/contrib/sequences.hy
@@ -9,7 +9,7 @@
 
 (defn test-infinite-sequence []
   "NATIVE: test creating infinite sequence"
-  (assert (= (list (cut (seq [n] n) 0 5))
+  (assert (= (list (cut (seq [n] n) 5))
              [0 1 2 3 4])))
 
 (defn test-indexing-sequence []
@@ -66,7 +66,7 @@
   (assert (= (get fibonacci 40)
              102334155)
           "40th element of fibonacci didn't match")
-  (assert (= (list (cut fibonacci 0 9))
+  (assert (= (list (cut fibonacci 9))
              [0 1 1 2 3 5 8 13 21])
           "taking 8 elements of fibonacci didn't match"))
 
@@ -81,7 +81,7 @@
                 prevs)))
     (defn previous-primes [n]
       "previous prime numbers"
-      (cut primes 0 (dec n)))
+      (cut primes (dec n)))
     (defn next-possible-prime [n]
       "next possible prime after nth prime"
       (inc (get primes (dec n))))
@@ -90,6 +90,6 @@
                     (while (divisible? guess (previous-primes n))
                       (setv guess (inc guess)))
                     guess)]))
-  (assert (= (list (cut primes 0 10))
+  (assert (= (list (cut primes 10))
              [2 3 5 7 11 13 17 19 23 29])
           "prime sequence didn't match"))

--- a/tests/native_tests/contrib/test_pprint.hy
+++ b/tests/native_tests/contrib/test_pprint.hy
@@ -42,8 +42,8 @@
 
   ;; Break the cycles
   (d.clear)
-  (del (cut a))
-  (del (cut b))
+  (del (cut a None))
+  (del (cut b None))
 
   (for [safe (, a b d (, d d))]
     (assert (not (pprint.recursive? safe)))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -762,7 +762,8 @@
 
 (defn test-cut []
   "NATIVE: test cut"
-  (assert (= (cut [1 2 3 4 5] 1) [2 3 4 5]))
+  (assert (= (cut [1 2 3 4 5] 3) [1 2 3]))
+  (assert (= (cut [1 2 3 4 5] 1 None) [2 3 4 5]))
   (assert (= (cut [1 2 3 4 5] 1 3) [2 3]))
   (assert (= (cut [1 2 3 4 5]) [1 2 3 4 5])))
 

--- a/tests/native_tests/model_patterns.hy
+++ b/tests/native_tests/model_patterns.hy
@@ -39,7 +39,7 @@
     (many FORM)]))))
   (defn f [loopers]
     (setv head (if loopers (get loopers 0)))
-    (setv tail (cut loopers 1))
+    (setv tail (cut loopers 1 None))
     (print head)
     (cond
       [(none? head)

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -540,7 +540,7 @@ in expansions."
 
   (setv output (traceback.format_exception_only
                  excinfo.type excinfo.value))
-  (setv output (cut (.splitlines (.strip (get output 0))) 1))
+  (setv output (cut (.splitlines (.strip (get output 0))) 1 None))
 
   (setv expected ["  File \"<string>\", line 1"
                   "    (defmacro blah [x] `(print ~@z)) (blah y)"

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -21,7 +21,7 @@
   "NATIVE: check whether quote works on hoisted things"
   (setv f (quote (if True True True)))
   (assert (= (get f 0) (quote if)))
-  (assert (= (cut f 1) (quote (True True True)))))
+  (assert (= (cut f 1 None) (quote (True True True)))))
 
 
 (defn test-quoted-macroexpand []
@@ -30,7 +30,7 @@
   (setv q2 (quasiquote (-> a b c)))
   (assert (= q1 q2))
   (assert (= (get q1 0) (quote ->)))
-  (assert (= (cut q1 1) (quote (a b c)))))
+  (assert (= (cut q1 1 None) (quote (a b c)))))
 
 
 (defn test-quote-dicts []

--- a/tests/resources/bin/main.hy
+++ b/tests/resources/bin/main.hy
@@ -1,5 +1,5 @@
 (defmain [#* args]
-  (print (+ "<" (.join "|" (cut args 1)) ">"))
+  (print (+ "<" (.join "|" (cut args 1 None)) ">"))
   (print "Hello World")
   (if (in "exit1" args)
     1))


### PR DESCRIPTION
Fixes #2038. `cut` with one index now specifies the _stopping_ index.

Thus `(cut x n)` translates to `x[:n]` now instead of `x[n:]`.
This is consistent with `slice`: `(= (slice n) (slice None n))`.
