### PR TITLE
Fix equality for Hy models

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -51,12 +51,15 @@ Other Breaking Changes
 * return annotation for `defn` has been moved to before the function name
 * Python reserved words can no longer be parameter names or
   function call keywords
+* hy models are no longer equal to their associated Python values. `(= 1 '1)  ; => False`
 
 New Features
 ------------------------------
 * `hy-repr` is now the default REPL output function.
 * Running the module a la `python -m hy` is now equivalent to running
   the `hy` command.
+* `hy.as-model` has been added to create canonical model trees from
+  unquote spliced expressions
 
 Bug Fixes
 ------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1482,6 +1482,7 @@ the following methods
 
 .. hy:autofunction:: hy.gensym
 
+.. hy:autofunction:: hy.as-model
 
 .. _Core:
 

--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -20,7 +20,8 @@
           "hy.gensym",
           "hy.macroexpand",
           "hy.macroexpand-1",
-          "hy.disassemble"
+          "hy.disassemble",
+          "hy.as-model"
         ]
       }
     ]

--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -30,7 +30,8 @@ _jit_imports = dict(
     gensym="hy.core.language",
     macroexpand="hy.core.language",
     macroexpand_1="hy.core.language",
-    disassemble="hy.core.language")
+    disassemble="hy.core.language",
+    as_model="hy.models")
 
 def __getattr__(k):
     if k not in _jit_imports:

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -6,7 +6,7 @@
 from itertools import dropwhile
 from hy.models import (Object, Expression, Keyword, Integer, Complex,
                        String, FComponent, FString, Bytes, Symbol,
-                       Float, List, Set, Dict, Sequence, wrap_value)
+                       Float, List, Set, Dict, Sequence, as_model)
 from hy.model_patterns import (FORM, SYM, KEYWORD, STR, sym, brackets, whole,
                                notpexpr, dolike, pexpr, times, Tag, tag, unpack)
 from funcparserlib.parser import some, many, oneplus, maybe, NoParseError, a
@@ -2124,7 +2124,7 @@ def hy_compile(tree, module, root=ast.Module, get_expr=False,
     filename = getattr(tree, 'filename', filename)
     source = getattr(tree, 'source', source)
 
-    tree = wrap_value(tree)
+    tree = as_model(tree)
     if not isinstance(tree, Object):
         raise TypeError("`tree` must be a hy.models.Object or capable of "
                         "being promoted to one")

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -294,8 +294,7 @@ class Result(object):
 def is_unpack(kind, x):
     return (isinstance(x, Expression)
             and len(x) > 0
-            and isinstance(x[0], Symbol)
-            and x[0] == "unpack-" + kind)
+            and x[0] == Symbol("unpack-" + kind))
 
 
 def make_hy_model(outer, x, rest):
@@ -317,7 +316,7 @@ OPTIONAL_ANNOTATION = maybe(pvalue("annotate", FORM))
 
 
 def is_annotate_expression(model):
-    return (isinstance(model, Expression) and model and isinstance(model[0], Symbol)
+    return (isinstance(model, Expression) and model
             and model[0] == Symbol("annotate"))
 
 
@@ -703,7 +702,7 @@ class HyASTCompiler(object):
         orel = Result()
         if orel_expr is not None:
             if isinstance(orel_expr, Expression) and isinstance(orel_expr[0],
-               Symbol) and orel_expr[0] == 'if*':
+               Symbol) and orel_expr[0] == Symbol('if*'):
                 # Nested ifs: don't waste temporaries
                 root = self.temp_if is None
                 nested = True
@@ -917,7 +916,7 @@ class HyASTCompiler(object):
             ctx = self.compile(ctx)
             ret += ctx
             variable = (None
-                if isinstance(variable, Symbol) and variable == Symbol('_')
+                if variable == Symbol('_')
                 else self._storeize(variable, self.compile(variable)))
             items.append(asty.withitem(expr,
                                        context_expr=ctx.force_expr,
@@ -1332,7 +1331,7 @@ class HyASTCompiler(object):
             return asty.Constant(expr, value=None)
 
         result = Result()
-        is_assignment_expr = root == Symbol("setx")
+        is_assignment_expr = root == "setx"
         for decl in decls:
             if is_assignment_expr:
                 ann = None
@@ -1446,7 +1445,7 @@ class HyASTCompiler(object):
     NASYM = some(lambda x: isinstance(x, Symbol) and x not in (Symbol("/"), Symbol("*")))
     argument = OPTIONAL_ANNOTATION + (NASYM | brackets(NASYM, FORM))
     varargs = lambda unpack_type, wanted: OPTIONAL_ANNOTATION + pvalue(unpack_type, wanted)
-    kwonly_delim = some(lambda x: isinstance(x, Symbol) and x == Symbol("*"))
+    kwonly_delim = some(lambda x: x == Symbol("*"))
     lambda_list = brackets(
             maybe(many(argument) + sym("/")),
             many(argument),
@@ -1682,7 +1681,6 @@ class HyASTCompiler(object):
             return Expression([*expr, Symbol("None")]).replace(expr)
         elif not (isinstance(expr, Expression)
             and len(expr) > 1
-            and isinstance(expr[0], Symbol)
             and expr[0] == Symbol("setv")):
             return expr
         else:
@@ -1738,7 +1736,7 @@ class HyASTCompiler(object):
 
     @special(["py", "pys"], [STR])
     def compile_inline_python(self, expr, root, code):
-        exec_mode = root == Symbol("pys")
+        exec_mode = root == "pys"
 
         try:
             o = ast.parse(

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -57,7 +57,7 @@ tail-call optimization (TCO) in their Hy code.
 
 (defmacro/g! fnr [signature #* body]
   (setv new-body (prewalk
-    (fn [x] (if (and (symbol? x) (= x "recur")) g!recur-fn x))
+    (fn [x] (if (and (symbol? x) (= x (hy.models.Symbol "recur"))) g!recur-fn x))
     body))
   `(do
     (import [hy.contrib.loop [__trampoline__]])

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -323,7 +323,7 @@
   (defn handle-args-list [self]
     (setv protected #{}
           argslist [])
-    (for [[header section] (.items (lambda-list (get (.tail self) (if (= (self.head) "defn") 1 0))))]
+    (for [[header section] (.items (lambda-list (get (.tail self) (if (= (self.head) (hy.models.Symbol "defn")) 1 0))))]
       (unless (in header [None 'unpack-iterable 'unpack-mapping])
           (.append argslist header))
       (cond [(in header [None '*])
@@ -343,7 +343,9 @@
 
   (defn handle-fn [self]
     (setv [protected argslist] (self.handle-args-list))
-    `(~(self.head) ~@(if (= (self.head) "defn") [(get (.tail self) 0)] []) ~argslist
+    `(~(self.head) ~@(if (= (self.head) (hy.models.Symbol "defn"))
+                        [(get (.tail self) 0)]
+                        []) ~argslist
        ~@(self.traverse (cut (self.tail) 1 None)(| protected self.protected))))
 
   ;; don't expand symbols in quotations
@@ -405,7 +407,7 @@
                   eval-and-compile
                   eval-when-compile]) (self.handle-base)]
       [(= head 'except) (self.handle-except)]
-      [(= head ".") (self.handle-dot)]
+      [(= head '.) (self.handle-dot)]
       [(= head 'defclass) (self.handle-defclass)]
       [(= head 'quasiquote) (self.+quote)]
         ;; must be checked last!

--- a/hy/core/hy_repr.hy
+++ b/hy/core/hy_repr.hy
@@ -131,11 +131,13 @@
       (+ "\"" (.replace (cut r 1 -1) "\"" "\\\"") "\"")))))
 (hy-repr-register bool str)
 (hy-repr-register [hy.models.Float float] (fn [x]
+  (setv fx (float x))
   (cond
-    [(isnan x)  "NaN"]
-    [(= x Inf)  "Inf"]
-    [(= x -Inf) "-Inf"]
+    [(isnan fx)  "NaN"]
+    [(= fx Inf)  "Inf"]
+    [(= fx -Inf) "-Inf"]
     [True (_base-repr x)])))
+
 (hy-repr-register [hy.models.Complex complex] (fn [x]
   (.replace (.replace (.strip (_base-repr x) "()") "inf" "Inf") "nan" "NaN")))
 (hy-repr-register Fraction (fn [x]

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -9,7 +9,7 @@ import pkgutil
 import traceback
 
 from hy._compat import PY3_8
-from hy.models import replace_hy_obj, Expression, Symbol, wrap_value
+from hy.models import replace_hy_obj, Expression, Symbol, as_model
 from hy.lex import mangle, unmangle
 from hy.errors import (HyLanguageError, HyMacroExpansionError, HyTypeError,
                        HyRequireError)
@@ -334,7 +334,7 @@ def macroexpand(tree, module, compiler=None, once=False):
         if once:
             break
 
-    tree = wrap_value(tree)
+    tree = as_model(tree)
     return tree
 
 

--- a/hy/model_patterns.py
+++ b/hy/model_patterns.py
@@ -22,7 +22,7 @@ def sym(wanted):
     "Parse and skip the given symbol or keyword."
     if wanted.startswith(":"):
         return skip(a(Keyword(wanted[1:])))
-    return skip(some(lambda x: isinstance(x, Symbol) and x == wanted))
+    return skip(some(lambda x: x == Symbol(wanted)))
 
 def whole(parsers):
     """Parse the parsers in the given list one after another, then
@@ -52,10 +52,10 @@ def dolike(head):
 def notpexpr(*disallowed_heads):
     """Parse any object other than a hy.models.Expression beginning with a
     hy.models.Symbol equal to one of the disallowed_heads."""
+    disallowed_heads = list(map(Symbol, disallowed_heads))
     return some(lambda x: not (
         isinstance(x, Expression) and
         x and
-        isinstance(x[0], Symbol) and
         x[0] in disallowed_heads))
 
 def unpack(kind):
@@ -63,8 +63,7 @@ def unpack(kind):
     return some(lambda x:
         isinstance(x, Expression)
         and len(x) > 0
-        and isinstance(x[0], Symbol)
-        and x[0] == "unpack-" + kind)
+        and x[0] == Symbol("unpack-" + kind))
 
 def times(lo, hi, parser):
     """Parse `parser` several times (`lo` to `hi`) in a row. `hi` can be

--- a/hy/models.py
+++ b/hy/models.py
@@ -87,6 +87,15 @@ class Object(object):
         return (f"hy.models.{self.__class__.__name__}"
                 f"({super(Object, self).__repr__()})")
 
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+        else:
+            return super(Object, self).__eq__(other)
+
+    def __hash__(self):
+        return super().__hash__()
+
 
 _wrappers = {}
 

--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -24,7 +24,7 @@ def test_preprocessor_simple():
     obj = macroexpand(tokenize('(test "one" "two")')[0],
                       __name__,
                       HyASTCompiler(__name__))
-    assert obj == List(["one", "two"])
+    assert obj == List([String("one"), String("two")])
     assert type(obj) == List
 
 

--- a/tests/native_tests/contrib/destructure.hy
+++ b/tests/native_tests/contrib/destructure.hy
@@ -26,15 +26,15 @@
   ;; dict=:
   (assert (= (dict=: (a (b (c)) d)
                      [1 [2 [3 4 5] 6] 7 8])
-             {"a" 1  "b" 2  "c" 3  "d" 7}))
+             {'a 1  'b 2  'c 3  'd 7}))
   ;; dict=: :&
   (setv D (dict=: (a (b (c :& inner)) d :& outer)
                   [1 [2 [3 4 5] 6] 7 8]))
-  (assert (= (lfor k "abcd" (get D k))
+  (assert (= (lfor k "abcd" (get D (hy.models.Symbol k)))
              [1 2 3 7]))
-  (assert (= (list (get D "inner"))
+  (assert (= (list (get D 'inner))
              [4 5]))
-  (assert (= (list (get D "outer"))
+  (assert (= (list (get D 'outer))
              [8]))
   ;; infinite
   (setv+ (a b c) (cycle [1 2]))
@@ -150,7 +150,7 @@
          {"a" "a"  "b" "b"  "c" "c"})
   (assert (= [a b c]
              ["a" "b" "c"]))
-  (assert (= full {'a "a"  'b "b"  'c "c"})))
+  (assert (= full {"a" "a"  "b" "b"  "c" "c"})))
 
 (defn test-both []
   (setv data {"cells" [{"type" "x"  "count" 3}
@@ -192,22 +192,22 @@
                 :as full}
                 data))
   (setv+ expected
-         {'full {'cells [{'type "x"
-                          'count 3}
-                         {'type "y"
-                          'count 6}]
-                 'format ["pretty"
+         {'full {"cells" [{"type" "x"
+                          "count" 3}
+                         {"type" "y"
+                          "count" 6}]
+                 "format" ["pretty"
                           "purple"]
-                 'options "xyzq"}
+                 "options" "xyzq"}
           'foo 42
           'the-rest ["y" "z" "q"]
           'X "x"
           'color "purple"
           'style "pretty"
-          'cells [{'type "x"
-                   'count 3}
-                  {'type "y"
-                   'count 6}]
+          'cells [{"type" "x"
+                   "count" 3}
+                  {"type" "y"
+                   "count" 6}]
           'y-count 6
           'type "x"
           'count 3})

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -48,8 +48,8 @@
 ;; test that expressions within f-strings are also walked
 ;; https://github.com/hylang/hy/issues/1843
 (defn test-walking-update []
-  (assert (= (prewalk inc-ints walk-form) walk-form-inc))
-  (assert (= (postwalk inc-ints walk-form) walk-form-inc)))
+  (assert (= (hy.as-model (prewalk inc-ints walk-form)) walk-form-inc))
+  (assert (= (hy.as-model (postwalk inc-ints walk-form)) walk-form-inc)))
 
 (defmacro foo-walk []
   42)
@@ -57,7 +57,7 @@
 (defn test-macroexpand-all []
   ;; make sure a macro from the current module works
   (assert (= (macroexpand-all '(foo-walk))
-             42))
+             '42))
   (assert (= (macroexpand-all '(-> 1 a))
              '(a 1)))
   ;; macros within f-strings should also be expanded
@@ -171,13 +171,13 @@
     (assert (= a "x"))
     (assert (= 'a a-symbol))
     (assert (= `a a-symbol))
-    (assert (= `(foo ~a)
+    (assert (= (hy.as-model `(foo ~a))
                '(foo "x")))
-    (assert (= `(foo `(bar a ~a ~~a))
+    (assert (= (hy.as-model `(foo `(bar a ~a ~~a)))
                '(foo `(bar a ~a ~"x"))))
-    (assert (= `(foo ~@[a])
+    (assert (= (hy.as-model `(foo ~@[a]))
                '(foo "x")))
-    (assert (= `(foo `(bar [a] ~@[a] ~@~(hy.models.List [a 'a `a]) ~~@[a]))
+    (assert (= (hy.as-model `(foo `(bar [a] ~@[a] ~@~(hy.models.List [a 'a `a]) ~~@[a])))
                '(foo `(bar [a] ~@[a] ~@["x" a a] ~"x"))))))
 
 (defn test-let-except []

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1131,7 +1131,7 @@
   (assert (= 1 (hy.eval (quote 1))))
   (assert (= "foobar" (hy.eval (quote "foobar"))))
   (setv x (quote 42))
-  (assert (= x (hy.eval x)))
+  (assert (= 42 (hy.eval x)))
   (assert (= 27 (hy.eval (+ (quote (*)) (* [(quote 3)] 3)))))
   (assert (= None (hy.eval (quote (print "")))))
 
@@ -1155,7 +1155,7 @@
 
 (defn test-eval-globals []
   "NATIVE: test eval with explicit global dict"
-  (assert (= 'bar (hy.eval (quote foo) {'foo 'bar})))
+  (assert (= 'bar (hy.eval (quote foo) {"foo" 'bar})))
   (assert (= 1 (do (setv d {}) (hy.eval '(setv x 1) d) (hy.eval (quote x) d))))
   (setv d1 {}  d2 {})
   (hy.eval '(setv x 1) d1)
@@ -1569,7 +1569,7 @@ cee\"} dee" "ey bee\ncee dee"))
   (defmacro m-with-named-import []
     (import [math [pow]])
     (pow 2 3))
-  (assert (= (hy.macroexpand '(m-with-named-import)) (** 2 3))))
+  (assert (= (hy.macroexpand '(m-with-named-import)) (hy.models.Float (** 2 3)))))
 
 (defn test-macroexpand-1 []
   "Test macroexpand-1 on ->"

--- a/tests/native_tests/mangling.hy
+++ b/tests/native_tests/mangling.hy
@@ -167,8 +167,8 @@
   ; Mangling should only happen during compilation.
   (assert (!= 'foo? 'is_foo))
   (setv sym 'foo?)
-  (assert (= sym "foo?"))
-  (assert (!= sym "is_foo"))
+  (assert (= sym (hy.models.Symbol "foo?")))
+  (assert (!= sym (hy.models.Symbol "is_foo")))
   (setv out (hy.eval `(do
                      (setv ~sym 10)
                      [foo? is_foo])))

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -16,7 +16,7 @@
     (.append defns `(defn ~(hy.models.Symbol (+ "test_operator_" o "_real")) []
       (setv f-name ~(hy.models.String o))
       ~@(prewalk :form body :f (fn [x]
-        (if (and (symbol? x) (= x "f")) o x)))))
+          (if (and (symbol? x) (= x (hy.models.Symbol "f"))) o x)))))
     (.append defns `(defn ~(hy.models.Symbol (+ "test_operator_" o "_shadow")) []
       (setv f-name ~(hy.models.String o))
       (setv f ~o)

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -66,7 +66,7 @@
   (assert (= (get q 1) (quote foo)))
   (setv qq (quasiquote (a b c (unquote (+ 1 2)))))
   (assert (= (len qq) 4))
-  (assert (= qq (quote (a b c 3)))))
+  (assert (= (hy.as-model qq) (quote (a b c 3)))))
 
 
 (defn test-unquote-splice []
@@ -79,7 +79,7 @@
 
 (defn test-nested-quasiquote []
   "NATIVE: test nested quasiquotes"
-  (setv qq `(1 `~(+ 1 ~(+ 2 3) ~@None) 4))
+  (setv qq (hy.as-model `(1 `~(+ 1 ~(+ 2 3) ~@None) 4)))
   (setv q (quote (1 `~(+ 1 5) 4)))
   (assert (= (len q) 3))
   (assert (= (get qq 1) (quote `~(+ 1 5))))

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -312,12 +312,12 @@ def test_lex_line_counting_multi_inner():
 def test_dicts():
     """ Ensure that we can tokenize a dict. """
     objs = tokenize("{foo bar bar baz}")
-    assert objs == [Dict(["foo", "bar", "bar", "baz"])]
+    assert objs == [Dict([Symbol("foo"), Symbol("bar"), Symbol("bar"), Symbol("baz")])]
 
     objs = tokenize("(bar {foo bar bar baz})")
     assert objs == [Expression([Symbol("bar"),
-                                Dict(["foo", "bar",
-                                      "bar", "baz"])])]
+                                Dict([Symbol("foo"), Symbol("bar"),
+                                      Symbol("bar"), Symbol("baz")])])]
 
     objs = tokenize("{(foo bar) (baz quux)}")
     assert objs == [Dict([
@@ -332,7 +332,7 @@ def test_sets():
     assert objs == [Set([Integer(1), Integer(2)])]
     objs = tokenize("(bar #{foo bar baz})")
     assert objs == [Expression([Symbol("bar"),
-                                Set(["foo", "bar", "baz"])])]
+                                Set([Symbol("foo"), Symbol("bar"), Symbol("baz")])])]
 
     objs = tokenize("#{(foo bar) (baz quux)}")
     assert objs == [Set([
@@ -372,10 +372,10 @@ def test_nospace():
 def test_escapes():
     """ Ensure we can escape things """
     entry = tokenize(r"""(foo "foo\n")""")[0]
-    assert entry[1] == "foo\n"
+    assert entry[1] == String("foo\n")
 
     entry = tokenize(r"""(foo r"foo\s")""")[0]
-    assert entry[1] == r"foo\s"
+    assert entry[1] == String(r"foo\s")
 
 
 def test_unicode_escapes():
@@ -426,21 +426,21 @@ def test_discard():
     assert tokenize("#_ #_1 2") == []
     assert tokenize("#_ #_ #_1 2 3") == []
     # trailing
-    assert tokenize("0") == [0]
-    assert tokenize("0 #_1") == [0]
-    assert tokenize("0 #_1 #_2") == [0]
+    assert tokenize("0") == [Integer(0)]
+    assert tokenize("0 #_1") == [Integer(0)]
+    assert tokenize("0 #_1 #_2") == [Integer(0)]
     # leading
-    assert tokenize("2") == [2]
-    assert tokenize("#_1 2") == [2]
-    assert tokenize("#_0 #_1 2") == [2]
-    assert tokenize("#_ #_0 1 2") == [2]
+    assert tokenize("2") == [Integer(2)]
+    assert tokenize("#_1 2") == [Integer(2)]
+    assert tokenize("#_0 #_1 2") == [Integer(2)]
+    assert tokenize("#_ #_0 1 2") == [Integer(2)]
     # both
-    assert tokenize("#_1 2 #_3") == [2]
-    assert tokenize("#_0 #_1 2 #_ #_3 4") == [2]
+    assert tokenize("#_1 2 #_3") == [Integer(2)]
+    assert tokenize("#_0 #_1 2 #_ #_3 4") == [Integer(2)]
     # inside
-    assert tokenize("0 #_1 2") == [0, 2]
-    assert tokenize("0 #_1 #_2 3") == [0, 3]
-    assert tokenize("0 #_ #_1 2 3") == [0, 3]
+    assert tokenize("0 #_1 2") == [Integer(0), Integer(2)]
+    assert tokenize("0 #_1 #_2 3") == [Integer(0), Integer(3)]
+    assert tokenize("0 #_ #_1 2 3") == [Integer(0), Integer(3)]
     # in List
     assert tokenize("[]") == [List([])]
     assert tokenize("[#_1]") == [List([])]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ import copy
 import pytest
 import hy
 from hy.models import (
-    wrap_value, replace_hy_obj, Symbol, Keyword, String, Integer,
+    as_model, replace_hy_obj, Symbol, Keyword, String, Integer,
     List, Dict, Set, Expression, Complex, Float, pretty)
 
 hy.models.COLORED = False
@@ -26,13 +26,13 @@ def test_symbol_or_keyword():
 
 def test_wrap_int():
     """ Test conversion of integers."""
-    wrapped = wrap_value(0)
+    wrapped = as_model(0)
     assert type(wrapped) == Integer
 
 
 def test_wrap_tuple():
     """ Test conversion of tuples."""
-    wrapped = wrap_value((Integer(0),))
+    wrapped = as_model((Integer(0),))
     assert type(wrapped) == List
     assert type(wrapped[0]) == Integer
     assert wrapped == List([Integer(0)])
@@ -40,7 +40,7 @@ def test_wrap_tuple():
 
 def test_wrap_nested_expr():
     """ Test conversion of Expressions with embedded non-HyObjects."""
-    wrapped = wrap_value(Expression([0]))
+    wrapped = as_model(Expression([0]))
     assert type(wrapped) == Expression
     assert type(wrapped[0]) == Integer
     assert wrapped == Expression([Integer(0)])


### PR DESCRIPTION
closes #1363 

* models are no longer equal to equivalent python literals
* models only equal to models of the same kind
* renamed `wrap_value` -> `as_model` and exposed under `hy` module 