### PR TITLE
Run REPL using `python -m hy`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -48,6 +48,8 @@ Other Breaking Changes
 New Features
 ------------------------------
 * `hy-repr` is now the default REPL output function.
+* Running the module a la `python -m hy` is now equivalent to running
+  the `hy` command.
 
 Bug Fixes
 ------------------------------

--- a/hy/__main__.py
+++ b/hy/__main__.py
@@ -1,14 +1,8 @@
-import hy  # NOQA
 import sys
 
-# This just mocks the normalish behavior of the Python interp. Helpful to aid
-# with shimming existing apps that don't really "work" with Hy.
-#
-# You could say this script helps Hyjack a file.
-#
+from hy.cmdline import hy_main
 
+# Running hy as a module (e.g. `python -m hy`)
+# is equivalent to running the main `hy` command.
 
-if len(sys.argv) > 1:
-    sys.argv.pop(0)
-    hy.importer._import_from_path('__main__', sys.argv[0])
-    sys.exit(0)  # right?
+sys.exit(hy_main())


### PR DESCRIPTION
Fixes #2069.

The previous code in `__main__.py` let you run files (e.g. `python -m hy script.hy`) but did
nothing when given no arguments.

The new code just runs `hy_main()` and lets it handle everything, so it's
equivalent to running the `hy` command.
