### PR TITLE
Docs: fix typo in cheatsheet.json

### DIFF
--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -155,7 +155,7 @@
         ]
       },
       {
-        "name": "Arithmatic",
+        "name": "Arithmetic",
         "methods": [
           "hy.core.language.dec",
           "hy.core.shadow.@",


### PR DESCRIPTION
Fixes the spelling of the word 'arithmetic' in the cheatsheet page of the documentation.