### PR TITLE
Clean: make 'calling-module' & 'calling-module-name' internal to hy

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -43,6 +43,7 @@ Other Breaking Changes
 * `gensym`, `macroexpand`, `macroexpand-1`, and `disassemble` are no longer
   automatically brought into scope. Call them as `hy.gensym`, `hy.macroexpand`, etc
   or import them explicitly.
+* made `calling-module-name` private and `calling-module` internal to Hy
 
 New Features
 ------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1263,14 +1263,11 @@ base names, such that ``hy.core.language.butlast`` can be called with just ``but
 
 
 .. hy:automodule:: hy.core.language
-   :members: butlast, calling-module, calling-module-name,
+   :members: butlast,
       coll?, constantly, dec, distinct, drop-last, empty?,
       even?, every?, flatten, float?, inc, integer?, integer-char?,
       iterable?, iterator?, keyword?, list?, neg?, none?, numeric?, odd?,
       parse-args, pos?, rest, some, string?, symbol?, tuple?, xor, zero?
-
-.. hy:autofunction:: hy.core.language.calling-module
-
 
 .. hy:automodule:: hy.core.shadow
    :members:

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -11,7 +11,7 @@
         [importlib [import-module]]
         [collections [OrderedDict]]
         [hy.macros [macroexpand :as mexpand]]
-        [hy.compiler [HyASTCompiler]]
+        [hy.compiler [HyASTCompiler calling-module]]
         [hy.extra.reserved [special]])
 
 (defn walk [inner outer form]

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -168,7 +168,7 @@
   "
   (import ast hy.compiler)
 
-  (setv compiled (hy.compiler.hy-compile tree (calling-module-name) :import-stdlib False))
+  (setv compiled (hy.compiler.hy-compile tree (_calling-module-name) :import-stdlib False))
   (if
     codegen
       (ast.unparse compiled)
@@ -441,9 +441,9 @@
        (finally (.release _gensym_lock)))
   new_symbol)
 
-(defn calling-module-name [[n 1]]
+(defn _calling-module-name [[n 1]]
   "Get the name of the module calling `n` levels up the stack from the
-  `calling-module-name` function call (by default, one level up)"
+  `_calling-module-name` function call (by default, one level up)"
   (import inspect)
 
   (setv f (get (.stack inspect) (+ n 1) 0))
@@ -866,7 +866,7 @@
 
 (setv __all__
   (list (map mangle
-    '[butlast calling-module calling-module-name coll?
+    '[butlast coll?
       constantly dec distinct
       drop-last empty? even? every?
       flatten float? inc

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1586,12 +1586,6 @@ cee\"} dee" "ey bee\ncee dee"))
   (assert (= (hy.macroexpand-1 '(-> (a b) (-> (c d) (e f))))
              '(-> (a b) (c d) (e f)))))
 
-
-(defn test-calling-module-name []
-  "NATIVE: Test the calling-module-name function"
-  (assert (= (calling-module-name -1) "hy.core.language")))
-
-
 (defn test-disassemble []
   "NATIVE: Test the disassemble function"
   (defn nos [x] (re.sub r"\s" "" x))


### PR DESCRIPTION
I didn't end up making `calling-module` private because `contrib.walk` uses it, but i did remove it from autodocs and builtins injection. 