### PR TITLE
Fix: dissallow python reserved words as parameters or func kwargs

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -49,6 +49,8 @@ Other Breaking Changes
 * `defn`, `defn/a` have been made a special forms
 * `annotate*` has been made public and renamed `annotate`
 * return annotation for `defn` has been moved to before the function name
+* Python reserved words can no longer be parameter names or
+  function call keywords
 
 New Features
 ------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -269,6 +269,35 @@ Special Forms
            parameter-1 1
            parameter-2 2
 
+   .. _reserved_param_names:
+
+   .. note::
+
+      Parameter names cannot be Python reserved words nor can a function
+      be called with keyword arguments that are Python reserved words. This means
+      that the following will raise a `SyntaxError` as they would in Python::
+
+         (defn afunc [a b if])
+         Traceback (most recent call last):
+           File "<stdin>", line 1
+             (defn afunc [a b if])
+                              ^
+         hy.errors.HySyntaxError: parameter name cannot be Python reserved word
+
+         (dict :a 1 :from 2)
+         Traceback (most recent call last):
+           File "<stdin>", line 1
+             (dict :a 1 :from 2)
+                        ^
+         hy.errors.HySyntaxError: keyword argument cannot be Python reserved word
+
+      This only applies to parameter names and a keyword argument name. The value of
+      the parameter or keyword argument can still be a keyword of a reserved word::
+
+         => (defn test [a] a)
+         => (test :a :from)
+         :from
+
 .. hy:function:: (defn/a [name lambda-list #* body])
 
    Define `name` as a function with `lambda-list` signature and body `body`.

--- a/docs/language/syntax.rst
+++ b/docs/language/syntax.rst
@@ -127,7 +127,9 @@ the function ``f`` with the keyword argument named ``foo`` set to ``3``. Hence,
 trying to call a function on a literal keyword may fail: ``(f :foo)`` yields
 the error ``Keyword argument :foo needs a value``. To avoid this, you can quote
 the keyword, as in ``(f ':foo)``, or use it as the value of another keyword
-argument, as in ``(f :arg :foo)``.
+argument, as in ``(f :arg :foo)``. It is important to note that a keyword argument
+cannot be a Python reserved word. This will raise a ``SyntaxError`` similar to Python.
+See :ref:`defn <reserved_param_names>` for examples.
 
 Keywords can be called like functions as shorthand for ``get``. ``(:foo obj)``
 is equivalent to ``(get obj (hy.mangle "foo"))``. An optional ``default`` argument

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -139,7 +139,6 @@
       (setv True 1)
       (defn None [] (print "hello"))
       (defn True [] (print "hello"))
-      (defn f [True] (print "hello"))
       (for [True [1 2 3]] (print "hello"))
       (lfor  True [1 2 3]  True)
       (lfor  :setv True 1  True)
@@ -148,7 +147,14 @@
       (defclass True [])]]
     (with [e (pytest.raises HyLanguageError)]
       (hy.eval form))
-    (assert (in "Can't assign" e.value.msg))))
+    (assert (in "Can't assign" e.value.msg)))
+
+  (for [form '[(defn f [True] (print "hello"))
+               (defn f [a b break])
+               (defn f [a [from 1]])]])
+  (with [e (pytest.raises HySyntaxError)]
+    (hy.eval form))
+  (assert (in "parameter name cannot be" e.value.msg)))
 
 
 (defn test-no-str-as-sym []


### PR DESCRIPTION
closes #1765 

this one is actually pretty minimal and didn't break anything in any real way. One thing to note though is that while `(:from {"from" 1})` won't syntax error its still a key error since `Keyword.__call__` is defined as `return data[mangle(self.name)]` do we still think that's okay given this change?
