### PR TITLE
consistent binding constructs

### DIFF
--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -32,7 +32,7 @@ tail-call optimization (TCO) in their Hy code.
     -- Wikipedia (https://en.wikipedia.org/wiki/Tail_call)
 "
 
-(import [hy.contrib.walk [prewalk]])
+(import [hy.contrib.walk [prewalk by2s]])
 
 (defn __trampoline__ [f]
   "Wrap f function and make it tail-call optimized."
@@ -88,12 +88,13 @@ tail-call optimization (TCO) in their Hy code.
 
        => (require [hy.contrib.loop [loop]])
        => (defn factorial [n]
-       ...  (loop [[i n] [acc 1]]
+       ...  (loop [i n
+       ...         acc 1]
        ...    (if (= i 0)
        ...      acc
        ...      (recur (dec i) (* acc i)))))
        => (factorial 1000)"
-  (setv [fnargs initargs] (if bindings (zip #* bindings) [[] []]))
+  (setv [fnargs initargs] (if bindings (zip #* (by2s bindings)) [[] []]))
   `(do (require hy.contrib.loop)
        (hy.contrib.loop.defnr ~g!recur-fn [~@fnargs] ~@body)
        (~g!recur-fn ~@initargs)))

--- a/hy/contrib/sequences.hy
+++ b/hy/contrib/sequences.hy
@@ -58,7 +58,7 @@ This results in the sequence ``[0 1 1 2 3 5 8 13 21 34 ...]``.
   (defn __getitem__ [self n]
     "get nth item of sequence"
     (if (hasattr n "start")
-    (gfor x (range (or n.start 0) n.stop (or n.step 1))
+    (gfor [x (range (or n.start 0) n.stop (or n.step 1))]
          (get self x))
     (do (when (< n 0)
          ; Call (len) to force the whole

--- a/hy/contrib/slicing.hy
+++ b/hy/contrib/slicing.hy
@@ -32,7 +32,7 @@ or more manually using the tag macro as::
 "
 (eval-and-compile
   (defn parse-colon [sym]
-    (lfor index (.split (str sym) ":")
+    (lfor [index (.split (str sym) ":")]
           (if index (int index))))
 
   (defn parse-indexing [sym]

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -394,7 +394,7 @@
                       (.add protected pair)
                       (.append argslist pair)]))]
             [(in header ['unpack-iterable 'unpack-mapping])
-             (.update protected (gfor  [_ b #* _] section  b))
+             (.update protected (gfor  [[_ b #* _] section]  b))
              (.extend argslist section)]))
     (, protected argslist))
 

--- a/hy/core/hy_repr.hy
+++ b/hy/core/hy_repr.hy
@@ -97,12 +97,12 @@
   (+ "(," (if x " " "") (_cat x) ")")))
 (hy-repr-register dict :placeholder "{...}" (fn [x]
   (setv text (.join "  " (gfor
-    [k v] (.items x)
+    [[k v] (.items x)]
     (+ (hy-repr k) " " (hy-repr v)))))
   (+ "{" text "}")))
 (hy-repr-register hy.models.Dict :placeholder "{...}" (fn [x]
   (setv text (.join " " (gfor
-    [i item] (enumerate x)
+    [[i item] (enumerate x)]
     (+ (if (and i (= (% i 2) 0)) " " "") (hy-repr item)))))
   (+ "{" text "}")))
 (hy-repr-register hy.models.Expression (fn [x]
@@ -160,8 +160,8 @@
   hy.models.FString
   (fn [fstring]
     (+ "f\""
-       #* (lfor component fstring
-                :setv s (hy-repr component)
+       #* (lfor [component fstring
+                :setv s (hy-repr component)]
                 (if (isinstance component hy.models.String)
                     (-> s (cut 1 -1) (.replace "{" "{{") (.replace "}" "}}"))
                     s))
@@ -224,7 +224,7 @@
     ; collections.namedtuple.)
     (return (.format "({} {})"
                      (. (type x) __name__)
-                     (.join " " (gfor [k v] (zip x._fields x) (+ ":" k " " (hy-repr v)))))))
+                     (.join " " (gfor [[k v] (zip x._fields x)] (+ ":" k " " (hy-repr v)))))))
 
   (unless (isinstance x hy.models.Object)
     (return (repr x)))
@@ -232,7 +232,7 @@
   ; hy.models.Object.
   (.__repr__
     (next (gfor
-      t (. (type x) __mro__)
-      :if (not (issubclass t hy.models.Object))
+      [t (. (type x) __mro__)
+      :if (not (issubclass t hy.models.Object))]
       t))
     x))

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -211,7 +211,7 @@
   "
   (import [itertools [tee islice]])
   (setv [copy1 copy2] (tee coll))
-  (gfor  [x _] (zip copy1 (islice copy2 n None))  x))
+  (gfor  [[x _] (zip copy1 (islice copy2 n None))]  x))
 
 (defn flatten [coll]
   "Return a single flat list expanding all members of `coll`.

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -86,7 +86,7 @@
   "
   `(do (setv
          ~name ~head
-         ~@(sum (gfor  x rest  [name x]) []))
+         ~@(sum (gfor  [x rest]  [name x]) []))
      ~name))
 
 
@@ -133,7 +133,7 @@
   `(setv ~@(+ (if other-kvs
                 [c coll]
                 [])
-              (lfor [i x] (enumerate (+ (, k1 v1) other-kvs))
+              (lfor [[i x] (enumerate (+ (, k1 v1) other-kvs))]
                     (if (% i 2) x `(get ~c ~x))))))
 
 
@@ -531,8 +531,8 @@
            arg]
           [(and (isinstance args hy.models.List) (.startswith (get arg 0) "o!"))
            (get arg 0)]))
-  (setv os (lfor  x (map extract-o!-sym args)  :if x  x)
-        gs (lfor s os (hy.models.Symbol (+ "g!" (cut s 2 None)))))
+  (setv os (lfor [x (map extract-o!-sym args)  :if x]  x)
+        gs (lfor [s os] (hy.models.Symbol (+ "g!" (cut s 2 None)))))
 
   (setv [docstring body] (if (and (isinstance (get body 0) str)
                                   (> (len body) 1))
@@ -660,7 +660,7 @@
 
 
 (defmacro cfor [f #* generator]
-  #[[syntactic sugar for passing a ``generator`` expression to the callable ``f``
+  #[doc[syntactic sugar for passing a ``generator`` expression to the callable ``f``
 
   Its syntax is the same as :ref:`generator expression <py:genexpr>`, but takes
   a function ``f`` that the generator will be immedietly passed to. Equivalent
@@ -668,7 +668,7 @@
 
   Examples:
   ::
-     => (cfor tuple x (range 10) :if (% x 2) x)
+     => (cfor tuple [x (range 10) :if (% x 2)] x)
      (, 1 3 5 7 9)
 
   The equivalent in python would be:
@@ -677,17 +677,17 @@
 
   Some other common functions that take iterables::
 
-     => (cfor all x [1 3 8 5] (< x 10))
+     => (cfor all [x [1 3 8 5]] (< x 10))
      True
 
      => (with [f (open "AUTHORS")]
      ...  (cfor max
-     ...        author (.splitlines (f.read))
-     ...        :setv name (.group (re.match r"\* (.*?) <" author) 1)
-     ...        :if (name.startswith "A")
+     ...        [author (.splitlines (f.read))
+     ...         :setv name (.group (re.match r"\* (.*?) <" author) 1)
+     ...         :if (name.startswith "A")]
      ...        (len name)))
      20 ;; The number of characters in the longest author's name that starts with 'A'
-  ]]
+  ]doc]
   `(~f (gfor ~@generator)))
 
 

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -745,7 +745,7 @@ def compile_for_loop(compiler, expr, root, parts, final):
     return _compile_manual_loop(parts, base_case, orelse=orel)
 
 
-@pattern_macro(["lfor", "sfor", "gfor"], [_loopers, FORM])
+@pattern_macro(["lfor", "sfor", "gfor"], [brackets(_loopers), FORM])
 def compile_sequence_comprehension(compiler, expr, root, parts, final):
     node_class = {
         "lfor": asty.ListComp,
@@ -754,6 +754,7 @@ def compile_sequence_comprehension(compiler, expr, root, parts, final):
     }[root]
 
     elt = compiler.compile(final)
+    parts = parts[0]
     if not parts:
         return Result(
             expr=ast.parse(
@@ -784,13 +785,14 @@ def compile_sequence_comprehension(compiler, expr, root, parts, final):
         )
 
 
-@pattern_macro("dfor", [_loopers, brackets(FORM, FORM)])
+@pattern_macro("dfor", [brackets(_loopers), brackets(FORM, FORM)])
 def compile_dict_comprehension(compiler, expr, root, parts, final):
     # Get the final value (and for dictionary
     # comprehensions, the final key).
     key, elt = map(compiler.compile, final)
 
     # Compile the parts.
+    parts = parts[0]
     if not parts:
         return Result(expr=asty.Dict(expr, keys=[], values=[]))
     parts = _compile_looper_parts(compiler, parts)

--- a/hy/core/shadow.hy
+++ b/hy/core/shadow.hy
@@ -91,7 +91,7 @@
 (defn comp-op [op a1 a-rest]
   "Helper for shadow comparison operators"
   (if a-rest
-    (and #* (gfor (, x y) (zip (+ (, a1) a-rest) a-rest) (op x y)))
+    (and #* (gfor [(, x y) (zip (+ (, a1) a-rest) a-rest)] (op x y)))
     True))
 (defn < [a1 #* a-rest]
   "Shadowed `<` operator perform lt comparison on `a1` by each `a-rest`."

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -95,7 +95,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
        => (list (ap-map (* it 2) [1 2 3]))
        [2 4 6]"
-  (rit `(gfor  ~it ~xs  ~(R form))))
+  (rit `(gfor  [~it ~xs]  ~(R form))))
 
 
 (defmacro ap-map-when [predfn rep xs]
@@ -114,7 +114,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
        => (list (ap-map-when (fn [x] (= (% x 2) 0)) (* it 2) [1 2 3 4]))
        [1 4 3 8]"
-  (rit `(gfor  ~it ~xs  (if (~predfn ~it) ~(R rep) ~it))))
+  (rit `(gfor  [~it ~xs]  (if (~predfn ~it) ~(R rep) ~it))))
 
 
 (defmacro ap-filter [form xs]
@@ -125,7 +125,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
        => (list (ap-filter (> (* it 2) 6) [1 2 3 4 5]))
        [4 5]"
-  (rit `(gfor  ~it ~xs  :if ~(R form)  ~it)))
+  (rit `(gfor  [~it ~xs  :if ~(R form)]  ~it)))
 
 
 (defmacro ap-reject [form xs]
@@ -136,7 +136,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
        => (list (ap-reject (> (* it 2) 6) [1 2 3 4 5]))
        [1 2 3]"
-  (rit `(gfor  ~it ~xs  :if (not ~(R form))  ~it)))
+  (rit `(gfor  [~it ~xs  :if (not ~(R form))]  ~it)))
 
 
 (defmacro ap-dotimes [n #* body]
@@ -164,7 +164,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
        => (ap-first (> it 5) (range 10))
        6"
   (rit `(next
-    (gfor  ~it ~xs  :if ~(R form)  ~it)
+    (gfor  [~it ~xs  :if ~(R form)]  ~it)
     None)))
 
 
@@ -253,17 +253,17 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
     ``#%`` determines the parameter list by the presence of a ``%*`` or ``%**``
     symbol and by the maximum ``%i`` symbol found *anywhere* in the expression,
     so nesting of ``#%`` forms is not recommended."
-  (setv %symbols (sfor a (flatten [expr])
-                       :if (and (isinstance a hy.models.Symbol)
-                                (.startswith a '%))
+  (setv %symbols (sfor [a (flatten [expr])
+                        :if (and (isinstance a hy.models.Symbol)
+                                 (.startswith a '%))]
                        a))
   `(fn [;; generate all %i symbols up to the maximum found in expr
-        ~@(gfor i (range 1 (-> (lfor a %symbols
-                                     :if (.isdigit (cut a 1 None))
+        ~@(gfor [i (range 1 (-> (lfor [a %symbols
+                                     :if (.isdigit (cut a 1 None))]
                                      (int (cut a 1 None)))
                                (or (, 0))
                                max
-                               inc))
+                               inc))]
                 (hy.models.Symbol (+ "%" (str i))))
         ;; generate the #* parameter only if '%* is present in expr
         ~@(if (in '%* %symbols)
@@ -286,6 +286,6 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
     [(isinstance form hy.models.Symbol)
       (.get d form form)]
     [(coll? form)
-      ((type form) (gfor  x form  (recur-sym-replace d x)))]
+      ((type form) (gfor  [x form]  (recur-sym-replace d x)))]
     [True
       form]))

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -125,7 +125,7 @@ def test_eval():
     assert eval_str('(.strip " fooooo   ")') == 'fooooo'
     assert eval_str(
         '(if True "this is if true" "this is if false")') == "this is if true"
-    assert eval_str('(lfor num (range 100) :if (= (% num 2) 1) (pow num 2))') == [
+    assert eval_str('(lfor [num (range 100) :if (= (% num 2) 1)] (pow num 2))') == [
         pow(num, 2) for num in range(100) if num % 2 == 1]
 
 

--- a/tests/native_tests/comprehensions.hy
+++ b/tests/native_tests/comprehensions.hy
@@ -6,58 +6,58 @@
 (defn test-comprehension-types []
 
   ; Forms that get compiled to real comprehensions
-  (assert (is (type (lfor x "abc" x)) list))
-  (assert (is (type (sfor x "abc" x)) set))
-  (assert (is (type (dfor x "abc" [x x])) dict))
-  (assert (is (type (gfor x "abc" x)) types.GeneratorType))
+  (assert (is (type (lfor [x "abc"] x)) list))
+  (assert (is (type (sfor [x "abc"] x)) set))
+  (assert (is (type (dfor [x "abc"] [x x])) dict))
+  (assert (is (type (gfor [x "abc"] x)) types.GeneratorType))
 
   ; Forms that get compiled to loops
-  (assert (is (type (lfor x "abc" :do (setv y 1) x)) list))
-  (assert (is (type (sfor x "abc" :do (setv y 1) x)) set))
-  (assert (is (type (dfor x "abc" :do (setv y 1) [x x])) dict))
-  (assert (is (type (gfor x "abc" :do (setv y 1) x)) types.GeneratorType)))
+  (assert (is (type (lfor [x "abc" :do (setv y 1)] x)) list))
+  (assert (is (type (sfor [x "abc" :do (setv y 1)] x)) set))
+  (assert (is (type (dfor [x "abc" :do (setv y 1)] [x x])) dict))
+  (assert (is (type (gfor [x "abc" :do (setv y 1)] x)) types.GeneratorType)))
 
 
 #@ ((pytest.mark.parametrize "specialop" ["for" "lfor" "sfor" "gfor" "dfor"])
 (defn test-fors [specialop]
 
   (setv cases [
-    ['(f x [] x)
+    ['(f [x []] x)
       []]
-    ['(f j [1 2 3] j)
+    ['(f [j [1 2 3]] j)
       [1 2 3]]
-    ['(f x (range 3) (* x 2))
+    ['(f [x (range 3)] (* x 2))
       [0 2 4]]
-    ['(f x (range 2) y (range 2) (, x y))
+    ['(f [x (range 2) y (range 2)] (, x y))
       [(, 0 0) (, 0 1) (, 1 0) (, 1 1)]]
-    ['(f (, x y) (.items {"1" 1 "2" 2}) (* y 2))
+    ['(f [(, x y) (.items {"1" 1 "2" 2})] (* y 2))
       [2 4]]
-    ['(f x (do (setv s "x") "ab") y (do (+= s "y") "def") (+ x y s))
+    ['(f [x (do (setv s "x") "ab") y (do (+= s "y") "def")] (+ x y s))
       ["adxy" "aexy" "afxy" "bdxyy" "bexyy" "bfxyy"]]
-    ['(f x (range 4) :if (% x 2) (* x 2))
+    ['(f [x (range 4) :if (% x 2)] (* x 2))
       [2 6]]
-    ['(f x "abc" :setv y (.upper x) (+ x y))
+    ['(f [x "abc" :setv y (.upper x)] (+ x y))
       ["aA" "bB" "cC"]]
-    ['(f x "abc" :do (setv y (.upper x)) (+ x y))
+    ['(f [x "abc" :do (setv y (.upper x))] (+ x y))
       ["aA" "bB" "cC"]]
     ['(f
-        x (range 3)
+        [x (range 3)
         y (range 3)
         :if (> y x)
         z [7 8 9]
         :setv s (+ x y z)
-        :if (!= z 8)
+        :if (!= z 8)]
         (, x y z s))
       [(, 0 1 7 8) (, 0 1 9 10) (, 0 2 7 9) (, 0 2 9 11)
         (, 1 2 7 10) (, 1 2 9 12)]]
     ['(f
-        x [0 1]
+        [x [0 1]
         :setv l []
         y (range 4)
         :do (.append l (, x y))
         :if (>= y 2)
         z [7 8 9]
-        :if (!= z 8)
+        :if (!= z 8)]
         (, x y (tuple l) z))
       [(, 0 2 (, (, 0 0) (, 0 1) (, 0 2)) 7)
         (, 0 2 (, (, 0 0) (, 0 1) (, 0 2)) 9)
@@ -68,15 +68,15 @@
         (, 1 3 (, (, 1 0) (, 1 1) (, 1 2) (, 1 3)) 7)
         (, 1 3 (, (, 1 0) (, 1 1) (, 1 2) (, 1 3)) 9)]]
 
-    ['(f x (range 4) :do (unless (% x 2) (continue)) (* x 2))
+    ['(f [x (range 4) :do (unless (% x 2) (continue))] (* x 2))
       [2 6]]
-    ['(f x (range 4) :setv p 9 :do (unless (% x 2) (continue)) (* x 2))
+    ['(f [x (range 4) :setv p 9 :do (unless (% x 2) (continue))] (* x 2))
       [2 6]]
-    ['(f x (range 20) :do (when (= x 3) (break)) (* x 2))
+    ['(f [x (range 20) :do (when (= x 3) (break))] (* x 2))
       [0 2 4]]
-    ['(f x (range 20) :setv p 9 :do (when (= x 3) (break)) (* x 2))
+    ['(f [x (range 20) :setv p 9 :do (when (= x 3) (break))] (* x 2))
       [0 2 4]]
-    ['(f x [4 5] y (range 20) :do (when (> y 1) (break)) z [8 9] (, x y z))
+    ['(f [x [4 5] y (range 20) :do (when (> y 1) (break)) z [8 9]] (, x y z))
       [(, 4 0 8) (, 4 0 9) (, 4 1 8) (, 4 1 9)
         (, 5 0 8) (, 5 0 9) (, 5 1 8) (, 5 1 9)]]])
 
@@ -90,7 +90,7 @@
     (when (= specialop "for")
       (setv expr `(do
         (setv out [])
-        (for [~@(cut expr 1 -1)]
+        (for ~@(cut expr 1 -1)
           (.append out ~(get expr -1)))
         out)))
     (setv result (hy.eval expr))
@@ -105,10 +105,10 @@
   (for [] (.append l 1))
   (assert (= l []))
 
-  (assert (= (lfor 1) []))
-  (assert (= (sfor 1) #{}))
-  (assert (= (list (gfor 1)) []))
-  (assert (= (dfor [1 2]) {})))
+  (assert (= (lfor [] 1) []))
+  (assert (= (sfor [] 1) #{}))
+  (assert (= (list (gfor [] 1)) []))
+  (assert (= (dfor [] [1 2]) {})))
 
 
 (defn test-raise-in-comp []
@@ -117,10 +117,10 @@
   (import pytest)
   (with [(pytest.raises E)]
     (lfor
-      x (range 10)
+      [x (range 10)
       :do (.append l x)
       :do (when (= x 5)
-        (raise (E)))
+        (raise (E)))]
       x))
   (assert (= l [0 1 2 3 4 5])))
 
@@ -133,18 +133,18 @@
 
   ; An `lfor` that gets compiled to a real comprehension
   (setv x 0)
-  (assert (= (lfor x [1 2 3] (inc x)) [2 3 4]))
+  (assert (= (lfor [x [1 2 3]] (inc x)) [2 3 4]))
   (assert (= x 0))
 
   ; An `lfor` that gets compiled to a loop
   (setv x 0  l [])
-  (assert (= (lfor x [4 5 6] :do (.append l 1) (inc x)) [5 6 7]))
+  (assert (= (lfor [x [4 5 6] :do (.append l 1)] (inc x)) [5 6 7]))
   (assert (= l [1 1 1]))
   (assert (= x 0))
 
   ; An `sfor` that gets compiled to a real comprehension
   (setv x 0)
-  (assert (= (sfor x [1 2 3] (inc x)) #{2 3 4}))
+  (assert (= (sfor [x [1 2 3]] (inc x)) #{2 3 4}))
   (assert (= x 0)))
 
 
@@ -190,9 +190,9 @@
   (assert (= s "az"))
 
   (assert (= (list ((fn [] (for [x [[1] [2 3]] y x] (yield y)))))
-             (lfor  x [[1] [2 3]]  y x  y)))
+             (lfor  [x [[1] [2 3]]  y x]  y)))
   (assert (= (list ((fn [] (for [x [[1] [2 3]] y x z (range 5)] (yield z)))))
-             (lfor  x [[1] [2 3]]  y x  z (range 5)  z))))
+             (lfor  [x [[1] [2 3]]  y x  z (range 5)]  z))))
 
 
 (defn test-nasty-for-nesting []

--- a/tests/native_tests/contrib/destructure.hy
+++ b/tests/native_tests/contrib/destructure.hy
@@ -34,7 +34,7 @@
   ;; dict=: :&
   (setv D (dict=: (a (b (c :& inner)) d :& outer)
                   [1 [2 [3 4 5] 6] 7 8]))
-  (assert (= (lfor k "abcd" (get D (hy.models.Symbol k)))
+  (assert (= (lfor [k "abcd"] (get D (hy.models.Symbol k)))
              [1 2 3 7]))
   (assert (= (list (get D 'inner))
              [4 5]))
@@ -61,7 +61,7 @@
   (assert (= [3 4 5] (list (islice d 3))))
   (assert (= [0 1 2 3 4 5] (list (islice e 6))))
   ;; missing
-  (setv+ (a b c :& d :as e) (gfor i (range 2) i))
+  (setv+ (a b c :& d :as e) (gfor [i (range 2)] i))
   (assert (= [a b c]
              [0 1 None]))
   (assert (= [] (list d)))

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -6,7 +6,8 @@
 (import sys)
 
 (defn tco-sum [x y]
-  (loop [[x x] [y y]]
+  (loop [x x
+         y y]
         (cond
          [(> y 0) (recur (inc x) (dec y))]
          [(< y 0) (recur (dec x) (inc y))]
@@ -37,7 +38,7 @@
 
 (defn test-recur-in-wrong-loc []
   (defn bad-recur [n]
-    (loop [[i n]]
+    (loop [i n]
           (if (= i 0)
             0
             (inc (recur (dec i))))))

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -318,7 +318,7 @@ result['y in globals'] = 'y' in globals()")
   (assert (= (list-n 3 (.pop l)) [9 8 7])))
 
 (defn test-cfor []
-  (assert (= (cfor tuple x (range 10) :if (% x 2) x) (, 1 3 5 7 9)))
-  (assert (= (cfor all x [1 3 8 5] (< x 10))) True)
-  (assert (= (cfor dict x "ABCD" [x True])
+  (assert (= (cfor tuple [x (range 10) :if (% x 2)] x) (, 1 3 5 7 9)))
+  (assert (= (cfor all [x [1 3 8 5]] (< x 10))) True)
+  (assert (= (cfor dict [x "ABCD"] [x True])
              {"A" True  "B" True  "C" True  "D" True})))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -143,8 +143,8 @@
       (defn None [] (print "hello"))
       (defn True [] (print "hello"))
       (for [True [1 2 3]] (print "hello"))
-      (lfor  True [1 2 3]  True)
-      (lfor  :setv True 1  True)
+      (lfor  [True [1 2 3]]  True)
+      (lfor  [:setv True 1]  True)
       (with [True x] (print "hello"))
       (try 1 (except [True AssertionError] 2))
       (defclass True [])]]

--- a/tests/native_tests/py3_8_only_tests.hy
+++ b/tests/native_tests/py3_8_only_tests.hy
@@ -20,8 +20,8 @@
 
   (setv a ["apple" None "banana"])
   (setv filtered (lfor
-    i (range (len a))
-    :if (is-not (setx v (get a i)) None)
+    [i (range (len a))
+    :if (is-not (setx v (get a i)) None)]
     v))
   (assert (= filtered ["apple" "banana"]))
   (assert (= v "banana"))

--- a/tests/native_tests/tag_macros.hy
+++ b/tests/native_tests/tag_macros.hy
@@ -91,7 +91,7 @@
     ((wraps func)
        (fn [#* args #** kwargs]
          (func #* (map inc args)
-               #** (dfor [k v] (.items kwargs) [k (inc v)])))))
+               #** (dfor [[k v] (.items kwargs)] [k (inc v)])))))
 
   #@(increment-arguments
      (defn foo [#* args #** kwargs]

--- a/tests/resources/pydemo.hy
+++ b/tests/resources/pydemo.hy
@@ -35,12 +35,12 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
 (setv emptyset #{})
 (setv emptydict {})
 
-(setv mylistcomp (lfor x (range 10) :if (% x 2) x))
-(setv mysetcomp (sfor x (range 5) :if (not (% x 2)) x))
-(setv mydictcomp (dfor k "abcde" :if (!= k "c") [k (.upper k)]))
+(setv mylistcomp (lfor [x (range 10) :if (% x 2)] x))
+(setv mysetcomp (sfor [x (range 5) :if (not (% x 2))] x))
+(setv mydictcomp (dfor [k "abcde" :if (!= k "c")] [k (.upper k)]))
 
 (import [itertools [cycle]])
-(setv mygenexpr (gfor x (cycle [1 2 3]) :if (!= x 2) x))
+(setv mygenexpr (gfor [x (cycle [1 2 3]) :if (!= x 2)] x))
 
 (setv attr-ref str.upper)
 (setv subscript (get "hello" 2))
@@ -181,6 +181,6 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
   (for [:async item (async-loop ["c" "d"])]
     (.append values item))
   (.extend values (lfor
-    :async item (async-loop ["e" "f"])
+    [:async item (async-loop ["e" "f"])]
     item))
   values)


### PR DESCRIPTION
closes #1723 

This attempts to unify the syntax for all the paired binding constructs where the introduced bindings are intended to be used in some following `FORM` or `dolike` body (Such as `(let [...] ...)`, `(with [...] ...)`, `(except [...] ...)`, etc) by adding brackets around loopers such that they follow the form `(lfor [...] ...)`, `(sfor [...] ...)`, etc and also drops the brackets around `loop`'s bindings since they act as binding pairs and not lambda-list. 

Also does some cleanup of the comprehension compile methods since that thing had become a giant 130 line mess