### PR TITLE
Remove core predicate functions

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,9 +26,13 @@ Removals
     (formerly `take-while`), `tee`, `zip-longest`
   * From `functools`: `reduce`
   * From `fractions`: `Fraction` (formerly `fraction`)
+
+* The following core predicate functions have been removed. Use
+  `isinstance` etc. instead.
+
+  * `empty?`, `even?`, `every?`, `float?`, `integer-char?`, `integer?`, `iterable?`, `iterator?`, `keyword?`, `list?`, `neg?`, `none?`, `numeric?`, `odd?`, `pos?`, `some`, `string?`, `symbol?`, `tuple?`, `zero?`
 * Several other core functions and macros have been removed:
 
-  * `instance?`: Use `isinstance` instead.
   * `keyword`: Use `(hy.models.Keyword (hy.unmangle …))` instead.
   * `repeatedly`: Use `toolz.iterate` instead.
   * `if-not`: Use `(if (not …) …)` instead.

--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,7 @@ def pytest_ignore_collect(path, config):
     return reduce(
         or_,
         (name in path.basename and not condition for condition, name in versions),
-    )
+    ) or None
 
 
 def pyimport_patch_mismatch(self, **kwargs):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -209,8 +209,8 @@ Special Forms
        every even number::
 
            => (defn zig-zag-sum [#* numbers]
-                (setv odd-numbers (lfor x numbers :if (odd? x) x)
-                      even-numbers (lfor x numbers :if (even? x) x))
+                (setv odd-numbers (lfor x numbers :if (% x 2) x)
+                      even-numbers (lfor x numbers :if (= (% x 2) 0) x))
                 (- (sum odd-numbers) (sum even-numbers)))
 
            => (zig-zag-sum)
@@ -1300,7 +1300,7 @@ Special Forms
        '(+ 1 2 3 4)
        => `(+ ~@nums)
        '(+ 1 2 3 4)
-       => `[1 2 ~@(if (neg? (get nums 0)) nums)]
+       => `[1 2 ~@(if (< (get nums 0) 0) nums)]
        '[1 2]
 
    Here, the last example evaluates to ``('+' 1 2)``, since the condition
@@ -1537,10 +1537,9 @@ base names, such that ``hy.core.language.butlast`` can be called with just ``but
 
 .. hy:automodule:: hy.core.language
    :members: butlast,
-      coll?, constantly, dec, distinct, drop-last, empty?,
-      even?, every?, flatten, float?, inc, integer?, integer-char?,
-      iterable?, iterator?, keyword?, list?, neg?, none?, numeric?, odd?,
-      parse-args, pos?, rest, some, string?, symbol?, tuple?, xor, zero?
+      coll?, constantly, dec, distinct, drop-last,
+      flatten, inc,
+      parse-args, rest, xor
 
 .. hy:automodule:: hy.core.shadow
    :members:

--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -33,41 +33,16 @@
         "name": "Collections",
         "methods": [
           "hy.core.language.butlast",
+          "hy.core.language.coll?",
           "hy.core.language.distinct",
           "hy.core.language.drop-last",
           "hy.core.language.flatten",
-          "hy.core.language.rest",
-          "hy.core.language.some"
+          "hy.core.language.rest"
         ]
       },
       {
         "name": "Functions",
         "methods": ["hy.core.language.constantly"]
-      },
-      {
-        "name": "Tests",
-        "methods": [
-          "hy.core.language.pos?",
-          "hy.core.language.coll?",
-          "hy.core.language.integer?",
-          "hy.core.language.integer-char?",
-          "hy.core.language.iterable?",
-          "hy.core.language.keyword?",
-          "hy.core.language.list?",
-          "hy.core.language.iterator?",
-          "hy.core.language.empty?",
-          "hy.core.language.even?",
-          "hy.core.language.every?",
-          "hy.core.language.float?",
-          "hy.core.language.neg?",
-          "hy.core.language.none?",
-          "hy.core.language.numeric?",
-          "hy.core.language.odd?",
-          "hy.core.language.tuple?",
-          "hy.core.language.string?",
-          "hy.core.language.symbol?",
-          "hy.core.language.zero?"
-        ]
       },
       {
         "name": "Meta",

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -375,9 +375,9 @@ A first pass might be something like::
    (defmacro nif [expr pos-form zero-form neg-form]
      `(do
        (setv obscure-name ~expr)
-       (cond [(pos? obscure-name) ~pos-form]
-             [(zero? obscure-name) ~zero-form]
-             [(neg? obscure-name) ~neg-form])))
+       (cond [(> obscure-name 0) ~pos-form]
+             [(= obscure-name 0) ~zero-form]
+             [(< obscure-name 0) ~neg-form])))
 
 where ``obscure-name`` is an attempt to pick some variable name as not to
 conflict with other code. But of course, while well-intentioned,
@@ -390,9 +390,9 @@ such an occasion. A much better version of ``nif`` would be::
      (setv g (hy.gensym))
      `(do
         (setv ~g ~expr)
-        (cond [(pos? ~g) ~pos-form]
-              [(zero? ~g) ~zero-form]
-              [(neg? ~g) ~neg-form])))
+        (cond [(> ~g 0) ~pos-form]
+              [(= ~g 0) ~zero-form]
+              [(< ~g 0) ~neg-form])))
 
 This is an easy case, since there is only one symbol. But if there is
 a need for several gensym's there is a second macro :hy:func:`with-gensyms <hy.core.macros.with-gensyms>` that
@@ -415,9 +415,9 @@ so our re-written ``nif`` would look like::
      (with-gensyms [g]
        `(do
           (setv ~g ~expr)
-          (cond [(pos? ~g) ~pos-form]
-                [(zero? ~g) ~zero-form]
-                [(neg? ~g) ~neg-form]))))
+          (cond [(> ~g 0) ~pos-form]
+                [(= ~g 0) ~zero-form]
+                [(< ~g 0) ~neg-form]))))
 
 Finally, though we can make a new macro that does all this for us. :hy:func:`defmacro/g! <hy.core.macros.defmacro/g!>`
 will take all symbols that begin with ``g!`` and automatically call ``gensym`` with the
@@ -428,6 +428,6 @@ Our final version of ``nif``, built with ``defmacro/g!`` becomes::
    (defmacro/g! nif [expr pos-form zero-form neg-form]
      `(do
         (setv ~g!res ~expr)
-        (cond [(pos? ~g!res) ~pos-form]
-              [(zero? ~g!res) ~zero-form]
-              [(neg? ~g!res) ~neg-form])))
+        (cond [(> ~g!res 0) ~pos-form]
+              [(= ~g!res 0) ~zero-form]
+              [(< ~g!res 0) ~neg-form])))

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -57,7 +57,7 @@ tail-call optimization (TCO) in their Hy code.
 
 (defmacro/g! fnr [signature #* body]
   (setv new-body (prewalk
-    (fn [x] (if (and (symbol? x) (= x (hy.models.Symbol "recur"))) g!recur-fn x))
+    (fn [x] (if (= x 'recur) g!recur-fn x))
     body))
   `(do
     (import [hy.contrib.loop [__trampoline__]])
@@ -89,7 +89,7 @@ tail-call optimization (TCO) in their Hy code.
        => (require [hy.contrib.loop [loop]])
        => (defn factorial [n]
        ...  (loop [[i n] [acc 1]]
-       ...    (if (zero? i)
+       ...    (if (= i 0)
        ...      acc
        ...      (recur (dec i) (* acc i)))))
        => (factorial 1000)"

--- a/hy/contrib/pprint.hy
+++ b/hy/contrib/pprint.hy
@@ -232,7 +232,7 @@ The differences that do exist are as follows:
   (defn _format-items [self items stream indent allowance context level]
     (setv write stream.write)
     (+= indent self._indent-per-level)
-    (when (pos? self._indent-per-level)
+    (when self._indent-per-level
       (write (* (dec self._indent-per-level) " ")))
 
     (setv delimnl (+ "\n" (* " " indent))

--- a/hy/contrib/sequences.hy
+++ b/hy/contrib/sequences.hy
@@ -60,7 +60,7 @@ This results in the sequence ``[0 1 1 2 3 5 8 13 21 34 ...]``.
     (if (hasattr n "start")
     (gfor x (range (or n.start 0) n.stop (or n.step 1))
          (get self x))
-    (do (when (neg? n)
+    (do (when (< n 0)
          ; Call (len) to force the whole
          ; sequence to be evaluated.
          (len self))

--- a/hy/contrib/slicing.hy
+++ b/hy/contrib/slicing.hy
@@ -33,15 +33,14 @@ or more manually using the tag macro as::
 (eval-and-compile
   (defn parse-colon [sym]
     (lfor index (.split (str sym) ":")
-          (if (empty? index) None
-              (int index))))
+          (if index (int index))))
 
   (defn parse-indexing [sym]
     (cond
       [(and (isinstance sym hy.models.Expression) (= (get sym 0) :))
        `(slice ~@(cut sym 1 None))]
 
-      [(and (symbol? sym) (= sym '...))
+      [(= sym '...)
        'Ellipsis]
 
       [(and (isinstance sym (, hy.models.Keyword hy.models.Symbol))

--- a/hy/core/hy_repr.hy
+++ b/hy/core/hy_repr.hy
@@ -50,7 +50,7 @@
       => (print (hy.repr container))
       '(Container HY THERE)'
   "
-  (for [typ (if (list? types) types [types])]
+  (for [typ (if (isinstance types list) types [types])]
     (setv (get _registry typ) (, f placeholder))))
 
 (setv _quoting False)
@@ -83,7 +83,7 @@
 
   (setv oid (id obj))
   (when (in oid _seen)
-    (return (if (none? placeholder) "..." placeholder)))
+    (return (if (is placeholder None) "..." placeholder)))
   (.add _seen oid)
 
   (try
@@ -113,7 +113,7 @@
     'unquote-splice "~@"
     'unpack-iterable "#* "
     'unpack-mapping "#** "})
-  (if (and x (symbol? (get x 0)) (in (get x 0) syntax))
+  (if (and x (in (get x 0) syntax))
     (+ (get syntax (get x 0)) (hy-repr (get x 1)))
     (+ "(" (_cat x) ")"))))
 
@@ -188,7 +188,7 @@
 (defn _repr-time-innards [x]
   (.rstrip (+ " " (.join " " (filter (fn [x] x) [
     (if x.microsecond (str x.microsecond))
-    (if (not (none? x.tzinfo)) (+ ":tzinfo " (hy-repr x.tzinfo)))
+    (if (is-not x.tzinfo None) (+ ":tzinfo " (hy-repr x.tzinfo)))
     (if x.fold (+ ":fold " (hy-repr x.fold)))])))))
 (defn _strftime-0 [x fmt]
   ; Remove leading 0s in `strftime`. This is a substitute for the `-`

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -98,27 +98,6 @@
   (fn [#* args #** kwargs]
     value))
 
-(defn keyword? [k]
-  "Check whether `k` is a keyword.
-
-  .. versionadded:: 0.10.1
-
-  Check whether *foo* is a :ref:`keyword<hy.models.Keyword>`.
-
-  Examples:
-    ::
-
-       => (keyword? :foo)
-       True
-
-    ::
-
-       => (setv foo 1)
-       => (keyword? foo)
-       False
-  "
-  (isinstance k Keyword))
-
 (defn dec [n]
   "Decrement `n` by 1.
 
@@ -234,84 +213,6 @@
   (setv [copy1 copy2] (tee coll))
   (gfor  [x _] (zip copy1 (islice copy2 n None))  x))
 
-(defn empty? [coll]
-  "Check if `coll` is empty.
-
-  Returns ``True`` if *coll* is empty. Equivalent to ``(= 0 (len coll))``.
-
-  Examples:
-    ::
-
-       => (empty? [])
-       True
-
-    ::
-
-       => (empty? "")
-       True
-
-    ::
-
-       => (empty? (, 1 2))
-       False
-  "
-  (= 0 (len coll)))
-
-(defn even? [n]
-  "Check if `n` is an even number.
-
-  Returns ``True`` if *x* is even. Raises ``TypeError`` if
-  ``(not (numeric? x))``.
-
-  Examples:
-    ::
-
-       => (even? 2)
-       True
-
-    ::
-
-       => (even? 13)
-       False
-
-    ::
-
-       => (even? 0)
-       True
-  "
-  (= (% n 2) 0))
-
-(defn every? [pred coll]
-  "Check if `pred` is true applied to every x in `coll`.
-
-  .. versionadded:: 0.10.0
-
-  Returns ``True`` if ``(pred x)`` is logical true for every *x* in *coll*,
-  otherwise ``False``. Return ``True`` if *coll* is empty.
-
-  Examples:
-    ::
-
-       => (every? even? [2 4 6])
-       True
-
-    ::
-
-       => (every? even? [1 3 5])
-       False
-
-    ::
-
-       => (every? even? [2 4 5])
-       False
-
-    ::
-
-       => (every? even? [])
-       True
-  "
-  (all (map pred coll)))
-
 (defn flatten [coll]
   "Return a single flat list expanding all members of `coll`.
 
@@ -341,70 +242,6 @@
           (_flatten b result)))
     (.append result coll))
   result)
-
-(defn float? [x]
-  "Returns ``True`` if *x* is a float.
-
-  Examples:
-    ::
-
-       => (float? 3.2)
-       True
-
-    ::
-
-       => (float? -2)
-       False
-  "
-  (isinstance x float))
-
-(defn list? [x]
-  "Check if x is a `list`
-
-  Examples:
-    ::
-
-       => (list? '(inc 41))
-       True
-
-    ::
-
-       => (list? '42)
-       False
-  "
-  (isinstance x list))
-
-(defn tuple? [x]
-  "Check if x is a `tuple`
-
-  Examples:
-    ::
-
-       => (tuple? (, 42 44))
-       True
-
-    ::
-
-       => (tuple? [42 44])
-       False
-  "
-  (isinstance x tuple))
-
-(defn symbol? [s]
-  "Check if `s` is a symbol.
-
-  Examples:
-    ::
-
-       => (symbol? 'foo)
-       True
-
-    ::
-
-       => (symbol? '[a b c])
-       False
-  "
-  (isinstance s Symbol))
 
 (import [threading [Lock]])
 (setv _gensym_counter 0)
@@ -472,103 +309,6 @@
   "
   (+ n 1))
 
-(defn integer? [x]
-  "Check if `x` is an integer.
-
-  Examples:
-    ::
-
-       => (integer? 3)
-       True
-
-    ::
-
-       => (integer? -2.4)
-       False
-  "
-  (isinstance x int))
-
-(defn integer-char? [x]
-  "Check if char `x` parses as an integer."
-  (try
-    (integer? (int x))
-    (except [ValueError] False)
-    (except [TypeError] False)))
-
-(defn iterable? [x]
-  "Check if `x` is an iterable.
-
-  Returns ``True`` if *x* is iterable. Iterable objects return a new iterator
-  when ``(iter x)`` is called. Contrast with :hy:func:`iterator? <hy.core.language.iterator?>`.
-
-  Examples:
-    ::
-
-       => ;; works for strings
-       => (iterable? (str \"abcde\"))
-       True
-
-    ::
-
-       => ;; works for lists
-       => (iterable? [1 2 3 4 5])
-       True
-
-    ::
-
-       => ;; works for tuples
-       => (iterable? (, 1 2 3))
-       True
-
-    ::
-
-       => ;; works for dicts
-       => (iterable? {:a 1 :b 2 :c 3})
-       True
-
-    ::
-
-       => ;; works for iterators/generators
-       => (import [itertools [repeat]])
-       => (iterable? (repeat 3))
-       True
-  "
-  (isinstance x cabc.Iterable))
-
-(defn iterator? [x]
-  "Check if `x` is an iterator.
-
-  Returns ``True`` if *x* is an iterator. Iterators are objects that return
-  themselves as an iterator when ``(iter x)`` is called. Contrast with
-  :hy:func:`iterable? <hy.core.language.iterable?>`.
-
-  Examples:
-    ::
-
-       => ;; doesn't work for a list
-       => (iterator? [1 2 3 4 5])
-       False
-
-    ::
-
-       => ;; but we can get an iter from the list
-       => (iterator? (iter [1 2 3 4 5]))
-       True
-
-    ::
-
-       => ;; doesn't work for dict
-       => (iterator? {:a 1 :b 2 :c 3})
-       False
-
-    ::
-
-       => ;; create an iterator from the dict
-       => (iterator? (iter {:a 1 :b 2 :c 3}))
-       True
-  "
-  (isinstance x cabc.Iterator))
-
 (defn macroexpand [form]
   "Return the full macro expansion of `form`.
 
@@ -604,128 +344,6 @@
   (setv module (calling-module))
   (hy.macros.macroexpand-1 form module (HyASTCompiler module)))
 
-(defn neg? [n]
-  "Check if `n` is < 0.
-
-  Returns ``True`` if *x* is less than zero. Raises ``TypeError`` if
-  ``(not (numeric? x))``.
-
-  Examples:
-    ::
-
-       => (neg? -2)
-       True
-
-    ::
-
-       => (neg? 3)
-       False
-
-    ::
-
-       => (neg? 0)
-       False
-  "
-  (< n 0))
-
-(defn none? [x]
-  "Check if `x` is None
-
-  Examples:
-    ::
-
-       => (none? None)
-       True
-
-    ::
-
-       => (none? 0)
-       False
-
-    ::
-
-       => (setv x None)
-       => (none? x)
-       True
-
-    ::
-
-       => ;; list.append always returns None
-       => (none? (.append [1 2 3] 4))
-       True
-  "
-  (is x None))
-
-(defn numeric? [x]
-  "Check if `x` is an instance of numbers.Number.
-
-  Examples:
-    ::
-
-       => (numeric? -2)
-       True
-
-    ::
-
-       => (numeric? 3.2)
-       True
-
-    ::
-
-       => (numeric? \"foo\")
-       False
-  "
-  (import numbers)
-  (isinstance x numbers.Number))
-
-(defn odd? [^int n]
-  "Check if `n` is an odd number.
-
-  Returns ``True`` if *x* is odd. Raises ``TypeError`` if
-  ``(not (numeric? x))``.
-
-  Examples:
-    ::
-
-       => (odd? 13)
-       True
-
-    ::
-
-       => (odd? 2)
-       False
-
-    ::
-
-       => (odd? 0)
-       False
-  "
-  (= (% n 2) 1))
-
-(defn pos? [n]
-  "Check if `n` is > 0.
-
-  Returns ``True`` if *x* is greater than zero. Raises ``TypeError``
-  if ``(not (numeric? x))``.
-
-  Examples:
-    ::
-
-       => (pos? 3)
-       True
-
-    ::
-
-       => (pos? -2)
-       False
-
-    ::
-
-       => (pos? 0)
-       False
-  "
-  (> n 0))
-
 (defn rest [coll]
   "Get all the elements of `coll`, except the first.
 
@@ -745,69 +363,6 @@
   "
   (import [itertools [islice]])
   (islice coll 1 None))
-
-(defn some [pred coll]
-  "Return the first logical true value of applying `pred` in `coll`, else None.
-
-  .. versionadded:: 0.10.0
-
-  Returns the first logically-true value of ``(pred x)`` for any ``x`` in
-  *coll*, otherwise ``None``. Return ``None`` if *coll* is empty.
-
-  Examples:
-    ::
-
-       => (some (fn [x] (= (% x 2) 0)) [2 4 6])
-       True
-
-    ::
-
-       => (is (some (fn [x] (= (% x 2) 0)) [1 3 5]) None)
-       True
-
-    ::
-
-       => (is (some (fn [x] (= (% x 2) 0)) []) None)
-       True
-  "
-  (next (filter None (map pred coll)) None))
-
-(defn string? [x]
-  "Check if `x` is a string.
-
-  Examples:
-    ::
-
-       => (string? \"foo\")
-       True
-
-    ::
-
-       => (string? -2)
-       False
-  "
-  (isinstance x str))
-
-(defn zero? [n]
-  "Check if `n` equals 0.
-
-  Examples:
-    ::
-
-       => (zero? 3)
-       False
-
-    ::
-
-       => (zero? -2)
-       False
-
-    ::
-
-       => (zero? 0)
-       True
-  "
-  (= n 0))
 
 (defn xor [a b]
   "Perform exclusive or between `a` and `b`.
@@ -869,11 +424,8 @@
   (list (map mangle
     '[butlast coll?
       constantly dec distinct
-      drop-last empty? even? every?
-      flatten float? inc
-      integer? integer-char? iterable?
-      iterator? keyword? list?
-      neg? none?
-      numeric? odd? parse-args pos?
-      rest some string? symbol?
-      tuple? xor zero?])))
+      drop-last
+      flatten inc
+      parse-args
+      rest
+      xor])))

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -66,7 +66,9 @@
        => (coll? \"abc\")
        False
   "
-  (and (iterable? coll) (not (string? coll))))
+  (and
+    (isinstance coll cabc.Iterable)
+    (not (isinstance coll str))))
 
 (defn constantly [value]
   "Create a new function that always returns `value` regardless of its input.
@@ -121,7 +123,7 @@
   "Decrement `n` by 1.
 
   Returns one less than *x*. Equivalent to ``(- x 1)``. Raises ``TypeError``
-  if ``(not (numeric? x))``.
+  if *x* is not numeric.
 
   Examples:
     ::
@@ -450,7 +452,7 @@
   "Increment `n` by 1.
 
   Returns one more than *x*. Equivalent to ``(+ x 1)``. Raises ``TypeError``
-  if ``(not (numeric? x))``.
+  if *x* is not numeric.
 
   Examples:
     ::
@@ -755,17 +757,17 @@
   Examples:
     ::
 
-       => (some even? [2 4 6])
+       => (some (fn [x] (= (% x 2) 0)) [2 4 6])
        True
 
     ::
 
-       => (none? (some even? [1 3 5]))
+       => (is (some (fn [x] (= (% x 2) 0)) [1 3 5]) None)
        True
 
     ::
 
-       => (none? (some even? []))
+       => (is (some (fn [x] (= (% x 2) 0)) []) None)
        True
   "
   (next (filter None (map pred coll)) None))
@@ -854,10 +856,12 @@
     (for [item arg]
       (if value-of-keyword?
           (.append (get keyword-arguments -1) item)
-          (if (keyword? item)
+          (if (isinstance item Keyword)
               (.append keyword-arguments [item.name])
               (.append positional-arguments item)))
-      (setv value-of-keyword? (and (not value-of-keyword?) (keyword? item))))
+      (setv value-of-keyword? (and
+        (not value-of-keyword?)
+        (isinstance item Keyword))))
     (parser.add-argument #* positional-arguments #** (dict keyword-arguments)))
   (.parse-args parser args))
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -125,7 +125,7 @@
 
   .. note:: ``assoc`` modifies the datastructure in place and returns ``None``.
   "
-  (if (odd? (len other-kvs))
+  (if (% (len other-kvs) 2)
       (raise (ValueError "`assoc` takes an odd number of arguments")))
   (setv c (if other-kvs
             (hy.gensym "c")
@@ -309,7 +309,7 @@
        Callable[[int, str], str]
   "
   (if
-    (empty? args) base
+    (not args) base
     (if (= (len args) 1)
         `(get ~base ~@args)
         `(get ~base (, ~@args)))))
@@ -527,7 +527,7 @@
        42
   "
   (defn extract-o!-sym [arg]
-    (cond [(and (symbol? arg) (.startswith arg "o!"))
+    (cond [(and (isinstance arg hy.models.Symbol) (.startswith arg "o!"))
            arg]
           [(and (isinstance args hy.models.List) (.startswith (get arg 0) "o!"))
            (get arg 0)]))
@@ -601,13 +601,13 @@
   `(when (= __name__ "__main__")
      (import sys)
      (setv ~retval ((fn [~@(or args `[#* ~restval])] ~@body) #* sys.argv))
-     (if (integer? ~retval)
+     (if (isinstance ~retval int)
        (sys.exit ~retval))))
 
 
 (defmacro "#@" [expr]
   "with-decorator tag macro"
-  (if (empty? expr)
+  (if (not expr)
       (raise (ValueError "missing function argument")))
   (setv decorators (cut expr -1)
         fndef (get expr -1))
@@ -668,7 +668,7 @@
 
   Examples:
   ::
-     => (cfor tuple x (range 10) :if (odd? x) x)
+     => (cfor tuple x (range 10) :if (% x 2) x)
      (, 1 3 5 7 9)
 
   The equivalent in python would be:

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -107,12 +107,12 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
   Examples:
     ::
 
-       => (list (ap-map-when odd? (* it 2) [1 2 3 4]))
+       => (list (ap-map-when (fn [x] (% x 2)) (* it 2) [1 2 3 4]))
        [2 2 6 4]
 
     ::
 
-       => (list (ap-map-when even? (* it 2) [1 2 3 4]))
+       => (list (ap-map-when (fn [x] (= (% x 2) 0)) (* it 2) [1 2 3 4]))
        [1 4 3 8]"
   (rit `(gfor  ~it ~xs  (if (~predfn ~it) ~(R rep) ~it))))
 
@@ -213,7 +213,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
   (defn R [form]
     (recur-sym-replace {'it it  'acc acc} form))
   `(do
-    (setv ~acc ~(if (none? initial-value)
+    (setv ~acc ~(if (is initial-value None)
       `(do
         (setv ~g!xs (iter ~g!xs))
         (next ~g!xs))
@@ -254,7 +254,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
     symbol and by the maximum ``%i`` symbol found *anywhere* in the expression,
     so nesting of ``#%`` forms is not recommended."
   (setv %symbols (sfor a (flatten [expr])
-                       :if (and (symbol? a)
+                       :if (and (isinstance a hy.models.Symbol)
                                 (.startswith a '%))
                        a))
   `(fn [;; generate all %i symbols up to the maximum found in expr
@@ -281,6 +281,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
 (defn recur-sym-replace [d form]
   "Recursive symbol replacement."
+  (import collections.abc)
   (cond
     [(isinstance form hy.models.Symbol)
       (.get d form form)]

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -658,7 +658,7 @@ def test_module_prelude():
     assert isinstance(hy_ast.body[0], ast.Import)
     assert hy_ast.body[0].module == 'hy'
 
-    hy_ast = can_compile('(setv flag (keyword? hy.models.Symbol))',
+    hy_ast = can_compile('(setv flag (dec hy.models.Symbol))',
                          import_stdlib=True)
     assert len(hy_ast.body) == 2
     assert isinstance(hy_ast.body[0], ast.Import)

--- a/tests/native_tests/contrib/destructure.hy
+++ b/tests/native_tests/contrib/destructure.hy
@@ -3,9 +3,13 @@
 ;; license. See the LICENSE.
 
 (import pytest)
+(import collections.abc)
 (import [itertools [cycle count islice]])
 (import [hy.contrib.destructure [destructure]])
 (require [hy.contrib.destructure [setv+ dict=: defn+ fn+ let+]])
+
+(defn iterator? [x]
+  (isinstance x collections.abc.Iterator))
 
 (defn test-iter []
   ;; empty

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -24,7 +24,7 @@
   None)
 
 (defn inc-ints [x]
-  (if (integer? x) (+ x 1) x))
+  (if (isinstance x int) (+ x 1) x))
 
 (defn test-walk-identity []
   (assert (= (walk (fn [x] x) (fn [x] x) walk-form)
@@ -100,7 +100,7 @@
                       (* b (bar 7))))))
 
 (defn test-let-basic []
-  (assert (zero? (let [a 0] a)))
+  (assert (= (let [a 0] a) 0))
   (setv a "a"
         b "b")
   (let [a "x"
@@ -124,7 +124,7 @@
 ;; let should substitute within f-strings
 ;; related to https://github.com/hylang/hy/issues/1843
 (defn test-let-fstring []
-  (assert (zero? (let [a 0] a)))
+  (assert (= (let [a 0] a) 0))
   (setv a "a"
         b "b")
   (let [a "x"
@@ -226,14 +226,14 @@
 
 (defn test-let-break []
   (for [x (range 3)]
-    (let [done (odd? x)]
+    (let [done (% x 2)]
       (if done (break))))
   (assert (= x 1)))
 
 (defn test-let-continue []
   (let [foo []]
     (for [x (range 10)]
-      (let [odd (odd? x)]
+      (let [odd (% x 2)]
         (if odd (continue))
         (.append foo x)))
     (assert (= foo [0 2 4 6 8]))))

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -112,33 +112,6 @@
   (assert-equal (list (islice (drop-last 100 (itertools.count 10)) 5))
                 [10 11 12 13 14]))
 
-(defn test-empty? []
-  "NATIVE: testing the empty? function"
-  (assert-true (empty? ""))
-  (assert-false (empty? "None"))
-  (assert-true (empty? (,)))
-  (assert-false (empty? (, None)))
-  (assert-true (empty? []))
-  (assert-false (empty? [None]))
-  (assert-true (empty? {}))
-  (assert-false (empty? {"a" None}))
-  (assert-true (empty? (set)))
-  (assert-false (empty? (set [None]))))
-
-(defn test-even []
-  "NATIVE: testing the even? function"
-  (assert-true (even? -2))
-  (assert-false (even? 1))
-  (assert-true (even? 0))
-  (assert-requires-num even?))
-
-(defn test-every? []
-  "NATIVE: testing the every? function"
-  (assert-true (every? even? [2 4 6]))
-  (assert-false (every? even? [1 3 5]))
-  (assert-false (every? even? [2 4 5]))
-  (assert-true (every? even? [])))
-
 (setv globalvar 1)
 (defn test-exec []
   (setv localvar 1)
@@ -223,31 +196,6 @@ result['y in globals'] = 'y' in globals()")
   (try (flatten 12.34)
        (except [e [TypeError]] (assert (in "not a collection" (str e))))))
 
-(defn test-float? []
-  "NATIVE: testing the float? function"
-  (assert-true (float? 4.2))
-  (assert-false (float? 0))
-  (assert-false (float? -3))
-  (assert-true (float? -3.2))
-  (assert-false (float? "foo")))
-
-(defn test-symbol? []
-  "NATIVE: testing the symbol? function"
-  (assert-false (symbol? "hello"))
-  (assert-false (symbol? [1 2 3]))
-  (assert-false (symbol? '[a b c]))
-  (assert-true (symbol? 'im-symbol)))
-
-(defn test-list? []
-  "NATIVE: testing the list? function"
-  (assert-false (list? "hello"))
-  (assert-true (list? [1 2 3])))
-
-(defn test-tuple? []
-  "NATIVE: testing the tuple? function"
-  (assert-false (tuple? [4 5]))
-  (assert-true (tuple? (, 4 5))))
-
 (defn test-gensym []
   "NATIVE: testing the gensym function"
   (setv s1 (hy.gensym))
@@ -269,105 +217,6 @@ result['y in globals'] = 'y' in globals()")
     (defn __add__ [self other] (.format "__add__ got {}" other)))
   (assert-equal (inc (X)) "__add__ got 1"))
 
-(defn test-integer? []
-  "NATIVE: testing the integer? function"
-  (assert-true (integer? 0))
-  (assert-true (integer? 3))
-  (assert-true (integer? -3))
-  (assert-true (integer? (int "-3")))
-  (assert-true (integer? (int 3)))
-  (assert-false (integer? 4.2))
-  (assert-false (integer? None))
-  (assert-false (integer? "foo")))
-
-(defn test-integer-char? []
-  "NATIVE: testing the integer-char? function"
-  (assert-true (integer-char? "1"))
-  (assert-true (integer-char? "-1"))
-  (assert-true (integer-char? (str (int 300))))
-  (assert-false (integer-char? "foo"))
-  (assert-false (integer-char? None)))
-
-(defn test-iterable []
-  "NATIVE: testing iterable? function"
-  ;; should work for a string
-  (setv s (str "abcde"))
-  (assert-true (iterable? s))
-  ;; should work for unicode
-  (setv u "hello")
-  (assert-true (iterable? u))
-  (assert-true (iterable? (iter u)))
-  ;; should work for a list
-  (setv l [1 2 3 4])
-  (assert-true (iterable? l))
-  (assert-true (iterable? (iter l)))
-  ;; should work for a dict
-  (setv d {:a 1 :b 2 :c 3})
-  (assert-true (iterable? d))
-  ;; should work for a tuple?
-  (setv t (, 1 2 3 4))
-  (assert-true (iterable? t))
-  ;; should work for a generator
-  (assert-true (iterable? (repeat 3)))
-  ;; shouldn't work for an int
-  (assert-false (iterable? 5)))
-
-(defn test-iterator []
-  "NATIVE: testing iterator? function"
-  ;; should not work for a list
-  (setv l [1 2 3 4])
-  (assert-false (iterator? l))
-  ;; should work for an iter over a list
-  (setv i (iter [1 2 3 4]))
-  (assert-true (iterator? i))
-  ;; should not work for a dict
-  (setv d {:a 1 :b 2 :c 3})
-  (assert-false (iterator? d))
-  ;; should not work for a tuple?
-  (setv t (, 1 2 3 4))
-  (assert-false (iterator? t))
-  ;; should work for a generator
-  (assert-true (iterator? (repeat 3)))
-  ;; should not work for an int
-  (assert-false (iterator? 5)))
-
-(defn test-neg []
-  "NATIVE: testing the neg? function"
-  (assert-true (neg? -2))
-  (assert-false (neg? 1))
-  (assert-false (neg? 0))
-  (assert-requires-num neg?))
-
-(defn test-zero []
-  "NATIVE: testing the zero? function"
-  (assert-false (zero? -2))
-  (assert-false (zero? 1))
-  (assert-true (zero? 0)))
-
-(defn test-none []
-  "NATIVE: testing for `is None`"
-  (assert-true (none? None))
-  (setv f None)
-  (assert-true (none? f))
-  (assert-false (none? 0))
-  (assert-false (none? "")))
-
-(defn test-numeric? []
-  "NATIVE: testing the numeric? function"
-  (assert-true (numeric? 1))
-  (assert-true (numeric? 3.4))
-  (assert-true (numeric? 0.0))
-  (assert-true (numeric? -1.45))
-  (assert-false (numeric? "Foo"))
-  (assert-false (numeric? None)))
-
-(defn test-odd []
-  "NATIVE: testing the odd? function"
-  (assert-true (odd? -3))
-  (assert-true (odd? 1))
-  (assert-false (odd? 0))
-  (assert-requires-num odd?))
-
 (defn test-parse-args []
   "NATIVE: testing the parse-args function"
   ; https://github.com/hylang/hy/issues/1875
@@ -378,35 +227,6 @@ result['y in globals'] = 'y' in globals()")
   (assert-equal parsed-args.strings ["a" "b"])
   (assert-equal parsed-args.numbers [1 2]))
 
-(defn test-pos []
-  "NATIVE: testing the pos? function"
-  (assert-true (pos? 2))
-  (assert-false (pos? -1))
-  (assert-false (pos? 0))
-  (assert-requires-num pos?))
-
-(defn test-some []
-  "NATIVE: testing the some function"
-  (assert-true (some even? [2 4 6]))
-  (assert-none (some even? [1 3 5]))
-  (assert-true (some even? [1 2 3]))
-  (assert-none (some even? []))
-  ; 0, "" (empty string) and [] (empty list) are all logical false
-  (assert-none (some (fn [x] x) [0 "" []]))
-  ; non-empty string is logical true
-  (assert-equal (some (fn [x] x) [0 "this string is non-empty" []])
-                "this string is non-empty")
-  ; None if collection is empty
-  (assert-none (some even? [])))
-
-(defn test-string? []
-  "NATIVE: testing string?"
-  (assert-true (string? "foo"))
-  (assert-true (string? ""))
-  (assert-false (string? 5.3))
-  (assert-true (string? (str 5.3)))
-  (assert-false (string? None)))
-
 (defn test-doto []
   "NATIVE: testing doto macro"
   (setv collection [])
@@ -416,17 +236,6 @@ result['y in globals'] = 'y' in globals()")
   (assert-equal res (set [1 2]))
   (setv res (doto [] (.append 1) (.append 2) .reverse))
   (assert-equal res [2 1]))
-
-(defn test-is-keyword []
-  "NATIVE: testing the keyword? function"
-  (assert (keyword? ':bar))
-  (assert (keyword? ':baz))
-  (setv x :bar)
-  (assert (keyword? x))
-  (assert (not (keyword? "foo")))
-  (assert (not (keyword? ":foo")))
-  (assert (not (keyword? 1)))
-  (assert (not (keyword? None))))
 
 (defn test-import-init-hy []
   "NATIVE: testing import of __init__.hy"

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -184,20 +184,23 @@ result['y in globals'] = 'y' in globals()")
 
 (defn test-filter []
   "NATIVE: testing the filter function"
-  (setv res (list (filter pos? [ 1 2 3 -4 5])))
+  (setv res (list (filter (fn [x] (> x 0)) [ 1 2 3 -4 5])))
   (assert-equal res [ 1 2 3 5 ])
   ;; test with iter
-  (setv res (list (filter pos? (iter [ 1 2 3 -4 5 -6]))))
+  (setv res (list (filter (fn [x] (> x 0)) (iter [ 1 2 3 -4 5 -6]))))
   (assert-equal res [ 1 2 3 5])
-  (setv res (list (filter neg? [ -1 -4 5 3 4])))
+  (setv res (list (filter (fn [x] (< x 0)) [ -1 -4 5 3 4])))
   (assert-false (= res [1 2]))
   ;; test with empty list
-  (setv res (list (filter neg? [])))
+  (setv res (list (filter (fn [x] (< x 0)) [])))
   (assert-equal res [])
   ;; test with None in the list
-  (setv res (list (filter even? (filter numeric? [1 2 None 3 4 None 4 6]))))
+  (setv res (list
+    (filter (fn [x] (not (% x 2)))
+      (filter (fn [x] (isinstance x int))
+        [1 2 None 3 4 None 4 6]))))
   (assert-equal res [2 4 4 6])
-  (setv res (list (filter none? [1 2 None 3 4 None 4 6])))
+  (setv res (list (filter (fn [x] (is x None)) [1 2 None 3 4 None 4 6])))
   (assert-equal res [None None]))
 
 (defn test-flatten []
@@ -463,7 +466,7 @@ result['y in globals'] = 'y' in globals()")
   (assert (.startswith (.strip out)
             f"Help on function {(hy.mangle '<-mangle->)} in module "))
   (assert (in "a fancy docstring" out))
-  (assert (empty? err))
+  (assert (not err))
 
   (defmacro "#pillgrums" [x]
     "Look at the quality of that picture!"
@@ -471,7 +474,7 @@ result['y in globals'] = 'y' in globals()")
   (doc "#pillgrums")
   (setv [out err] (.readouterr capsys))
   (assert (in "Look at the quality of that picture!" out))
-  (assert (empty? err))
+  (assert (not err))
 
   ;; make sure doc raises an error instead of
   ;; presenting a default value help screen
@@ -506,7 +509,7 @@ result['y in globals'] = 'y' in globals()")
   (assert (= (list-n 3 (.pop l)) [9 8 7])))
 
 (defn test-cfor []
-  (assert (= (cfor tuple x (range 10) :if (odd? x) x) (, 1 3 5 7 9)))
+  (assert (= (cfor tuple x (range 10) :if (% x 2) x) (, 1 3 5 7 9)))
   (assert (= (cfor all x [1 3 8 5] (< x 10))) True)
   (assert (= (cfor dict x "ABCD" [x True])
              {"A" True  "B" True  "C" True  "D" True})))

--- a/tests/native_tests/extra/anaphoric.hy
+++ b/tests/native_tests/extra/anaphoric.hy
@@ -5,6 +5,9 @@
 (import [hy.errors [HyMacroExpansionError]])
 (require [hy.extra.anaphoric [*]])
 
+(defn even? [x] (= (% x 2) 0))
+(defn odd?  [x] (= (% x 2) 1))
+
 (defn test-ap-if []
   (ap-if True (assert (is it True)))
   (ap-if False True (assert (is it False)))

--- a/tests/native_tests/extra/reserved.hy
+++ b/tests/native_tests/extra/reserved.hy
@@ -19,6 +19,6 @@
   (assert (in "defclass" (names)))
   (assert (in "defmacro" (names)))
   (assert (in "->" (names)))
-  (assert (in "keyword?" (names)))
+  (assert (in "dec" (names)))
   (assert (not-in "foo" (names)))
   (assert (not-in "hy" (names))))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -83,46 +83,49 @@
 (defn test-setv-returns-none []
   "NATIVE: test that setv always returns None"
 
-  (assert (none? (setv)))
-  (assert (none? (setv x 1)))
+  (defn an [x]
+    (assert (is x None)))
+
+  (an (setv))
+  (an (setv x 1))
   (assert (= x 1))
-  (assert (none? (setv x 2)))
+  (an (setv x 2))
   (assert (= x 2))
-  (assert (none? (setv y 2  z 3)))
+  (an (setv y 2  z 3))
   (assert (= y 2))
   (assert (= z 3))
-  (assert (none? (setv [y z] [7 8])))
+  (an (setv [y z] [7 8]))
   (assert (= y 7))
   (assert (= z 8))
-  (assert (none? (setv (, y z) [9 10])))
+  (an (setv (, y z) [9 10]))
   (assert (= y 9))
   (assert (= z 10))
 
   (setv p 11)
   (setv p (setv q 12))
   (assert (= q 12))
-  (assert (none? p))
+  (an p)
 
-  (assert (none? (setv x (defn phooey [] (setv p 1) (+ p 6)))))
-  (assert (none? (setv x (defclass C))))
-  (assert (none? (setv x (for [i (range 3)] i (inc i)))))
-  (assert (none? (setv x (assert True))))
+  (an (setv x (defn phooey [] (setv p 1) (+ p 6))))
+  (an (setv x (defclass C)))
+  (an (setv x (for [i (range 3)] i (inc i))))
+  (an (setv x (assert True)))
 
-  (assert (none? (setv x (with [(open "README.md" "r")] 3))))
+  (an (setv x (with [(open "README.md" "r")] 3)))
   (assert (= x 3))
-  (assert (none? (setv x (try (/ 1 2) (except [ZeroDivisionError] "E1")))))
+  (an (setv x (try (/ 1 2) (except [ZeroDivisionError] "E1"))))
   (assert (= x .5))
-  (assert (none? (setv x (try (/ 1 0) (except [ZeroDivisionError] "E2")))))
+  (an (setv x (try (/ 1 0) (except [ZeroDivisionError] "E2"))))
   (assert (= x "E2"))
 
   ; https://github.com/hylang/hy/issues/1052
-  (assert (none? (setv (get {} "x") 42)))
+  (an (setv (get {} "x") 42))
   (setv l [])
   (defclass Foo [object]
     (defn __setattr__ [self attr val]
       (.append l [attr val])))
   (setv x (Foo))
-  (assert (none? (setv x.eggs "ham")))
+  (an (setv x.eggs "ham"))
   (assert (not (hasattr x "eggs")))
   (assert (= l [["eggs" "ham"]])))
 
@@ -898,7 +901,7 @@
   (defn f [x]
     (return)
     5)
-  (assert (none? (f "q")))
+  (assert (is (f "q") None))
 
   ; `return` in `when`
   (defn f [x]
@@ -912,13 +915,13 @@
   (setv accum [])
   (defn f [x]
     (while True
-      (when (zero? x)
+      (when (= x 0)
         (return))
       (.append accum x)
       (-= x 1))
     (.append accum "this should never be appended")
     1)
-  (assert (none? (f 5)))
+  (assert (is (f 5) None))
   (assert (= accum [5 4 3 2 1]))
 
   ; `return` of a `do`
@@ -1098,7 +1101,7 @@
 (defn test-empty-keyword []
   "NATIVE: test that the empty keyword is recognized"
   (assert (= : :))
-  (assert (keyword? ':))
+  (assert (isinstance ': hy.models.Keyword))
   (assert (!= : ":"))
   (assert (= (. ': name) "")))
 
@@ -1208,7 +1211,7 @@
 (defn test-quote-bracket-string-delim []
   (assert (= (. '#[my delim[hello world]my delim] brackets) "my delim"))
   (assert (= (. '#[[squid]] brackets) ""))
-  (assert (none? (. '"squid" brackets))))
+  (assert (is (. '"squid" brackets) None)))
 
 
 (defn test-format-strings []
@@ -1667,7 +1670,7 @@ cee\"} dee" "ey bee\ncee dee"))
 (defmacro identify-keywords [#* elts]
   `(list
     (map
-     (fn [x] (if (keyword? x) "keyword" "other"))
+     (fn [x] (if (isinstance x hy.models.Keyword) "keyword" "other"))
      ~elts)))
 
 (defn test-keywords-and-macros []
@@ -1701,7 +1704,7 @@ cee\"} dee" "ey bee\ncee dee"))
   ; a single string is the return value, not a docstring
   ; (https://github.com/hylang/hy/issues/1402)
   (defn f3 [] "not a docstring")
-  (assert (none? (. f3 __doc__)))
+  (assert (is (. f3 __doc__) None))
   (assert (= (f3) "not a docstring")))
 
 (defn test-module-docstring []

--- a/tests/native_tests/model_patterns.hy
+++ b/tests/native_tests/model_patterns.hy
@@ -42,7 +42,7 @@
     (setv tail (cut loopers 1 None))
     (print head)
     (cond
-      [(none? head)
+      [(is head None)
         `(do ~@body)]
       [(= (len head) 1)
         `(while ~@head ~(f tail))]

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -155,9 +155,9 @@
       (setv g (hy.gensym))
       `(do
          (setv ~g ~expr)
-         (cond [(pos? ~g) ~pos]
-               [(zero? ~g) ~zero]
-               [(neg? ~g) ~neg])))
+         (cond [(> ~g 0) ~pos]
+               [(= ~g 0) ~zero]
+               [(< ~g 0) ~neg])))
 
     (print (nif (inc -1) 1 0 -1))
     ")
@@ -181,9 +181,9 @@
       (with-gensyms [a]
         `(do
            (setv ~a ~expr)
-           (cond [(pos? ~a) ~pos]
-                 [(zero? ~a) ~zero]
-                 [(neg? ~a) ~neg]))))
+           (cond [(> ~a 0) ~pos]
+                 [(= ~a 0) ~zero]
+                 [(< ~a 0) ~neg]))))
 
     (print (nif (inc -1) 1 0 -1))
     ")
@@ -204,9 +204,9 @@
   (setv macro1 "(defmacro/g! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
-           (cond [(pos? ~g!res) ~pos]
-                 [(zero? ~g!res) ~zero]
-                 [(neg? ~g!res) ~neg])))
+           (cond [(> ~g!res 0) ~pos]
+                 [(= ~g!res 0) ~zero]
+                 [(< ~g!res 0) ~neg])))
 
     (print (nif (inc -1) 1 0 -1))
     ")
@@ -233,9 +233,9 @@
   (setv macro1 "(defmacro! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
-           (cond [(pos? ~g!res) ~pos]
-                 [(zero? ~g!res) ~zero]
-                 [(neg? ~g!res) ~neg])))
+           (cond [(> ~g!res 0) ~pos]
+                 [(= ~g!res 0) ~zero]
+                 [(< ~g!res 0) ~neg])))
 
     (print (nif (inc -1) 1 0 -1))
     ")
@@ -300,7 +300,7 @@
   (setv __name__ "__main__")
 
   (defn main [x]
-    (print (integer? x))
+    (print (isinstance x int))
     x)
 
   (try

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -12,11 +12,11 @@
   ; created for each operator.
   (import [hy.contrib.walk [prewalk]])
   (setv defns [])
-  (for [o (if (coll? op) op [op])]
+  (for [o (if (isinstance op hy.models.Symbol) [op] op)]
     (.append defns `(defn ~(hy.models.Symbol (+ "test_operator_" o "_real")) []
       (setv f-name ~(hy.models.String o))
       ~@(prewalk :form body :f (fn [x]
-          (if (and (symbol? x) (= x (hy.models.Symbol "f"))) o x)))))
+          (if (= x 'f) o x)))))
     (.append defns `(defn ~(hy.models.Symbol (+ "test_operator_" o "_shadow")) []
       (setv f-name ~(hy.models.String o))
       (setv f ~o)

--- a/tests/native_tests/with_test.hy
+++ b/tests/native_tests/with_test.hy
@@ -58,7 +58,7 @@
 (defclass SuppressZDE [object]
   (defn __enter__ [self])
   (defn __exit__ [self exc-type exc-value traceback]
-    (and (not (none? exc-type)) (issubclass exc-type ZeroDivisionError))))
+    (and (is-not exc-type None) (issubclass exc-type ZeroDivisionError))))
 
 (defn test-exception-suppressing-with []
   ; https://github.com/hylang/hy/issues/1320
@@ -67,15 +67,15 @@
   (assert (= x 5))
 
   (setv y (with [(SuppressZDE)] (/ 1 0)))
-  (assert (none? y))
+  (assert (is y None))
 
   (setv z (with [(SuppressZDE)] (/ 1 0) 5))
-  (assert (none? z))
+  (assert (is z None))
 
   (defn f [] (with [(SuppressZDE)] (/ 1 0)))
-  (assert (none? (f)))
+  (assert (is (f) None))
 
   (setv w 7  l [])
   (setv w (with [(SuppressZDE)] (.append l w) (/ 1 0) 5))
-  (assert (none? w))
+  (assert (is w None))
   (assert (= l [7])))

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -358,8 +358,8 @@ def test_bin_hy_builtins():
 def test_bin_hy_shadowing_core():
     # make sure we don't shadow user symbols with hy's core
     # https://github.com/hylang/hy/issues/791
-    output, _ = run_cmd("hy", "(defn keyword? [x] True)\n(keyword? 4)")
-    assert "True" in output
+    output, _ = run_cmd("hy", "(defn dec [x] (+ 66 x))\n(dec 4)")
+    assert "70" in output
 
 
 def test_bin_hy_main():


### PR DESCRIPTION
I wasn't sure which of these to delete and which to move to the spin-off library. It's one of those things where it's hard to draw the line between useful syntactic sugar and an endless parade of tiny functions. Ultimately I just decided to trash all of them.