### PR TITLE
Add initial GitHub Actions testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+name: Run Tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+
+  test:
+
+    strategy:
+      matrix:
+        python:
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+        allow-failure: [ false ]
+        include:
+          # https://github.com/hylang/hy/issues/2061
+          - python: '3.10-dev'
+            allow-failure: true
+          # TODO figure out why the PyPy installed by https://github.com/actions/setup-python fails :/
+          - python: 'pypy-3.7'
+            allow-failure: true
+
+    name: ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow-failure }}
+
+    defaults:
+      run:
+        shell: 'bash -Eeuo pipefail -x {0}'
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-travis.txt
+
+      - name: Install Hy
+        run: |
+          pip install -e .
+          hy -c '(+ 2 2)' # basic smoke test
+
+      - name: Run pytest
+        run: pytest


### PR DESCRIPTION
This mirrors `.travis.yml` fairly closely, but gives us a much newer 3.10-dev version (specifically 3.10.0-beta.1, at this time of writing, which is relevant for #2061).

Per #2061, I've set 3.10-dev to "allow failure" (since it's known-broken ATM), and I've currently got PyPy set similarly since it fails for reasons I wasn't able to chase down completely (that I think are due to how https://github.com/actions/setup-python is installing/configuring PyPy, but I'm not 100% certain).

You can see a "successful" run of this at https://github.com/tianon/hy/actions/runs/829829568. :smile:

As you can see there, it takes ~2m to run this entire matrix, and it triggered almost instantly every time I force pushed.

Relevant links:
- https://docs.github.com/en/actions/guides/building-and-testing-python
- https://github.com/actions/setup-python
- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions