### PR TITLE
Fix: Syntax error special forms on unsupported python versions

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -62,6 +62,8 @@ New Features
   the `hy` command.
 * `hy.as-model` has been added to create canonical model trees from
   unquote spliced expressions
+* Hy will raise a `SyntaxError` if attempting to use a special form
+  on an unsupported version of Python
 
 Bug Fixes
 ------------------------------

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,8 @@
+import sys
 import os
 import importlib
+from operator import or_
+from functools import reduce
 
 import py
 import pytest
@@ -15,7 +18,15 @@ os.environ.pop("HYSTARTUP", None)
 
 
 def pytest_ignore_collect(path, config):
-    return (("py3_8_only" in path.basename and not PY3_8) or None)
+    versions = [
+        (sys.version_info < (3, 8), "sub_py3_7_only"),
+        (PY3_8, "py3_8_only"),
+    ]
+
+    return reduce(
+        or_,
+        (name in path.basename and not condition for condition, name in versions),
+    )
 
 
 def pyimport_patch_mismatch(self, **kwargs):

--- a/tests/native_tests/sub_py3_7_only.hy
+++ b/tests/native_tests/sub_py3_7_only.hy
@@ -1,0 +1,13 @@
+;; Copyright 2021 the authors.
+;; This file is part of Hy, which is free software licensed under the Expat
+;; license. See the LICENSE.
+
+;; Tests where the emitted code relies on Python ≥3.8.
+;; conftest.py skips this file when running on Python <3.8.
+
+(import pytest)
+
+(defn test-setx []
+  (with [e (pytest.raises hy.errors.HySyntaxError)]
+    (hy.eval '(setx x 1)))
+  (assert (= "setx requires Python 3.8 or later")))


### PR DESCRIPTION
closes #2090 

easy money 

attempting to `setx` on Python 3.7 will result in 
```clojure
hy 1.0a1+136.gbeee3586.dirty using PyPy(51efa818fd9b) 3.7.10 on Linux
=> (setx x 1)
Traceback (most recent call last):
  File "stdin-12a3a753791edb1e67c4fba15af57553319e7498", line 1, in <module>
    (setx x 1)
  File "<stdin>", line 1
    (setx x 1)
    ^
hy.errors.HySyntaxError: setx is not supported on Python versions before Python 3.8
```
