### PR TITLE
Document the function return annotation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,6 +39,10 @@ Special Forms
       ; Equivalent to: def func(a: int, b: str = None, c: int = 1): ...
       (defn func [^int a ^str [b None] ^int [c 1]] ...)
 
+      ; Function return annotations have different ordering
+      (defn add1 ^int [^int x] (+ x 1))
+      (fn ^int [^int y] (+ y 2))
+
    The rules are:
 
    - The value to annotate with is the value that immediately follows the caret.
@@ -46,6 +50,8 @@ Special Forms
      interpreted as a bitwise XOR like the Python operator.
    - The annotation always comes (and is evaluated) *before* the value being annotated. This is
      unlike Python, where it comes and is evaluated *after* the value being annotated.
+   - The exception to the previous rule is function *return* annotation.  In
+     this case, the annotation comes just before the parameter list.
 
    Note that variable annotations are only supported on Python 3.6+.
 


### PR DESCRIPTION
There is one use case missing from the annotation documentation (`^`).  For example, the following Python definition:

``` python
def add1 (x: int) -> int:
    return x + 1
```

Can be translated to Hy as follows:

``` hy
(defn add1 ^int [^int x]
  (+ x 1))
```

The placement of the return type annotation does not conform to the documented rules, so it can be difficult to find or even confusing for users.  Given that function return type annotation is a very common use case, I think it should be more directly exposed through the documentation.
