### PR TITLE
Add: let hy cmdline args overwrite HYSTARTUP values

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -44,6 +44,8 @@ Bug Fixes
 * Fixed a bug in `pprint` in which `width` was ignored.
 * Corrected `repr` and `hy-repr` for f-strings.
 * `hy-repr` won't use the registerd method of a supertype anymore
+* REPL `--spy` and `--repl-output-fn` can now overwrite `HYSTARTUP` values
+  when specified as a cmdline argument
 
 .. _Toolz: https://toolz.readthedocs.io
 .. _CyToolz: https://github.com/pytoolz/cytoolz

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -262,8 +262,8 @@ class HyREPL(code.InteractiveConsole, object):
                     [name for name in mod.__dict__ if not name.startswith("_")]
                 )
                 imports = {name: mod.__dict__[name] for name in imports}
-                spy = imports.get("repl_spy", spy)
-                output_fn = imports.get("repl_output_fn", output_fn)
+                spy = spy or imports.get("repl_spy")
+                output_fn = output_fn or imports.get("repl_output_fn")
 
                 # Load imports and defs
                 self.locals.update(imports)

--- a/tests/resources/spy_off_startup.hy
+++ b/tests/resources/spy_off_startup.hy
@@ -1,0 +1,4 @@
+(import [hy.contrib.hy-repr [hy-repr]])
+
+(setv repl-spy False
+      repl-output-fn hy-repr)

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -613,6 +613,7 @@ def test_bin_hy_tracebacks():
 
 
 def test_hystartup():
+    # spy == True and repl-output-fn == hy-repr
     os.environ["HYSTARTUP"] = "tests/resources/hystartup.hy"
     output, _ = run_cmd("hy", "[1 2]")
     assert "[1 2]" in output
@@ -622,3 +623,15 @@ def test_hystartup():
     assert "(hello-world)" not in output
     assert "1 + 1" in output
     assert "2" in output
+
+    output, _ = run_cmd("hy --repl-output-fn repr", "[1 2 3 4]")
+    assert "[1, 2, 3, 4]" in output
+    assert "[1 2 3 4]" not in output
+
+    # spy == False and repl-output-fn == hy-repr
+    os.environ["HYSTARTUP"] = "tests/resources/spy_off_startup.hy"
+    output, _ = run_cmd("hy --spy", "[1 2]")  # overwrite spy with cmdline arg
+    assert "[1 2]" in output
+    assert "[1, 2]" in output
+
+    del os.environ['HYSTARTUP']


### PR DESCRIPTION
This lets `spy` or `repl-output-fn` values set at the cmdline take precedence over those set in `HYSTARTUP`. Note though that if you set `spy` to `True` in `HYSTARTUP` there's no way to set it back to `False` since `--spy` is a truthy check and changing the cmdline args to allow it would be overkill for something you'd only really do to debug anyways. 