### PR TITLE
Feature/pattern matching

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -64,6 +64,7 @@ New Features
   unquote spliced expressions
 * Hy will raise a `SyntaxError` if attempting to use a special form
   on an unsupported version of Python
+* support for Python 3.10's ``match`` statement
 
 Bug Fixes
 ------------------------------

--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,7 @@ from functools import reduce
 import py
 import pytest
 import hy
-from hy._compat import PY3_8
+from hy._compat import PY3_8, PY3_10
 
 NATIVE_TESTS = os.path.join("", "tests", "native_tests", "")
 
@@ -21,6 +21,7 @@ def pytest_ignore_collect(path, config):
     versions = [
         (sys.version_info < (3, 8), "sub_py3_7_only"),
         (PY3_8, "py3_8_only"),
+        (PY3_10, "py3_10_only"),
     ]
 
     return reduce(

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -816,6 +816,48 @@ Special Forms
        ...  (print x "is greater than 0"))
        3 is greater than 0
 
+.. hy:function:: (match [subject #* cases])
+
+   The ``match`` form creates a :ref:`match statement <py3_10:match>`. It
+   requires Python 3.10 or later. The first argument should be the subject,
+   and any remaining arguments should be pairs of patterns and results. The
+   ``match`` form returns the value of the corresponding result, or
+   ``None`` if no case matched. For example::
+
+       => (match (+ 1 1)
+       ...  1 "one"
+       ...  2 "two"
+       ...  3 "three")
+       "two"
+
+   You can use :hy:func:`do` to build a complex result form. Patterns, as
+   in Python match statements, are interpreted specially and can't be
+   arbitrary forms. Use ``(| …)`` for OR patterns, ``PATTERN :as NAME`` for
+   AS patterns, and syntax like the usual Hy syntax for literal, capture,
+   value, sequence, mapping, and class patterns. Guards are specified
+   with ``:if FORM``. Here's a more complex example::
+
+       => (match (, 100 200)
+       ...  [100 300]               "Case 1"
+       ...  [100 200] :if flag      "Case 2"
+       ...  [900   y]               f"Case 3, y: {y}"
+       ...  [100 (| 100 200) :as y] f"Case 4, y: {y}"
+       ...  _                       "Case 5, I match anything!")
+
+   This will match case 2 if ``flag`` is true and case 4 otherwise.
+
+   ``match`` can also match against class instances by keyword (or
+   positionally if its ``__match_args__`` attribute is defined, see
+   `pep 636 <https://www.python.org/dev/peps/pep-0636/#appendix-a-quick-intro>`_)::
+
+      => (with-decorator
+      ...  dataclass
+      ...  (defclass Point []
+      ...    (^int x)
+      ...    (^int y)))
+      => (match (Point 1 2)
+      ...  (Point 1 x) :if (= (% x 2) 0) x
+      2
 
 .. hy:function:: (defclass [class-name super-classes #* body])
 

--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -132,6 +132,7 @@
           "sfor",
           "setv",
           "setx",
+          "match",
           "defclass",
           "del",
           "nonlocal",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,8 @@ html_context = dict(
 highlight_language = 'clojure'
 
 intersphinx_mapping = dict(
-    py = ('https://docs.python.org/3/', None))
+    py = ('https://docs.python.org/3/', None),
+    py3_10 = ('https://docs.python.org/3.10/', None))
 # ** Generate Cheatsheet
 import json
 from pathlib import Path

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -150,6 +150,12 @@ class Asty(object):
                 x, 'start_line', getattr(x, 'lineno', None)),
             col_offset=getattr(
                 x, 'start_column', getattr(x, 'col_offset', None)),
+            end_lineno=getattr(
+                x, 'end_line', getattr(x, 'end_lineno', None)
+            ),
+            end_col_offset=getattr(
+                x, 'end_column', getattr(x, 'end_col_offset', None)
+            ),
             **kwargs)))
         return getattr(Asty, name)
 asty = Asty()
@@ -212,6 +218,22 @@ class Result(object):
             return self._expr.col_offset
         if self.stmts:
             return self.stmts[-1].col_offset
+        return None
+
+    @property
+    def end_col_offset(self):
+        if self._expr is not None:
+            return self._expr.end_col_offset
+        if self.stmts:
+            return self.stmts[-1].end_col_offset
+        return None
+
+    @property
+    def end_lineno(self):
+        if self._expr is not None:
+            return self._expr.end_lineno
+        if self.stmts:
+            return self.stmts[-1].end_lineno
         return None
 
     def is_expr(self):

--- a/hy/model_patterns.py
+++ b/hy/model_patterns.py
@@ -4,7 +4,7 @@
 
 "Parser combinators for pattern-matching Hy model trees."
 
-from hy.models import Expression, Symbol, Keyword, String, List
+from hy.models import Expression, Symbol, Keyword, String, List, Dict, Integer, Float, Complex, Bytes
 from funcparserlib.parser import (
     some, skip, many, finished, a, Parser, NoParseError, State)
 from functools import reduce
@@ -17,6 +17,8 @@ FORM = some(lambda _: True)
 SYM = some(lambda x: isinstance(x, Symbol))
 KEYWORD = some(lambda x: isinstance(x, Keyword))
 STR = some(lambda x: isinstance(x, String))  # matches literal strings only!
+LITERAL = some(lambda x: isinstance(x, (String, Integer, Float, Complex, Bytes)))
+
 
 def sym(wanted):
     "Parse and skip the given symbol or keyword."
@@ -40,6 +42,10 @@ def _grouped(group_type, parsers): return (
 def brackets(*parsers):
     "Parse the given parsers inside square brackets."
     return _grouped(List, parsers)
+
+def braces(*parsers):
+    "Parse the given parsers inside curly braces"
+    return _grouped(Dict, parsers)
 
 def pexpr(*parsers):
     "Parse the given parsers inside a parenthesized expression."

--- a/hy/models.py
+++ b/hy/models.py
@@ -54,8 +54,8 @@ class Object(object):
     `abc` starting at the first column would have `start_column` 1 and
     `end_column` 3.
     """
-    properties = ["module", "_start_line", "end_line", "_start_column",
-                  "end_column"]
+    properties = ["module", "_start_line", "_end_line", "_start_column",
+                  "_end_column"]
 
     def replace(self, other, recursive=False):
         if isinstance(other, Object):
@@ -82,6 +82,22 @@ class Object(object):
     @start_column.setter
     def start_column(self, value):
         self._start_column = value
+
+    @property
+    def end_line(self):
+        return getattr(self, "_end_line", 1)
+
+    @end_line.setter
+    def end_line(self, value):
+        self._end_line = value
+
+    @property
+    def end_column(self):
+        return getattr(self, "_end_column", 1)
+
+    @end_column.setter
+    def end_column(self, value):
+        self._end_column = value
 
     def __repr__(self):
         return (f"hy.models.{self.__class__.__name__}"

--- a/tests/native_tests/py3_10_only_tests.hy
+++ b/tests/native_tests/py3_10_only_tests.hy
@@ -1,0 +1,141 @@
+(import pytest
+        [dataclasses [dataclass]]
+        [hy.errors [HySyntaxError]])
+
+(require [hy.contrib.walk [let]])
+
+(defn test-pattern-matching []
+  (assert (is (match 0
+                     0 :if False False
+                     0 :if True True)
+              True))
+  (assert (is (match 0
+                     0 True
+                     0 False)
+              True))
+
+  (assert (is (match 2 (| 0 1 2 3) True)
+              True))
+
+  (assert (is (match 4 (| 0 1 2 3) True)
+              None))
+
+  (assert (is (match 1) None))
+
+  (defclass A []
+    (setv B 0))
+  (setv z
+        (match 0
+               x :if x 0
+               _ :as y :if (and (= y x) y) 1
+               A.B 2
+               (. A B) 2))
+  (assert (= A.B 0))
+  (assert (= z 2))
+
+  (assert (= 0 (match (,) [] 0)))
+  (assert (= [0 [0 1 2]] (match (, 0 1 2) [#* x] [0 x])))
+  (assert (= [2] (match [0 1 2] [0 1 #* x] x)))
+  (assert (= [0 1] (match [0 1 2] [#* x 2] x)))
+  (assert (= 5 (match {"hello" 5} {"hello" x} x)))
+  (assert (= :as (match 1 1 :if True ':as)))
+  (assert (is (match {}
+                     {0 [1 2 {}]} 0
+                     {0 [1 2 {}] 1 [[]]} 1
+                     [] 2)
+              None))
+
+  (assert (= 1 (match {0 0}
+                      {0 [ 1 2 {}]} 0
+                      (| {0 (| [1 2 {}] False)}
+                          {1 [[]]}
+                          {0 [1 2 {}]}
+                          []
+                          "X"
+                          {})
+                       1
+                      [] 2)))
+  (assert (is (match [0 0] (| [0 1] [1 0]) 0)
+              None))
+
+  (setv x #{0})
+  (assert (is (match x [0] 0) None))
+  (assert (= x (match x (set z) z)))
+
+
+  (assert (= (match [0 1 2]
+                    [0 #* x] :as z :if (as-> z $ (+ $ [3]) (len $) (= $ 4)) 0)
+             0))
+
+  (with-decorator
+    dataclass
+    (defclass Point []
+      (^int x)
+      (^int y)))
+
+  (assert (= 0 (match (Point 1 0) (Point 1 :y var) var)))
+  (assert (is None (match (Point 0 0) (Point 1 :y var) var)))
+
+  (setv match-check [])
+  (match 1
+         1 :if (do (match-check.append 1) False) (match-check.append 2)
+         1 :if False (match-check.append 3)
+         _ :if (do (match-check.append 4) True) (match-check.append 5))
+  (assert (= match-check [1 4 5]))
+
+  (defn whereis [points]
+    (match points
+           [] "No points"
+           [(Point 0 0)] "The origin"
+           [(Point x y)] f"Single point {x}, {y}"
+           [(Point 0 y1) (Point 0 y2)] f"Two on the Y axis at {y1}, {y2}"
+           _ "Something else"))
+  (assert (= (whereis []) "No points"))
+  (assert (= (whereis [(Point 0 0)]) "The origin"))
+  (assert (= (whereis [(Point 0 1)]) "Single point 0, 1"))
+  (assert (= (whereis [(Point 0 0) (Point 0 0)]) "Two on the Y axis at 0, 0"))
+  (assert (= (whereis [(Point 0 1) (Point 0 1)]) "Two on the Y axis at 1, 1"))
+  (assert (= (whereis [(Point 0 1) (Point 1 0)]) "Something else"))
+  (assert (= (whereis 42) "Something else"))
+
+  (assert (= [42 [1 2 3]]
+             (match {"something" {"important" 42}
+                     "some list" [[1 2 3]]}
+                    {"something" {"important" a} "some list" [b]} [a b])))
+
+  (assert (= [-1 0 1 2 (Point 1 2) [(Point -1 0) (Point 1 2)]]
+             (match [(Point -1 0) (Point 1 2)]
+
+                    (, (Point x1 y1) (Point x2 y2) :as p2) :as whole
+                    [x1 y1 x2 y2 p2 whole])))
+  (assert (= (match [1 2 3]
+                    x x)
+             [1 2 3]))
+
+  ;; `print` is not a MatchClass type
+  (with [(pytest.raises TypeError)] (hy.eval '(match [] (print 1 1) 1)))
+  ;; key of MatchMapping can only be a literal
+  (with [(pytest.raises HySyntaxError)] (hy.eval '(match {} {x 1} 1)))
+  ;; :as clause cannot come after :if guard
+  (with [(pytest.raises HySyntaxError)]
+    (hy.eval '(match 1
+                     1 :if True :as x x))))
+
+(defn test-let-with-pattern-matching []
+  (let [x [1 2 3]
+        y (dict :a 1 :b 2 :c 3)
+        b 1
+        a 1
+        _ 42]
+    (assert (= [2 3]
+               (match x
+                      [1 #* x] x)))
+    (assert (= [3 [1 2 3] [1 2 3]]
+               (match x
+                      [_ _ 3 :as a] :as b :if (= a 3) [a b x])))
+    (assert (= [1 2]
+               (match [1 2]
+                      x x)))
+    (assert (= 42
+               (match [1 2 3]
+                    _ _)))))

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -169,6 +169,7 @@ def test_bin_hy_error_parts_length():
 
     (setv test-expr (hy-parse "(+ 1\n\n'a 2 3\n\n 1)"))
     (setv test-expr.start-line {})
+    (setv test-expr.end-line {})
     (setv test-expr.start-column {})
     (setv test-expr.end-column {})
 
@@ -180,7 +181,7 @@ def test_bin_hy_error_parts_length():
     """
 
     # Up-arrows right next to each other.
-    _, err = run_cmd("hy", prg_str.format(3, 1, 2))
+    _, err = run_cmd("hy", prg_str.format(3, 3, 1, 2))
 
     msg_idx = err.rindex("HyLanguageError:")
     assert msg_idx
@@ -198,7 +199,7 @@ def test_bin_hy_error_parts_length():
         assert obs.startswith(exp)
 
     # Make sure only one up-arrow is printed
-    _, err = run_cmd("hy", prg_str.format(3, 1, 1))
+    _, err = run_cmd("hy", prg_str.format(3, 3, 1, 1))
 
     msg_idx = err.rindex("HyLanguageError:")
     assert msg_idx
@@ -207,7 +208,7 @@ def test_bin_hy_error_parts_length():
 
     # Make sure lines are printed in between arrows separated by more than one
     # character.
-    _, err = run_cmd("hy", prg_str.format(3, 1, 6))
+    _, err = run_cmd("hy", prg_str.format(3, 3, 1, 6))
     print(err)
 
     msg_idx = err.rindex("HyLanguageError:")


### PR DESCRIPTION
closes #1954 

adds `match` special form for > 3.10. This is a pretty literal translation of the python syntax so it should be easy to learn the syntax. 

had to add `end_line` & `end_column` to `Asty` and `Object` since they are required on some new nodes, this doesn't affect other nodes. seems like it makes that info more consistent with `start_line` and `start_column` anyways. 

This implementation is heavily parser based since its heavily recursive and would have been a nightmare to do by hand. As such the syntax errors are a bit obtuse, but we already knew that https://github.com/vlasovskikh/funcparserlib/issues/52

This solves the issue of arbitraty statements in the `:if` guard by lifting them up into a function. this works because all of the bind targets have already been bound into local scope by the time the function gets called.

```clojure
=> (match [0 1 2]
...     (case [0 #* x] :as z :if (as-> z $ (+ $ [3]) (len $) (= $ 4))
...         0))
def _hy_anon_var_2():
    hyx_Xdollar_signX = z
    hyx_Xdollar_signX = hyx_Xdollar_signX + [3]
    hyx_Xdollar_signX = len(hyx_Xdollar_signX)
    hyx_Xdollar_signX = hyx_Xdollar_signX == 4
    return hyx_Xdollar_signX
match [0, 1, 2]:
    case [0, *x] as z if _hy_anon_var_2():
        _hy_anon_var_1 = 0
    case _:
        _hy_anon_var_1 = None
_hy_anon_var_1
0

```

let me know if you manage to blow it up somehow :+1: 