### PR TITLE
Refactor/yeet macro error

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -44,6 +44,7 @@ Other Breaking Changes
   automatically brought into scope. Call them as `hy.gensym`, `hy.macroexpand`, etc
   or import them explicitly.
 * made `calling-module-name` private and `calling-module` internal to Hy
+* `macro-error` has been removed, raise typical errors instead
 
 New Features
 ------------------------------

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -392,7 +392,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
 (defmacro let+ [args #* body]
   "let macro with full destructuring with `args`"
   (if (odd? (len args))
-    (macro-error args "let bindings must be paired"))
+      (raise (ValueError "let bindings must be paired")))
   `(let ~(lfor [bs expr] (by2s args)
                sym (destructure bs expr)
            sym)

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -69,7 +69,7 @@ tail-call optimization (TCO) in their Hy code.
 
 (defmacro defnr [name lambda-list #* body]
   (if (not (= (type name) hy.models.Symbol))
-    (macro-error name "defnr takes a name as first argument"))
+      (raise (TypeError "defnr takes a name as first argument")))
   `(do (require hy.contrib.loop)
        (setv ~name (hy.contrib.loop.fnr ~lambda-list ~@body))))
 

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -226,7 +226,7 @@
           parameter-2 2
  "
   (if (not (= (type name) hy.models.Symbol))
-    (macro-error name "defn takes a name as first argument"))
+      (raise (ValueError "defn takes a name as first argument")))
   `(setv ~name (fn* ~@args)))
 
 (defmacro defn/a [name lambda-list #* body]
@@ -242,7 +242,7 @@
        => (defn/a name [params] body)
   "
   (if (not (= (type name) hy.models.Symbol))
-    (macro-error name "defn/a takes a name as first argument"))
+      (raise (ValueError  "defn/a takes a name as first argument")))
   (if (not (isinstance lambda-list hy.models.List))
-    (macro-error name "defn/a takes a parameter list as second argument"))
+      (raise (ValueError "defn/a takes a parameter list as second argument")))
   `(setv ~name (fn/a ~lambda-list ~@body)))

--- a/hy/core/bootstrap.hy
+++ b/hy/core/bootstrap.hy
@@ -108,9 +108,6 @@
                   ~(get args 1)
                   (if ~@(cut args 2 None))))))
 
-(defmacro macro-error [expression reason [filename '__name__]]
-  `(raise (hy.errors.HyMacroExpansionError ~reason ~filename ~expression None)))
-
 (defmacro defn [name #* args]
   "Define `name` as a function with `args` as the signature, annotations, and body.
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -126,8 +126,7 @@
   .. note:: ``assoc`` modifies the datastructure in place and returns ``None``.
   "
   (if (odd? (len other-kvs))
-    (macro-error (get other-kvs -1)
-                 "`assoc` takes an odd number of arguments"))
+      (raise (ValueError "`assoc` takes an odd number of arguments")))
   (setv c (if other-kvs
             (hy.gensym "c")
             coll))
@@ -177,7 +176,7 @@
       branch branches
       (if
         (not (and (is (type branch) hy.models.List) branch))
-          (macro-error branch "each cond branch needs to be a nonempty list")
+        (raise (TypeError "each cond branch needs to be a nonempty list"))
         (= (len branch) 1) (do
           (setv g (hy.gensym))
           [`(do (setv ~g ~(get branch 0)) ~g) g])
@@ -646,7 +645,7 @@
 (defmacro "#@" [expr]
   "with-decorator tag macro"
   (if (empty? expr)
-      (macro-error expr "missing function argument"))
+      (raise (ValueError "missing function argument")))
   (setv decorators (cut expr -1)
         fndef (get expr -1))
   `(with-decorator ~@decorators ~fndef))


### PR DESCRIPTION
easy enough. Also looks like macro error was raising expansion errors with filename and expression backwards :/ 
`(hy.errors.HyMacroExpansionError ~reason ~filename ~expression None)`
and the init of `HyMacroExpansionError` is
```python
    def __init__(self, message, expression=None, filename=None, source=None,
                 lineno=1, colno=1):
```