### PR TITLE
bracketless cond

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -54,6 +54,7 @@ Other Breaking Changes
 * Python reserved words can no longer be parameter names or
   function call keywords
 * hy models are no longer equal to their associated Python values. `(= 1 '1)  ; => False`
+* brackets have been dropped from `cond` and it no longer accepts single condition branches
 
 New Features
 ------------------------------

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -111,7 +111,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
   [functools [reduce]]
   [hy.contrib.walk [by2s]])
 
-(defmacro! ifp [o!pred o!expr #* clauses]
+(defmacro! condp [o!pred o!expr #* clauses]
   "Takes a binary predicate ``pred``, an expression ``expr``, and a set of
   clauses. Each clause can be of the form ``cond res`` or ``cond :>> res``. For
   each clause, if ``(pred cond expr)`` evaluates to true, returns ``res`` in
@@ -121,7 +121,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
   Examples:
     ::
 
-       => (ifp = 4
+       => (condp = 4
        ...   3 :do-something
        ...   5 :do-something-else
        ...   :no-match)
@@ -129,7 +129,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
 
     ::
 
-       => (ifp (fn [x f] (f x)) ':a
+       => (condp (fn [x f] (f x)) ':a
        ...   {:b 1} :>> inc
        ...   {:a 1} :>> dec)
        0
@@ -214,7 +214,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
     (unless (none? gsyms)
       (.append gsyms dcoll))
     (f dcoll result found binds gsyms))
-  (ifp (fn [x y] (isinstance y x)) binds
+  (condp (fn [x y] (isinstance y x)) binds
        hy.models.Symbol [binds expr]
        hy.models.Dict (dispatch dest-dict)
        hy.models.Expression (dispatch dest-iter)
@@ -256,7 +256,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
       sym))
   (->> (.items binds)
        (starmap (fn [target lookup]
-                  (ifp found target
+                  (condp found target
                     ':or []
                     ':as [lookup ddict]
                     ':strs (get-as str lookup)
@@ -302,7 +302,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
                (destructure t `(.get (dict (enumerate ~dlist)) ~i) gsyms))
         err-msg "Invalid magic option :{} in list destructure"
         mres (lfor [m t] magics
-               (ifp found m
+               (condp found m
                  ':as [t dlist]
                  ':& (destructure t (if (isinstance t hy.models.Dict)
                                       `(dict (zip
@@ -337,7 +337,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
   (reduce +
           (+ (lfor t bs (destructure t `(next ~diter None) gsyms))
              (lfor [m t] magics
-               (ifp found m
+               (condp found m
                  ':& [t diter]
                  ':as [t copy-iter])))
           result))

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -140,16 +140,16 @@ Iterator patterns are specified using round brackets. They are the same as list 
           n (len clause)
           test (hy.gensym))
     (cond
-      [(= 0 n) `(raise (TypeError (+ "no option for " (repr ~expr))))]
-      [(= 1 n) (get clause 0)]
-      [(= 2 n) `(if (~pred ~(get clause 0) ~expr)
-                    ~(get clause -1)
-                    ~(emit pred expr more))]
-      [True `(do
-               (setv ~test (~pred ~(get clause 0) ~expr))
-               (if ~test
-                   (~(get clause -1) ~test)
-                   ~(emit pred expr more)))]))
+      (= 0 n) `(raise (TypeError (+ "no option for " (repr ~expr))))
+      (= 1 n) (get clause 0)
+      (= 2 n) `(if (~pred ~(get clause 0) ~expr)
+                   ~(get clause -1)
+                   ~(emit pred expr more))
+      `(do
+         (setv ~test (~pred ~(get clause 0) ~expr))
+         (if ~test
+             (~(get clause -1) ~test)
+             ~(emit pred expr more)))))
   `~(emit g!pred g!expr clauses))
 
 (defmacro setv+ [#* pairs]

--- a/hy/contrib/pprint.hy
+++ b/hy/contrib/pprint.hy
@@ -120,16 +120,16 @@ The differences that do exist are as follows:
   (when (or (and (issubclass typ list) (is r list.__repr__))
             (and (issubclass typ tuple) (is r tuple.__repr__)))
     (cond
-      [(issubclass typ list)
+      (issubclass typ list)
        (if object
           (setv format "[%s]")
-          (return (, "[]" True False)))]
+          (return (, "[]" True False)))
 
-      [(= (len object) 1) (setv format "(, %s)")]
+      (= (len object) 1) (setv format "(, %s)")
 
-      [True (if object
+      (if object
                 (setv format "(, %s)")
-                (return (, "(,)" True False)))])
+                (return (, "(,)" True False))))
     (setv objid (id object))
     (when (and maxlevels (>= level maxlevels))
       (return (, (% format "...") False (in objid context))))

--- a/hy/contrib/slicing.hy
+++ b/hy/contrib/slicing.hy
@@ -38,17 +38,17 @@ or more manually using the tag macro as::
 
   (defn parse-indexing [sym]
     (cond
-      [(and (isinstance sym hy.models.Expression) (= (get sym 0) :))
-       `(slice ~@(cut sym 1 None))]
+      (and (isinstance sym hy.models.Expression) (= (get sym 0) :))
+      `(slice ~@(cut sym 1 None))
 
-      [(and (symbol? sym) (= sym '...))
-       'Ellipsis]
+      (and (symbol? sym) (= sym '...))
+      'Ellipsis
 
-      [(and (isinstance sym (, hy.models.Keyword hy.models.Symbol))
-            (in ":" (str sym)))
-       (try `(slice ~@(parse-colon sym)) (except [ValueError] sym))]
+      (and (isinstance sym (, hy.models.Keyword hy.models.Symbol))
+           (in ":" (str sym)))
+      (try `(slice ~@(parse-colon sym)) (except [ValueError] sym))
 
-      [True sym])))
+      sym)))
 
 (defmacro ncut [seq key1 #* keys]
   "N-Dimensional ``cut`` macro with shorthand slice notation.

--- a/hy/core/hy_repr.hy
+++ b/hy/core/hy_repr.hy
@@ -133,10 +133,10 @@
 (hy-repr-register [hy.models.Float float] (fn [x]
   (setv fx (float x))
   (cond
-    [(isnan fx)  "NaN"]
-    [(= fx Inf)  "Inf"]
-    [(= fx -Inf) "-Inf"]
-    [True (_base-repr x)])))
+    (isnan fx)  "NaN"
+    (= fx Inf)  "Inf"
+    (= fx -Inf) "-Inf"
+    (_base-repr x))))
 
 (hy-repr-register [hy.models.Complex complex] (fn [x]
   (.replace (.replace (.strip (_base-repr x) "()") "inf" "Inf") "nan" "NaN")))

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -136,55 +136,35 @@
               (lfor [i x] (enumerate (+ (, k1 v1) other-kvs))
                     (if (% i 2) x `(get ~c ~x))))))
 
-
 (defmacro cond [#* branches]
-  "Build a nested if clause with each `branch` a [cond result] bracket pair.
+  #[[Build a nested if clause with each `branch` a cond result pair.
 
-  Examples:
-    ::
+     Examples:
+     ::
 
-       => (cond [condition-1 result-1]
-       ...      [condition-2 result-2])
-       (if condition-1 result-1
-         (if condition-2 result-2))
+        => (cond condition-1 result-1
+        ...      condition-2 result-2)
+        (if condition-1 result-1
+            (if condition-2 result-2))
 
-    If only the condition is given in a branch, then the condition is also used as
-    the result. The expansion of this single argument version is demonstrated
-    below::
+     As shown below, only the first matching result block is executed::
 
-       => (cond [condition-1]
-       ...       [condition-2])
-       (if condition-1 condition-1
-         (if condition-2 condition-2))
+        => (defn check-value [value]
+        ...   (cond (< value 5) (print "value is smaller than 5")
+        ...         (= value 5) (print "value is equal to 5")
+        ...         (> value 5) (print "value is greater than 5")
+        ...         (print "value is something that it should not be")))
 
-    As shown below, only the first matching result block is executed::
-
-       => (defn check-value [value]
-       ...   (cond [(< value 5) (print \"value is smaller than 5\")]
-       ...         [(= value 5) (print \"value is equal to 5\")]
-       ...         [(> value 5) (print \"value is greater than 5\")]
-       ...         [True (print \"value is something that it should not be\")]))
-
-       => (check-value 6)
-       \"value is greater than 5\"
-"
-  (or branches
-    (return))
-
-  (setv (, branch #* branches) branches)
-
-  (if (not (and (is (type branch) hy.models.List)
-                branch))
-      (raise (TypeError "each cond branch needs to be a nonempty list"))
-      `(if ~@(if (= (len branch) 1)
-                (do (setv g (hy.gensym))
-                    [`(do (setv ~g ~(get branch 0)) ~g)
-                     g
-                     `(cond ~@branches)])
-                [(get branch 0)
-                 `(do ~@(cut branch 1 None))
-                 `(cond ~@branches)]))))
-
+        => (check-value 6)
+        "value is greater than 5"
+     ]]
+  (setv n (len branches))
+  (if n
+      (if (= n 1)
+          (get branches 0)
+          `(if ~(get branches 0)
+               ~(get branches 1)
+               (cond ~@(cut branches 2 None))))))
 
 (defmacro -> [head #* args]
   "Thread `head` first through the `rest` of the forms.
@@ -527,10 +507,10 @@
        42
   "
   (defn extract-o!-sym [arg]
-    (cond [(and (symbol? arg) (.startswith arg "o!"))
-           arg]
-          [(and (isinstance args hy.models.List) (.startswith (get arg 0) "o!"))
-           (get arg 0)]))
+    (cond (and (symbol? arg) (.startswith arg "o!")) arg
+
+          (and (isinstance args hy.models.List) (.startswith (get arg 0) "o!"))
+          (get arg 0)))
   (setv os (lfor  x (map extract-o!-sym args)  :if x  x)
         gs (lfor s os (hy.models.Symbol (+ "g!" (cut s 2 None)))))
 

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -282,9 +282,6 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 (defn recur-sym-replace [d form]
   "Recursive symbol replacement."
   (cond
-    [(isinstance form hy.models.Symbol)
-      (.get d form form)]
-    [(coll? form)
-      ((type form) (gfor  x form  (recur-sym-replace d x)))]
-    [True
-      form]))
+    (isinstance form hy.models.Symbol) (.get d form form)
+    (coll? form) ((type form) (gfor  x form  (recur-sym-replace d x)))
+    form))

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -8,15 +8,15 @@
 (defn tco-sum [x y]
   (loop [[x x] [y y]]
         (cond
-         [(> y 0) (recur (inc x) (dec y))]
-         [(< y 0) (recur (dec x) (inc y))]
-         [True x])))
+         (> y 0) (recur (inc x) (dec y))
+         (< y 0) (recur (dec x) (inc y))
+         x)))
 
 (defn non-tco-sum [x y]
   (cond
-   [(> y 0) (inc (non-tco-sum x (dec y)))]
-   [(< y 0) (dec (non-tco-sum x (inc y)))]
-   [True x]))
+   (> y 0) (inc (non-tco-sum x (dec y)))
+   (< y 0) (dec (non-tco-sum x (inc y)))
+   x))
 
 (defn test-loop []
   ;; non-tco-sum should fail

--- a/tests/native_tests/contrib/sequences.hy
+++ b/tests/native_tests/contrib/sequences.hy
@@ -15,8 +15,8 @@
 (defn test-indexing-sequence []
   "NATIVE: test indexing sequence"
   (defseq shorty [n]
-    (cond [(< n 10) n]
-          [True (end-sequence)]))
+    (cond (< n 10) n
+          (end-sequence)))
   (setv 0-to-9 (list (range 10)))
   (assert (= (get shorty 0)
              (get 0-to-9 0))
@@ -31,8 +31,8 @@
 (defn test-slicing-sequence []
   "NATIVE: test slicing sequence"
   (defseq shorty [n]
-    (cond [(< n 10) n]
-          [True (end-sequence)]))
+    (cond (< n 10) n
+          (end-sequence)))
   (setv 0-to-9 (list (range 10)))
   (assert (= (get shorty 0)
              (get 0-to-9 0))
@@ -53,10 +53,10 @@
 (defn test-recursive-sequence []
   "NATIVE: test defining a recursive sequence"
   (defseq fibonacci [n]
-    (cond [(= n 0) 0]
-          [(= n 1) 1]
-          [True (+ (get fibonacci (- n 1))
-                   (get fibonacci (- n 2)))]))
+    (cond (= n 0) 0
+          (= n 1) 1
+          (+ (get fibonacci (- n 1))
+                   (get fibonacci (- n 2)))))
   (assert (= (get fibonacci 0)
              0)
           "first element of fibonacci didn't match")
@@ -85,11 +85,11 @@
     (defn next-possible-prime [n]
       "next possible prime after nth prime"
       (inc (get primes (dec n))))
-    (cond [(= n 0) 2]
-          [True (do (setv guess (next-possible-prime n))
-                    (while (divisible? guess (previous-primes n))
-                      (setv guess (inc guess)))
-                    guess)]))
+    (cond (= n 0) 2
+          (do (setv guess (next-possible-prime n))
+              (while (divisible? guess (previous-primes n))
+                (setv guess (inc guess)))
+              guess)))
   (assert (= (list (cut primes 10))
              [2 3 5 7 11 13 17 19 23 29])
           "prime sequence didn't match"))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -350,8 +350,8 @@
 (defn test-cond []
   "NATIVE: test if cond sorta works."
   (cond
-   [(= 1 2) (assert (is True False))]
-   [(is None None) (setv x True) (assert x)])
+   (= 1 2) (assert (is True False))
+   (is None None) (setv x True) (assert x))
   (assert (= (cond) None))
 
   (assert (= (cond
@@ -361,7 +361,7 @@
 
   ;make sure test is only evaluated once
   (setv x 0)
-  (cond [(do (+= x 1) True)])
+  (cond (do (+= x 1) True))
   (assert (= x 1)))
 
 

--- a/tests/native_tests/model_patterns.hy
+++ b/tests/native_tests/model_patterns.hy
@@ -42,15 +42,11 @@
     (setv tail (cut loopers 1 None))
     (print head)
     (cond
-      [(none? head)
-        `(do ~@body)]
-      [(= (len head) 1)
-        `(while ~@head ~(f tail))]
-      [(= (len head) 2)
-        `(for [~@head] ~(f tail))]
-      [True ; (= (len head) 3)
-        (setv [sym from to] head)
-        `(for [~sym (range ~from (inc ~to))] ~(f tail))]))
+      (none? head) `(do ~@body)
+      (= (len head) 1) `(while ~@head ~(f tail))
+      (= (len head) 2) `(for [~@head] ~(f tail))
+      (do (setv [sym from to] head)
+          `(for [~sym (range ~from (inc ~to))] ~(f tail)))))
   (f loopers))
 
 (defn test-loop []

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -155,9 +155,9 @@
       (setv g (hy.gensym))
       `(do
          (setv ~g ~expr)
-         (cond [(pos? ~g) ~pos]
-               [(zero? ~g) ~zero]
-               [(neg? ~g) ~neg])))
+         (cond (pos? ~g) ~pos
+               (zero? ~g) ~zero
+               (neg? ~g) ~neg)))
 
     (print (nif (inc -1) 1 0 -1))
     ")
@@ -181,9 +181,9 @@
       (with-gensyms [a]
         `(do
            (setv ~a ~expr)
-           (cond [(pos? ~a) ~pos]
-                 [(zero? ~a) ~zero]
-                 [(neg? ~a) ~neg]))))
+           (cond (pos? ~a) ~pos
+                 (zero? ~a) ~zero
+                 (neg? ~a) ~neg))))
 
     (print (nif (inc -1) 1 0 -1))
     ")
@@ -204,9 +204,9 @@
   (setv macro1 "(defmacro/g! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
-           (cond [(pos? ~g!res) ~pos]
-                 [(zero? ~g!res) ~zero]
-                 [(neg? ~g!res) ~neg])))
+           (cond (pos? ~g!res) ~pos
+                 (zero? ~g!res) ~zero
+                 (neg? ~g!res) ~neg)))
 
     (print (nif (inc -1) 1 0 -1))
     ")
@@ -233,9 +233,9 @@
   (setv macro1 "(defmacro! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
-           (cond [(pos? ~g!res) ~pos]
-                 [(zero? ~g!res) ~zero]
-                 [(neg? ~g!res) ~neg])))
+           (cond (pos? ~g!res) ~pos
+                 (zero? ~g!res) ~zero
+                 (neg? ~g!res) ~neg)))
 
     (print (nif (inc -1) 1 0 -1))
     ")

--- a/tests/resources/argparse_ex.hy
+++ b/tests/resources/argparse_ex.hy
@@ -15,7 +15,6 @@
 
 ;; using (cond) allows -i to take precedence over -c
 
-(cond [args.i
-       (print (str args.i))]
-      [args.c
-       (print (str "got c"))])
+(cond
+  args.i (print (str args.i))
+  args.c (print (str "got c")))


### PR DESCRIPTION
makes `cond` act like the previously yeeted macro `if`. Also renames `ifp` to `condp` since the behavior it's building off of is now `cond` and not macro `if`