### PR TITLE
Feature: qualify critical funcs under hy

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -40,6 +40,9 @@ Other Breaking Changes
 * `cmp` has been renamed to `chainc`.
 * `hy-repr` & `hy-repr-register` have been moved into `core` and are available
   at `hy.repr` & `hy.repr-register` respectively.
+* `gensym`, `macroexpand`, `macroexpand-1`, and `disassemble` are no longer
+  automatically brought into scope. Call them as `hy.gensym`, `hy.macroexpand`, etc
+  or import them explicitly.
 
 New Features
 ------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,6 @@
 API
 ===
 
-.. hy:autofunction:: hy.eval
 
 .. _special-forms:
 
@@ -1231,9 +1230,27 @@ Hy
 The ``hy`` module is auto imported into every Hy module and provides convient access to
 the following methods
 
+.. hy:autofunction:: hy.read-str
+
+.. hy:autofunction:: hy.read
+
+.. hy:autofunction:: hy.eval
+
 .. hy:autofunction:: hy.repr
 
 .. hy:autofunction:: hy.repr-register
+
+.. hy:autofunction:: hy.mangle
+
+.. hy:autofunction:: hy.unmangle
+
+.. hy:autofunction:: hy.disassemble
+
+.. hy:autofunction:: hy.macroexpand
+
+.. hy:autofunction:: hy.macroexpand-1
+
+.. hy:autofunction:: hy.gensym
 
 
 .. _Core:
@@ -1246,17 +1263,14 @@ base names, such that ``hy.core.language.butlast`` can be called with just ``but
 
 
 .. hy:automodule:: hy.core.language
-   :members:
+   :members: butlast, calling-module, calling-module-name,
+      coll?, constantly, dec, distinct, drop-last, empty?,
+      even?, every?, flatten, float?, inc, integer?, integer-char?,
+      iterable?, iterator?, keyword?, list?, neg?, none?, numeric?, odd?,
+      parse-args, pos?, rest, some, string?, symbol?, tuple?, xor, zero?
 
 .. hy:autofunction:: hy.core.language.calling-module
 
-.. hy:autofunction:: hy.core.language.mangle
-
-.. hy:autofunction:: hy.core.language.unmangle
-
-.. hy:autofunction:: hy.core.language.read-str
-
-.. hy:autofunction:: hy.core.language.read
 
 .. hy:automodule:: hy.core.shadow
    :members:

--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -4,7 +4,24 @@
     "categories": [
       {
         "name": "IO",
-        "methods": ["hy.repr", "hy.repr-register"]
+        "methods": [
+          "hy.repr",
+          "hy.repr-register",
+          "hy.mangle",
+          "hy.unmangle",
+          "hy.read",
+          "hy.read-str"
+        ]
+      },
+      {
+        "name": "Reader",
+        "methods": [
+          "hy.eval",
+          "hy.gensym",
+          "hy.macroexpand",
+          "hy.macroexpand-1",
+          "hy.disassemble"
+        ]
       }
     ]
   },
@@ -63,16 +80,7 @@
           "hy.core.bootstrap.defn/a",
           "hy.core.language.calling-module",
           "hy.core.language.calling-module-name",
-          "hy.core.language.parse-args",
-          "hy.core.language.disassemble",
-          "hy.eval",
-          "hy.core.language.gensym",
-          "hy.core.language.macroexpand",
-          "hy.core.language.macroexpand-1",
-          "hy.core.language.mangle",
-          "hy.core.language.read",
-          "hy.core.language.read-str",
-          "hy.core.language.unmangle"
+          "hy.core.language.parse-args"
         ]
       },
       {

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -182,7 +182,7 @@ For example::
   => (print x.name)
   foo-bar
 
-If needed, you can get the mangled name by calling :hy:func:`mangle <hy.core.language.mangle>`.
+If needed, you can get the mangled name by calling :hy:func:`mangle <hy.mangle>`.
 
 Hy Internal Theory
 ==================
@@ -383,11 +383,11 @@ where ``obscure-name`` is an attempt to pick some variable name as not to
 conflict with other code. But of course, while well-intentioned,
 this is no guarantee.
 
-The method :hy:func:`gensym <hy.core.language.gensym>` is designed to generate a new, unique symbol for just
+The method :hy:func:`gensym <hy.gensym>` is designed to generate a new, unique symbol for just
 such an occasion. A much better version of ``nif`` would be::
 
    (defmacro nif [expr pos-form zero-form neg-form]
-     (setv g (gensym))
+     (setv g (hy.gensym))
      `(do
         (setv ~g ~expr)
         (cond [(pos? ~g) ~pos-form]
@@ -404,9 +404,9 @@ basically expands to a ``setv`` form::
 expands to::
 
    (do
-     (setv a (gensym)
-           b (gensym)
-           c (gensym))
+     (setv a (hy.gensym)
+           b (hy.gensym)
+           c (hy.gensym))
      ...)
 
 so our re-written ``nif`` would look like::
@@ -421,7 +421,7 @@ so our re-written ``nif`` would look like::
 
 Finally, though we can make a new macro that does all this for us. :hy:func:`defmacro/g! <hy.core.macros.defmacro/g!>`
 will take all symbols that begin with ``g!`` and automatically call ``gensym`` with the
-remainder of the symbol. So ``g!a`` would become ``(gensym "a")``.
+remainder of the symbol. So ``g!a`` would become ``(hy.gensym "a")``.
 
 Our final version of ``nif``, built with ``defmacro/g!`` becomes::
 

--- a/docs/language/syntax.rst
+++ b/docs/language/syntax.rst
@@ -130,7 +130,7 @@ the keyword, as in ``(f ':foo)``, or use it as the value of another keyword
 argument, as in ``(f :arg :foo)``.
 
 Keywords can be called like functions as shorthand for ``get``. ``(:foo obj)``
-is equivalent to ``(get obj (mangle "foo"))``. An optional ``default`` argument
+is equivalent to ``(get obj (hy.mangle "foo"))``. An optional ``default`` argument
 is also allowed: ``(:foo obj 2)`` or ``(:foo obj :default 2)`` returns ``2`` if
 ``(get obj "foo")`` raises a ``KeyError``.
 
@@ -177,8 +177,8 @@ Python-legal names. The steps are as follows:
 
 #. Finally, any leading underscores removed in the first step are added back
    to the mangled name.
-   Thus, ``(mangle '_tasty?)`` is ``"_is_tasty"`` instead of ``"is__tasty"``
-   and ``(mangle '__-_has-dashes?)`` is ``"__hyx_is_XhyphenHminusX_has_dashes"``.
+   Thus, ``(hy.mangle '_tasty?)`` is ``"_is_tasty"`` instead of ``"is__tasty"``
+   and ``(hy.mangle '__-_has-dashes?)`` is ``"__hyx_is_XhyphenHminusX_has_dashes"``.
 
 Mangling isn't something you should have to think about often, but you may see
 mangled names in error messages, the output of ``hy2py``, etc. A catch to be

--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -26,7 +26,11 @@ _jit_imports = dict(
     unmangle = "hy.lex",
     eval = ["hy.compiler", "hy_eval"],
     repr = ["hy.core.hy_repr", "hy_repr"],
-    repr_register = ["hy.core.hy_repr", "hy_repr_register"])
+    repr_register = ["hy.core.hy_repr", "hy_repr_register"],
+    gensym="hy.core.language",
+    macroexpand="hy.core.language",
+    macroexpand_1="hy.core.language",
+    disassemble="hy.core.language")
 
 def __getattr__(k):
     if k not in _jit_imports:

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1913,7 +1913,7 @@ def hy_eval(hytree, locals=None, module=None, ast_callback=None,
       If you want to evaluate a string, use ``read-str`` to convert it to a
       form first::
 
-         => (hy.eval (read-str "(+ 1 1)"))
+         => (hy.eval (hy.read-str "(+ 1 1)"))
          2
 
     Args:

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -138,7 +138,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
     (setv n (if (and (> (len args) 1) (= :>> (get args 1))) 3 2)
           [clause more] [(cut args n) (cut args n None)]
           n (len clause)
-          test (gensym))
+          test (hy.gensym))
     (if
       (= 0 n) `(raise (TypeError (+ "no option for " (repr ~expr))))
       (= 1 n) (get clause 0)
@@ -176,7 +176,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
   Same as ``setv+``, except returns a dictionary with symbols to be defined,
   instead of actually declaring them."
   (setv gsyms []
-        result (gensym 'dict=:))
+        result (hy.gensym 'dict=:))
   `(do
      (setv ~result {}
            ~@(gfor [binds expr] (by2s pairs)
@@ -201,7 +201,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
   and :as must be last, if present.
   "
   (defn dispatch [f]
-    (setv dcoll (gensym f.__name__)
+    (setv dcoll (hy.gensym f.__name__)
       result [dcoll expr]
       seen #{})
     (defn found [magic target]
@@ -260,7 +260,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
                     ':or []
                     ':as [lookup ddict]
                     ':strs (get-as str lookup)
-                    ':keys (get-as (fn [x] (hy.models.Keyword (unmangle x))) lookup)
+                    ':keys (get-as (fn [x] (hy.models.Keyword (hy.unmangle x))) lookup)
                     (destructure #* (expand-lookup target lookup) gsyms))))
        ((fn [xs] (reduce + xs result)))))
 
@@ -326,8 +326,8 @@ Iterator patterns are specified using round brackets. They are the same as list 
   For example, try ``(destructure '(a b c :& more :as it) (count))``.
   "
   (setv [bs magics] (find-magics binds)
-        copy-iter (gensym)
-        tee (gensym))
+        copy-iter (hy.gensym)
+        tee (hy.gensym))
   (if (in ':as (sfor  [x #* _] magics  x))
     (.extend result [diter `(do
                               (import [itertools [tee :as ~tee]])
@@ -343,7 +343,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
           result))
 
 (defn _expanded-setv [actual args kwargs]
-  (macroexpand
+  (hy.macroexpand
     `(setv+ ~actual (+ (list ~args)
                           (lfor [k v] (.items ~kwargs)
                                 s [(hy.models.Keyword k) v]

--- a/hy/contrib/slicing.hy
+++ b/hy/contrib/slicing.hy
@@ -108,7 +108,7 @@ or more manually using the tag macro as::
     ::
 
        => (setv abc:def -2)
-       => (macroexpand '(ncut a abc:def (: (sum [1 2 3]) None abc:def)))
+       => (hy.macroexpand '(ncut a abc:def (: (sum [1 2 3]) None abc:def)))
        (get a (, abc:def (slice (sum [1 2 3]) None abc:def)))
 
     Pandas allows extensive slicing along single or multiple axes:

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -228,7 +228,7 @@
             form)))
   (expand form))
 
-(setv _mangled-special (frozenset (map mangle (special))))
+(setv _mangled-special (frozenset (map hy.mangle (special))))
 
 
 (defn lambda-list [form]
@@ -408,7 +408,7 @@
         (= head 'defclass) (self.handle-defclass)
         (= head 'quasiquote) (self.+quote)
         ;; must be checked last!
-        (in (mangle head) _mangled-special) (self.handle-special-form)
+        (in (hy.mangle head) _mangled-special) (self.handle-special-form)
         ;; Not a special form. Traverse it like a coll
         (self.handle-coll)))
 
@@ -513,7 +513,7 @@
   "
   (if (odd? (len bindings))
       (macro-error bindings "let bindings must be paired"))
-  (setv g!let (gensym 'let)
+  (setv g!let (hy.gensym 'let)
         replacements (OrderedDict)
         unpacked-syms (OrderedDict)
         keys []
@@ -525,7 +525,7 @@
     (cond
       [(not (symbol? symbol)) (macro-error symbol "bind targets must be symbol or destructing assignment")]
       [(in '. symbol) (macro-error symbol "binding target may not contain a dot")])
-    (setv replaced (gensym symbol))
+    (setv replaced (hy.gensym symbol))
     (assoc unpacked-syms symbol replaced)
     replaced)
 
@@ -560,7 +560,7 @@
                         (macro-error k "cannot destructure non-iterable unpacking expression")]
 
                        [(and (symbol? x) (in x unpacked-syms))
-                        (do (.append keys `(get ~g!let ~(unmangle x)))
+                        (do (.append keys `(get ~g!let ~(hy.unmangle x)))
                             (.append values (.get unpacked-syms x x))
                             (assoc replacements x (get keys -1)))]
 
@@ -568,7 +568,7 @@
                    k))
 
         (do (.append values (symbolexpand (macroexpand-all v &name) expander))
-            (.append keys `(get ~g!let ~(unmangle k)))
+            (.append keys `(get ~g!let ~(hy.unmangle k)))
             (assoc replacements k (get keys -1)))))
 
   `(do

--- a/hy/core/hy_repr.hy
+++ b/hy/core/hy_repr.hy
@@ -61,7 +61,7 @@
 
   Like ``repr`` in Python, ``hy.repr`` can round-trip many kinds of
   values. Round-tripping implies that given an object ``x``,
-  ``(hy.eval (read-str (hy.repr x)))`` returns ``x``, or at least a value
+  ``(hy.eval (hy.read-str (hy.repr x)))`` returns ``x``, or at least a value
   that's equal to ``x``.
 
   Examples:

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -868,11 +868,11 @@
   (list (map mangle
     '[butlast calling-module calling-module-name coll?
       constantly dec distinct
-      disassemble drop-last empty? even? every?
-      flatten float? gensym inc
+      drop-last empty? even? every?
+      flatten float? inc
       integer? integer-char? iterable?
-      iterator? keyword? list? macroexpand
-      macroexpand-1 mangle neg? none?
-      numeric? odd? parse-args pos? read read-str
+      iterator? keyword? list?
+      neg? none?
+      numeric? odd? parse-args pos?
       rest some string? symbol?
-      tuple? unmangle xor zero?])))
+      tuple? xor zero?])))

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -156,14 +156,14 @@
   Examples:
     ::
 
-       => (disassemble '(print \"Hello World!\"))
+       => (hy.disassemble '(print \"Hello World!\"))
        Module(
         body=[
             Expr(value=Call(func=Name(id='print'), args=[Str(s='Hello World!')], keywords=[], starargs=None, kwargs=None))])
 
     ::
 
-       => (disassemble '(print \"Hello World!\") True)
+       => (hy.disassemble '(print \"Hello World!\") True)
        print('Hello World!')
   "
   (import ast hy.compiler)
@@ -423,12 +423,12 @@
   Examples:
     ::
 
-      => (gensym)
+      => (hy.gensym)
       '_G￿1
 
     ::
 
-      => (gensym \"x\")
+      => (hy.gensym \"x\")
       '_x￿2
 
    "
@@ -578,12 +578,12 @@
   Examples:
     ::
 
-       => (macroexpand '(-> (a b) (x y)))
+       => (hy.macroexpand '(-> (a b) (x y)))
        '(x (a b) y)
 
     ::
 
-       => (macroexpand '(-> (a b) (-> (c d) (e f))))
+       => (hy.macroexpand '(-> (a b) (-> (c d) (e f))))
        '(e (c (a b) d) f)
   "
   (import hy.macros)
@@ -598,7 +598,7 @@
   Examples:
     ::
 
-       => (macroexpand-1 '(-> (a b) (-> (c d) (e f))))
+       => (hy.macroexpand-1 '(-> (a b) (-> (c d) (e f))))
        '(-> (a b) (c d) (e f))
   "
   (import hy.macros)

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -129,7 +129,7 @@
     (macro-error (get other-kvs -1)
                  "`assoc` takes an odd number of arguments"))
   (setv c (if other-kvs
-            (gensym "c")
+            (hy.gensym "c")
             coll))
   `(setv ~@(+ (if other-kvs
                 [c coll]
@@ -179,7 +179,7 @@
         (not (and (is (type branch) hy.models.List) branch))
           (macro-error branch "each cond branch needs to be a nonempty list")
         (= (len branch) 1) (do
-          (setv g (gensym))
+          (setv g (hy.gensym))
           [`(do (setv ~g ~(get branch 0)) ~g) g])
         True
           [(get branch 0) `(do ~@(cut branch 1 None))]))
@@ -230,7 +230,7 @@
        => collection
        [2 1]
   "
-  (setv f (gensym))
+  (setv f (hy.gensym))
   (defn build-form [expression]
     (if (isinstance expression hy.models.Expression)
       `(~(get expression 0) ~f ~@(rest expression))
@@ -425,7 +425,7 @@
 
 
 (defn _do-n [count-form body]
-  `(for [~(gensym) (range ~count-form)]
+  `(for [~(hy.gensym) (range ~count-form)]
     ~@body))
 
 
@@ -456,7 +456,7 @@
     => (list-n 5 (+= counter 1) counter)
     [1 2 3 4 5]
   "
-  (setv l (gensym))
+  (setv l (hy.gensym))
   `(do
     (setv ~l [])
     ~(_do-n count-form [`(.append ~l (do ~@body))])
@@ -480,9 +480,9 @@
     expands to::
 
        => (do
-       ...   (setv a (gensym)
-       ...         b (gensym)
-       ...         c (gensym))
+       ...   (setv a (hy.gensym)
+       ...         b (hy.gensym)
+       ...         c (hy.gensym))
        ...   ...)
 
   .. seealso::
@@ -491,7 +491,7 @@
   "
   (setv syms [])
   (for [arg args]
-    (.extend syms [arg `(gensym '~arg)]))
+    (.extend syms [arg `(hy.gensym '~arg)]))
   `(do
     (setv ~@syms)
     ~@body))
@@ -507,7 +507,7 @@
   any symbol that starts with
   ``g!``.
 
-  For example, ``g!a`` would become ``(gensym \"a\")``.
+  For example, ``g!a`` would become ``(hy.gensym \"a\")``.
 
   .. seealso::
 
@@ -521,7 +521,7 @@
                        (flatten body))))
         gensyms [])
   (for [sym syms]
-    (.extend gensyms [sym `(gensym ~(cut sym 2 None))]))
+    (.extend gensyms [sym `(hy.gensym ~(cut sym 2 None))]))
 
   (setv [docstring body] (if (and (isinstance (get body 0) str)
                                   (> (len body) 1))
@@ -634,8 +634,8 @@
        ...   (print (* args.STRING args.n))
        ...   0)
 "
-  (setv retval (gensym)
-        restval (gensym))
+  (setv retval (hy.gensym)
+        restval (hy.gensym))
   `(when (= __name__ "__main__")
      (import sys)
      (setv ~retval ((fn [~@(or args `[#* ~restval])] ~@body) #* sys.argv))
@@ -689,8 +689,8 @@
 
    Use ``(help foo)`` instead for help with runtime objects."
    (setv symbol (str symbol))
-   (setv mangled (mangle symbol))
-   (setv builtins (gensym "builtins"))
+   (setv mangled (hy.mangle symbol))
+   (setv builtins (hy.gensym "builtins"))
    `(do (import [builtins :as ~builtins])
         (help (or (.get __macros__ ~mangled)
                   (.get (. ~builtins __macros__) ~mangled)

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -31,7 +31,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
   "Supply `it` as a gensym and R as a function to replace `it` with the
   given gensym throughout expressions."
   `(do
-    (setv it (gensym))
+    (setv it (hy.gensym))
     (defn R [form]
       "Replace `it` with a gensym throughout `form`."
       (recur-sym-replace {'it it} form))
@@ -180,7 +180,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
        => (ap-last (> it 5) (range 10))
        9"
-  (setv x (gensym))
+  (setv x (hy.gensym))
   (rit `(do
     (setv ~x None)
     (for  [~it ~xs  :if ~(R form)]
@@ -208,8 +208,8 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
        => (ap-reduce (+ it acc) (range 10))
        45"
   (setv
-    it (gensym)
-    acc (gensym))
+    it (hy.gensym)
+    acc (hy.gensym))
   (defn R [form]
     (recur-sym-replace {'it it  'acc acc} form))
   `(do

--- a/hy/extra/reserved.hy
+++ b/hy/extra/reserved.hy
@@ -9,7 +9,7 @@
 
 (defn special []
   "Return a frozenset of special operators, such as ``fn`` and ``+``."
-  (frozenset (map unmangle
+  (frozenset (map hy.unmangle
     (.keys hy.compiler._special_form_compilers))))
 
 (defn names []
@@ -31,7 +31,7 @@
   "
   (global _cache)
   (if (is _cache None) (do
-    (setv _cache (frozenset (map unmangle (+
+    (setv _cache (frozenset (map hy.unmangle (+
       hy.core.__all__
       (list (.keys hy.core.bootstrap.__macros__))
       (list (.keys hy.core.macros.__macros__))

--- a/hy/lex/__init__.py
+++ b/hy/lex/__init__.py
@@ -103,22 +103,22 @@ def mangle(s):
     Examples:
       ::
 
-         => (mangle 'foo-bar)
+         => (hy.mangle 'foo-bar)
          "foo_bar"
 
-         => (mangle 'foo-bar?)
+         => (hy.mangle 'foo-bar?)
          "is_foo_bar"
 
-         => (mangle '*)
+         => (hy.mangle '*)
          "hyx_XasteriskX"
 
-         => (mangle '_foo/a?)
+         => (hy.mangle '_foo/a?)
          "_hyx_is_fooXsolidusXa"
 
-         => (mangle '-->)
+         => (hy.mangle '-->)
          "hyx_XhyphenHminusX_XgreaterHthan_signX"
 
-         => (mangle '<--)
+         => (hy.mangle '<--)
          "hyx_XlessHthan_signX__"
     """
     def unicode_char_to_hex(uchr):
@@ -175,25 +175,25 @@ def unmangle(s):
     Examples:
       ::
 
-         => (unmangle 'foo_bar)
+         => (hy.unmangle 'foo_bar)
          "foo-bar"
 
-         => (unmangle 'is_foo_bar)
+         => (hy.unmangle 'is_foo_bar)
          "foo-bar?"
 
-         => (unmangle 'hyx_XasteriskX)
+         => (hy.unmangle 'hyx_XasteriskX)
          "*"
 
-         => (unmangle '_hyx_is_fooXsolidusXa)
+         => (hy.unmangle '_hyx_is_fooXsolidusXa)
          "_foo/a?"
 
-         => (unmangle 'hyx_XhyphenHminusX_XgreaterHthan_signX)
+         => (hy.unmangle 'hyx_XhyphenHminusX_XgreaterHthan_signX)
          "-->"
 
-         => (unmangle 'hyx_XlessHthan_signX__)
+         => (hy.unmangle 'hyx_XlessHthan_signX__)
          "<--"
 
-         => (unmangle '__dunder_name__)
+         => (hy.unmangle '__dunder_name__)
          "__dunder-name__"
     """
 
@@ -233,13 +233,13 @@ def read(from_file=sys.stdin, eof=""):
     Examples:
       ::
 
-         => (read)
+         => (hy.read)
          (+ 2 2)
          '(+ 2 2)
 
       ::
 
-         => (hy.eval (read))
+         => (hy.eval (hy.read))
          (+ 2 2)
          4
 
@@ -247,9 +247,9 @@ def read(from_file=sys.stdin, eof=""):
 
          => (import io)
          => (setv buffer (io.StringIO "(+ 2 2)\\n(- 2 1)"))
-         => (hy.eval (read :from-file buffer))
+         => (hy.eval (hy.read :from-file buffer))
          4
-         => (hy.eval (read :from-file buffer))
+         => (hy.eval (hy.read :from-file buffer))
          1
 
       ::
@@ -259,7 +259,7 @@ def read(from_file=sys.stdin, eof=""):
          35
          => (with [f (open "example.hy")]
          ...  (try (while True
-         ...         (setv exp (read f))
+         ...         (setv exp (hy.read f))
          ...         (print "OHY" exp)
          ...         (hy.eval exp))
          ...       (except [e EOFError]
@@ -292,18 +292,18 @@ def read(from_file=sys.stdin, eof=""):
 
 
 def read_str(input):
-    """This is essentially a wrapper around `read` which reads expressions from a
+    """This is essentially a wrapper around ``hy.read`` which reads expressions from a
     string
 
     Examples:
       ::
 
-         => (read-str "(print 1)")
+         => (hy.read-str "(print 1)")
          '(print 1)
 
       ::
 
-         => (hy.eval (read-str "(print 1)"))
+         => (hy.eval (hy.read-str "(print 1)"))
          1
   """
     return read(StringIO(str(input)))

--- a/tests/native_tests/contrib/destructure.hy
+++ b/tests/native_tests/contrib/destructure.hy
@@ -215,9 +215,9 @@
 
 (defn test-errors []
   (with [(pytest.raises TypeError)]
-    (hy.eval (macroexpand '(setv+ [a b] 1))))
+    (hy.eval (hy.macroexpand '(setv+ [a b] 1))))
   (with [(pytest.raises AttributeError)]
-    (hy.eval (macroexpand '(setv+ {a :a} 1))))
+    (hy.eval (hy.macroexpand '(setv+ {a :a} 1))))
   (with [(pytest.raises SyntaxError)]
     (destructure '{a b c} {:a 1}))
   (with [(pytest.raises SyntaxError)]

--- a/tests/native_tests/contrib/slicing.hy
+++ b/tests/native_tests/contrib/slicing.hy
@@ -4,13 +4,13 @@
 (require [hy.contrib.slicing [*]])
 
 (defn test-ncuts-slicing []
-  (assert (= (macroexpand '(ncut df 1:5:-1))           '(get df (slice 1 5 -1))))
-  (assert (= (macroexpand '(ncut df :))                '(get df (slice None None))))
-  (assert (= (macroexpand '(ncut df 1:5:-1 ["A" "B"])) '(get df (, (slice 1 5 -1) ["A" "B"]))))
-  (assert (= (macroexpand '(ncut df ::2 3 ...))         '(get df (, (slice None None 2) 3 Ellipsis))))
-  (assert (= (macroexpand '(ncut df (: 1/3 2.5 5j) ["A" "B"] abc:def 5))
+  (assert (= (hy.macroexpand '(ncut df 1:5:-1))           '(get df (slice 1 5 -1))))
+  (assert (= (hy.macroexpand '(ncut df :))                '(get df (slice None None))))
+  (assert (= (hy.macroexpand '(ncut df 1:5:-1 ["A" "B"])) '(get df (, (slice 1 5 -1) ["A" "B"]))))
+  (assert (= (hy.macroexpand '(ncut df ::2 3 ...))         '(get df (, (slice None None 2) 3 Ellipsis))))
+  (assert (= (hy.macroexpand '(ncut df (: 1/3 2.5 5j) ["A" "B"] abc:def 5))
              '(get df (, (slice 1/3 2.5 5j) ["A" "B"] abc:def 5))))
-  (assert (= (macroexpand '(ncut df (, 1 2) (: (f) (g 1 2) -2) :))
+  (assert (= (hy.macroexpand '(ncut df (, 1 2) (: (f) (g 1 2) -2) :))
              '(get df (, (, 1 2) (slice (f) (g 1 2) -2) (slice None None)))))
 
   (assert (= (ncut [1 2 3 4] 1::-1)) [2 1])

--- a/tests/native_tests/contrib/test_pprint.hy
+++ b/tests/native_tests/contrib/test_pprint.hy
@@ -120,7 +120,7 @@
  [[[[[1 2 3]
      "1 2"]]]]]]FOO])
 
-  (setv o (hy.eval (read-str exp)))
+  (setv o (hy.eval (hy.read-str exp)))
   (assert (= (pprint.pformat o :width 16) exp))
   (assert (= (pprint.pformat o :width 17) exp))
   (assert (= (pprint.pformat o :width 22) exp))

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -79,15 +79,15 @@
   (setv form '(do
                 (setv foo (fn [a [b 1]] (* b (inc a))))
                 (* b (foo 7)))
-        form1 (macroexpand
+        form1 (hy.macroexpand
                 '(smacrolet [b c]
                    (setv foo (fn [a [b 1]] (* b (inc a))))
                    (* b (foo 7))))
-        form2 (macroexpand
+        form2 (hy.macroexpand
                 '(smacrolet [a c]
                    (setv foo (fn [a [b 1]] (* b (inc a))))
                    (* b (foo 7))))
-        form3 (macroexpand
+        form3 (hy.macroexpand
                 '(smacrolet [foo bar]
                    (setv foo (fn [a [b 1]] (* b (inc a))))
                    (* b (foo 7)))))
@@ -366,7 +366,7 @@
   (assert (= 42 (+count 40))))
 
 (defmacro triple [a]
-  (setv g!a (gensym a))
+  (setv g!a (hy.gensym a))
   `(do
      (setv ~g!a ~a)
      (+ ~g!a ~g!a ~g!a)))

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -247,11 +247,11 @@ result['y in globals'] = 'y' in globals()")
 
 (defn test-gensym []
   "NATIVE: testing the gensym function"
-  (setv s1 (gensym))
+  (setv s1 (hy.gensym))
   (assert (isinstance s1 hy.models.Symbol))
   (assert (= 0 (.find s1 "_G\uffff")))
-  (setv s2 (gensym "xx"))
-  (setv s3 (gensym "xx"))
+  (setv s2 (hy.gensym "xx"))
+  (setv s3 (hy.gensym "xx"))
   (assert (= 0 (.find s2 "_xx\uffff")))
   (assert (not (= s2 s3)))
   (assert (not (= (str s2) (str s3)))))
@@ -461,7 +461,7 @@ result['y in globals'] = 'y' in globals()")
   (setv [out err] (.readouterr capsys))
   ;; https://github.com/hylang/hy/issues/1946
   (assert (.startswith (.strip out)
-            f"Help on function {(mangle '<-mangle->)} in module "))
+            f"Help on function {(hy.mangle '<-mangle->)} in module "))
   (assert (in "a fancy docstring" out))
   (assert (empty? err))
 

--- a/tests/native_tests/hy_repr.hy
+++ b/tests/native_tests/hy_repr.hy
@@ -38,10 +38,10 @@
     'f"the answer is {(+ 2 2) = !r :4}"
     'f"the answer is {(+ 2 2):{(+ 2 3)}}"])
   (for [original-val values]
-    (setv evaled (hy.eval (read-str (hy.repr original-val))))
+    (setv evaled (hy.eval (hy.read-str (hy.repr original-val))))
     (assert (= evaled original-val))
     (assert (is (type evaled) (type original-val))))
-  (assert (isnan (hy.eval (read-str (hy.repr NaN))))))
+  (assert (isnan (hy.eval (hy.read-str (hy.repr NaN))))))
 
 (defn test-hy-repr-roundtrip-from-str []
   (setv strs [
@@ -69,7 +69,7 @@
     ":akeyword"
     "'(f #* args #** kwargs)"])
   (for [original-str strs]
-    (setv rep (hy.repr (hy.eval (read-str original-str))))
+    (setv rep (hy.repr (hy.eval (hy.read-str original-str))))
     (assert (= rep original-str))))
 
 (defn test-hy-repr-no-roundtrip []
@@ -80,7 +80,7 @@
   (setv orig `[a ~5.0])
   (setv reprd (hy.repr orig))
   (assert (= reprd "'[a 5.0]"))
-  (setv result (hy.eval (read-str reprd)))
+  (setv result (hy.eval (hy.read-str reprd)))
 
   (assert (is (type (get orig 1)) float))
   (assert (is (type (get result 1)) hy.models.Float)))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1475,7 +1475,7 @@ cee\"} dee" "ey bee\ncee dee"))
 
   (require [tests.resources [tlib macros :as m]])
   (assert (in "tlib.qplah" __macros__))
-  (assert (in (mangle "m.test-macro") __macros__))
+  (assert (in (hy.mangle "m.test-macro") __macros__))
   (require [os [path]])
   (with [(pytest.raises hy.errors.HyRequireError)]
     (hy.eval '(require [tests.resources [does-not-exist]]))))
@@ -1569,9 +1569,9 @@ cee\"} dee" "ey bee\ncee dee"))
 
 (defn test-macroexpand []
   "Test macroexpand on ->"
-  (assert (= (macroexpand '(-> (a b) (x y)))
+  (assert (= (hy.macroexpand '(-> (a b) (x y)))
              '(x (a b) y)))
-  (assert (= (macroexpand '(-> (a b) (-> (c d) (e f))))
+  (assert (= (hy.macroexpand '(-> (a b) (-> (c d) (e f))))
              '(e (c (a b) d) f))))
 
 (defn test-macroexpand-with-named-import []
@@ -1579,11 +1579,11 @@ cee\"} dee" "ey bee\ncee dee"))
   (defmacro m-with-named-import []
     (import [math [pow]])
     (pow 2 3))
-  (assert (= (macroexpand '(m-with-named-import)) (** 2 3))))
+  (assert (= (hy.macroexpand '(m-with-named-import)) (** 2 3))))
 
 (defn test-macroexpand-1 []
   "Test macroexpand-1 on ->"
-  (assert (= (macroexpand-1 '(-> (a b) (-> (c d) (e f))))
+  (assert (= (hy.macroexpand-1 '(-> (a b) (-> (c d) (e f))))
              '(-> (a b) (c d) (e f)))))
 
 
@@ -1595,16 +1595,16 @@ cee\"} dee" "ey bee\ncee dee"))
 (defn test-disassemble []
   "NATIVE: Test the disassemble function"
   (defn nos [x] (re.sub r"\s" "" x))
-  (assert (= (nos (disassemble '(do (leaky) (leaky) (macros))))
+  (assert (= (nos (hy.disassemble '(do (leaky) (leaky) (macros))))
     (nos (.format
       "Module(
           body=[Expr(value=Call(func=Name(id='leaky', ctx=Load()), args=[], keywords=[])),
               Expr(value=Call(func=Name(id='leaky', ctx=Load()), args=[], keywords=[])),
               Expr(value=Call(func=Name(id='macros', ctx=Load()), args=[], keywords=[]))]{})"
       (if PY3_8 ",type_ignores=[]" "")))))
-  (assert (= (nos (disassemble '(do (leaky) (leaky) (macros)) True))
+  (assert (= (nos (hy.disassemble '(do (leaky) (leaky) (macros)) True))
              "leaky()leaky()macros()"))
-  (assert (= (re.sub r"[()\n ]" "" (disassemble `(+ ~(+ 1 1) 40) True))
+  (assert (= (re.sub r"[()\n ]" "" (hy.disassemble `(+ ~(+ 1 1) 40) True))
              "2+40")))
 
 
@@ -1637,32 +1637,32 @@ cee\"} dee" "ey bee\ncee dee"))
   (import [io [StringIO]])
 
   (setv stdin-buffer (StringIO "(+ 2 2)\n(- 2 2)"))
-  (assert (= (hy.eval (read stdin-buffer)) 4))
-  (assert (isinstance (read stdin-buffer) hy.models.Expression))
+  (assert (= (hy.eval (hy.read stdin-buffer)) 4))
+  (assert (isinstance (hy.read stdin-buffer) hy.models.Expression))
 
   "Multiline test"
   (setv stdin-buffer (StringIO "(\n+\n41\n1\n)\n(-\n2\n1\n)"))
-  (assert (= (hy.eval (read stdin-buffer)) 42))
-  (assert (= (hy.eval (read stdin-buffer)) 1))
+  (assert (= (hy.eval (hy.read stdin-buffer)) 42))
+  (assert (= (hy.eval (hy.read stdin-buffer)) 1))
 
   "EOF test"
   (setv stdin-buffer (StringIO "(+ 2 2)"))
-  (read stdin-buffer)
+  (hy.read stdin-buffer)
   (with [(pytest.raises EOFError)]
-    (read stdin-buffer)))
+    (hy.read stdin-buffer)))
 
 (defn test-read-str []
   "NATIVE: test read-str"
-  (assert (= (read-str "(print 1)") '(print 1)))
-  (assert (is (type (read-str "(print 1)")) (type '(print 1))))
+  (assert (= (hy.read-str "(print 1)") '(print 1)))
+  (assert (is (type (hy.read-str "(print 1)")) (type '(print 1))))
 
   ; Watch out for false values: https://github.com/hylang/hy/issues/1243
-  (assert (= (read-str "\"\"") '""))
-  (assert (is (type (read-str "\"\"")) (type '"")))
-  (assert (= (read-str "[]") '[]))
-  (assert (is (type (read-str "[]")) (type '[])))
-  (assert (= (read-str "0") '0))
-  (assert (is (type (read-str "0")) (type '0))))
+  (assert (= (hy.read-str "\"\"") '""))
+  (assert (is (type (hy.read-str "\"\"")) (type '"")))
+  (assert (= (hy.read-str "[]") '[]))
+  (assert (is (type (hy.read-str "[]")) (type '[])))
+  (assert (= (hy.read-str "0") '0))
+  (assert (is (type (hy.read-str "0")) (type '0))))
 
 (defn test-keyword-creation []
   (assert (= (hy.models.Keyword "foo") :foo))

--- a/tests/native_tests/mangling.hy
+++ b/tests/native_tests/mangling.hy
@@ -18,32 +18,32 @@
 
 (defn test-mangle-hyphen-underscore []
   ;; https://github.com/hylang/hy/issues/1635
-  (assert (= (mangle "-")               "hyx_XhyphenHminusX"))
-  (assert (= (mangle "-a")              "hyx_XhyphenHminusXa"))
-  (assert (= (mangle "-_a")             "hyx_XhyphenHminusX_a"))
-  (assert (= (mangle "_-a")             "_hyx_XhyphenHminusXa"))
-  (assert (= (mangle "__init__")        "__init__"))
-  (assert (= (mangle "--init--")        "hyx_XhyphenHminusX_init__"))
-  (assert (= (mangle "__dunder-name__") "__dunder_name__"))
-  (assert (= (mangle "-->")             "hyx_XhyphenHminusX_XgreaterHthan_signX"))
-  (assert (= (mangle "<--")             "hyx_XlessHthan_signX__"))
+  (assert (= (hy.mangle "-")               "hyx_XhyphenHminusX"))
+  (assert (= (hy.mangle "-a")              "hyx_XhyphenHminusXa"))
+  (assert (= (hy.mangle "-_a")             "hyx_XhyphenHminusX_a"))
+  (assert (= (hy.mangle "_-a")             "_hyx_XhyphenHminusXa"))
+  (assert (= (hy.mangle "__init__")        "__init__"))
+  (assert (= (hy.mangle "--init--")        "hyx_XhyphenHminusX_init__"))
+  (assert (= (hy.mangle "__dunder-name__") "__dunder_name__"))
+  (assert (= (hy.mangle "-->")             "hyx_XhyphenHminusX_XgreaterHthan_signX"))
+  (assert (= (hy.mangle "<--")             "hyx_XlessHthan_signX__"))
 
   ;; test various interactions
-  (assert (= (mangle "----")   "hyx_XhyphenHminusX___"))
-  (assert (= (mangle "--__")   "hyx_XhyphenHminusX___"))
-  (assert (= (mangle "__--")   "__hyx_XhyphenHminusX_"))
-  (assert (= (mangle "__--__") "__hyx_XhyphenHminusX___"))
-  (assert (= (mangle "--?")    "hyx_is_XhyphenHminusX_"))
-  (assert (= (mangle "__--?")  "__hyx_is_XhyphenHminusX_"))
+  (assert (= (hy.mangle "----")   "hyx_XhyphenHminusX___"))
+  (assert (= (hy.mangle "--__")   "hyx_XhyphenHminusX___"))
+  (assert (= (hy.mangle "__--")   "__hyx_XhyphenHminusX_"))
+  (assert (= (hy.mangle "__--__") "__hyx_XhyphenHminusX___"))
+  (assert (= (hy.mangle "--?")    "hyx_is_XhyphenHminusX_"))
+  (assert (= (hy.mangle "__--?")  "__hyx_is_XhyphenHminusX_"))
 
   ;; test unmangling choices
-  (assert (= (unmangle "hyx_XhyphenHminusX")        "-"))
-  (assert (= (unmangle "_")                         "_"))
-  (assert (= (unmangle "__init__")                  "__init__"))
-  (assert (= (unmangle "hyx_XhyphenHminusX_init__") "--init--"))
-  (assert (= (unmangle "__dunder_name__")           "__dunder-name__"))
-  (assert (= (unmangle "hyx_XhyphenHminusX_XgreaterHthan_signX") "-->"))
-  (assert (= (unmangle "hyx_XlessHthan_signX__")                 "<--")))
+  (assert (= (hy.unmangle "hyx_XhyphenHminusX")        "-"))
+  (assert (= (hy.unmangle "_")                         "_"))
+  (assert (= (hy.unmangle "__init__")                  "__init__"))
+  (assert (= (hy.unmangle "hyx_XhyphenHminusX_init__") "--init--"))
+  (assert (= (hy.unmangle "__dunder_name__")           "__dunder-name__"))
+  (assert (= (hy.unmangle "hyx_XhyphenHminusX_XgreaterHthan_signX") "-->"))
+  (assert (= (hy.unmangle "hyx_XlessHthan_signX__")                 "<--")))
 
 
 (defn test-underscore-number []
@@ -179,29 +179,29 @@
   (for [[a b] [["___ab-cd?" "___is_ab_cd"]
                ["if" "hyx_if"]
                ["⚘-⚘" "hyx_XflowerX_XflowerX"]]]
-    (assert (= (mangle a) b))
-    (assert (= (unmangle b) a))))
+    (assert (= (hy.mangle a) b))
+    (assert (= (hy.unmangle b) a))))
 
 
 (defn test-nongraphic []
   ; https://github.com/hylang/hy/issues/1694
 
-  (assert (= (mangle " ") "hyx_XspaceX"))
-  (assert (= (mangle "\a") "hyx_XU7X"))
-  (assert (= (mangle "\t") "hyx_XU9X"))
-  (assert (= (mangle "\n") "hyx_XUaX"))
-  (assert (= (mangle "\r") "hyx_XUdX"))
-  (assert (= (mangle "\r") "hyx_XUdX"))
+  (assert (= (hy.mangle " ") "hyx_XspaceX"))
+  (assert (= (hy.mangle "\a") "hyx_XU7X"))
+  (assert (= (hy.mangle "\t") "hyx_XU9X"))
+  (assert (= (hy.mangle "\n") "hyx_XUaX"))
+  (assert (= (hy.mangle "\r") "hyx_XUdX"))
+  (assert (= (hy.mangle "\r") "hyx_XUdX"))
 
-  (assert (= (mangle (chr 127)) "hyx_XU7fX"))
-  (assert (= (mangle (chr 128)) "hyx_XU80X"))
-  (assert (= (mangle (chr 0xa0)) "hyx_XnoHbreak_spaceX"))
-  (assert (= (mangle (chr 0x378)) "hyx_XU378X"))
-  (assert (= (mangle (chr 0x200a) "hyx_Xhair_spaceX")))
-  (assert (= (mangle (chr 0x2065)) "hyx_XU2065X"))
-  (assert (= (mangle (chr 0x1000c)) "hyx_XU1000cX")))
+  (assert (= (hy.mangle (chr 127)) "hyx_XU7fX"))
+  (assert (= (hy.mangle (chr 128)) "hyx_XU80X"))
+  (assert (= (hy.mangle (chr 0xa0)) "hyx_XnoHbreak_spaceX"))
+  (assert (= (hy.mangle (chr 0x378)) "hyx_XU378X"))
+  (assert (= (hy.mangle (chr 0x200a) "hyx_Xhair_spaceX")))
+  (assert (= (hy.mangle (chr 0x2065)) "hyx_XU2065X"))
+  (assert (= (hy.mangle (chr 0x1000c)) "hyx_XU1000cX")))
 
 
 (defn test-mangle-bad-indent []
   ; Shouldn't crash with IndentationError
-  (mangle "  0\n 0"))
+  (hy.mangle "  0\n 0"))

--- a/tests/native_tests/model_patterns.hy
+++ b/tests/native_tests/model_patterns.hy
@@ -8,7 +8,7 @@
     [funcparserlib.parser [many]])
   (setv [body condition] (->> args (.parse (whole
     [(many (notpexpr "until")) (dolike "until")]))))
-  (setv g (gensym))
+  (setv g (hy.gensym))
   `(do
     (setv ~g True)
     (while (or ~g (not (do ~@condition)))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -155,7 +155,7 @@
   (import [hy.compiler [hy-compile]])
   (import [hy.lex [hy-parse]])
   (setv macro1 "(defmacro nif [expr pos zero neg]
-      (setv g (gensym))
+      (setv g (hy.gensym))
       `(do
          (setv ~g ~expr)
          (cond [(pos? ~g) ~pos]
@@ -171,8 +171,8 @@
   (setv s1 (ast.unparse _ast1))
   (setv s2 (ast.unparse _ast2))
   ;; and make sure there is something new that starts with _G\uffff
-  (assert (in (mangle "_G\uffff") s1))
-  (assert (in (mangle "_G\uffff") s2))
+  (assert (in (hy.mangle "_G\uffff") s1))
+  (assert (in (hy.mangle "_G\uffff") s2))
   ;; but make sure the two don't match each other
   (assert (not (= s1 s2))))
 
@@ -196,8 +196,8 @@
   (setv _ast2 (hy-compile (hy-parse macro1) __name__))
   (setv s1 (ast.unparse _ast1))
   (setv s2 (ast.unparse _ast2))
-  (assert (in (mangle "_a\uffff") s1))
-  (assert (in (mangle "_a\uffff") s2))
+  (assert (in (hy.mangle "_a\uffff") s1))
+  (assert (in (hy.mangle "_a\uffff") s2))
   (assert (not (= s1 s2))))
 
 (defn test-defmacro/g! []
@@ -219,8 +219,8 @@
   (setv _ast2 (hy-compile (hy-parse macro1) __name__))
   (setv s1 (ast.unparse _ast1))
   (setv s2 (ast.unparse _ast2))
-  (assert (in (mangle "_res\uffff") s1))
-  (assert (in (mangle "_res\uffff") s2))
+  (assert (in (hy.mangle "_res\uffff") s1))
+  (assert (in (hy.mangle "_res\uffff") s2))
   (assert (not (= s1 s2)))
 
   ;; defmacro/g! didn't like numbers initially because they
@@ -248,8 +248,8 @@
   (setv _ast2 (hy-compile (hy-parse macro1) __name__))
   (setv s1 (ast.unparse _ast1))
   (setv s2 (ast.unparse _ast2))
-  (assert (in (mangle "_res\uffff") s1))
-  (assert (in (mangle "_res\uffff") s2))
+  (assert (in (hy.mangle "_res\uffff") s1))
+  (assert (in (hy.mangle "_res\uffff") s2))
   (assert (not (= s1 s2)))
 
   ;; defmacro/g! didn't like numbers initially because they
@@ -424,7 +424,7 @@ in expansions."
   (defn require-macros []
     (require [tests.resources.macros :as m])
 
-    (assert (in (mangle "m.test-macro") __macros__))
+    (assert (in (hy.mangle "m.test-macro") __macros__))
     (for [macro-name __macros__]
       (assert (not (and (in "with" macro-name)
                         (!= "with" macro-name))))))
@@ -475,18 +475,18 @@ in expansions."
               [test-module-macro]])
 
     ;; Make sure that `require` didn't add any of its `require`s
-    (assert (not (in (mangle "nonlocal-test-macro") __macros__)))
+    (assert (not (in (hy.mangle "nonlocal-test-macro") __macros__)))
     ;; and that it didn't add its tags.
-    (assert (not (in (mangle "#test-module-tag") __macros__)))
+    (assert (not (in (hy.mangle "#test-module-tag") __macros__)))
 
     ;; Now, require everything.
     (require [tests.resources.macro-with-require [*]])
 
     ;; Again, make sure it didn't add its required macros and/or tags.
-    (assert (not (in (mangle "nonlocal-test-macro") __macros__)))
+    (assert (not (in (hy.mangle "nonlocal-test-macro") __macros__)))
 
     ;; Its tag(s) should be here now.
-    (assert (in (mangle "#test-module-tag") __macros__))
+    (assert (in (hy.mangle "#test-module-tag") __macros__))
 
     ;; The test macro expands to include this symbol.
     (setv module-name-var "tests.native_tests.native_macros")


### PR DESCRIPTION
this removes `read-str`, `read`, `eval`, `mangle`, `unmangle`, `disassemble`, `macroexpand`, `macroexpand-1`, and `gensym` from builtins injection and moves them under the root `hy` module if they weren't already there. 