### PR TITLE
Fix: hy-repr won't use the registered function of a supertype

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -43,6 +43,7 @@ Bug Fixes
 * REPL now properly displays SyntaxErrors.
 * Fixed a bug in `pprint` in which `width` was ignored.
 * Corrected `repr` and `hy-repr` for f-strings.
+* `hy-repr` won't use the registerd method of a supertype anymore
 
 .. _Toolz: https://toolz.readthedocs.io
 .. _CyToolz: https://github.com/pytoolz/cytoolz


### PR DESCRIPTION
closes #1873 namedtuple's are handled by moving the `_fields` check from the `tuple` repr function to `_base-repr` which seems to work just fine