### PR TITLE
Flatten import/require syntax

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,15 @@
 .. default-role:: code
 
+Unreleased
+==============================
+
+Other Breaking Changes
+------------------------------
+* `import` and `require` no longer need outer brackets.
+  `(import [foo [bar]])` is now `(import foo [bar])`
+  and `(import [foo :as baz])` is now `(import foo :as baz)`.
+  To import all names from a module, use `(import foo *)`.
+
 1.0a3 (released 2021-07-09)
 ==============================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -615,12 +615,12 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
        ;; Import from a module
        ;;
        ;; Python: from os.path import exists, isdir, isfile
-       (import [os.path [exists isdir isfile]])
+       (import os.path [exists isdir isfile])
 
        ;; Import with an alias
        ;;
        ;; Python: import sys as systest
-       (import [sys :as systest])
+       (import sys :as systest)
 
        ;; You can list as many imports as you like of different types.
        ;;
@@ -628,16 +628,16 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
        ;; from tests.resources import kwtest, function_with_a_dash
        ;; from os.path import exists, isdir as is_dir, isfile as is_file
        ;; import sys as systest
-       (import [tests.resources [kwtest function-with-a-dash]]
-               [os.path [exists
-                         isdir :as dir?
-                         isfile :as file?]]
-               [sys :as systest])
+       (import tests.resources [kwtest function-with-a-dash]
+               os.path [exists
+                        isdir :as dir?
+                        isfile :as file?]
+               sys :as systest)
 
        ;; Import all module functions into current namespace
        ;;
        ;; Python: from sys import *
-       (import [sys [*]])
+       (import sys *)
 
 .. hy:function:: (eval-and-compile [#* body])
 
@@ -757,7 +757,7 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
    ::
 
-       => (import [itertools [count take-while]])
+       => (import itertools [count take-while])
        => (setv accum [])
        => (list (take-while
        ...  (fn [x] (< x 5))
@@ -1042,16 +1042,16 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
        (require mymodule)
        (mymodule.foo 1)
 
-       (require [mymodule :as M])
+       (require mymodule :as M)
        (M.foo 1)
 
-       (require [mymodule [foo]])
+       (require mymodule [foo])
        (foo 1)
 
-       (require [mymodule [*]])
+       (require mymodule *)
        (foo 1)
 
-       (require [mymodule [foo :as bar]])
+       (require mymodule [foo :as bar])
        (bar 1)
 
    :strong:`Macros that call macros`
@@ -1073,7 +1073,7 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
    ::
 
-       (require [mymodule [foo]])
+       (require mymodule [foo])
 
        (print (mymodule.foo 3))
 
@@ -1081,8 +1081,8 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
    writing ``(print (foo 3))`` in ``mymodule`` works fine. The trouble is that your
    main program doesn't have the macro ``repexpr`` available, since it wasn't
    imported (and imported under exactly that name, as opposed to a qualified name).
-   You could do ``(require [mymodule [*]])`` or ``(require [mymodule [foo
-   repexpr]])``, but a less error-prone approach is to change the definition of
+   You could do ``(require mymodule *)`` or ``(require mymodule [foo repexpr])``,
+   but a less error-prone approach is to change the definition of
    ``foo`` to require whatever sub-macros it needs:
 
    ::
@@ -1092,8 +1092,8 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
            (require mymodule)
            (mymodule.repexpr ~n (input "Gimme some input: "))))
 
-   It's wise to use ``(require mymodule)`` here rather than ``(require [mymodule
-   [repexpr]])`` to avoid accidentally shadowing a function named ``repexpr`` in
+   It's wise to use ``(require mymodule)`` here rather than ``(require mymodule
+   [repexpr])`` to avoid accidentally shadowing a function named ``repexpr`` in
    the main program.
 
    .. note::

--- a/docs/language/model_patterns.rst
+++ b/docs/language/model_patterns.rst
@@ -35,8 +35,8 @@ a pattern for a ``try`` form of the above kind:
 
 .. code-block:: clj
 
-    (import [funcparserlib.parser [maybe many]])
-    (import [hy.model-patterns [*]])
+    (import funcparserlib.parser [maybe many])
+    (import hy.model-patterns [*])
     (setv parser (whole [
       (sym "try")
       (many (notpexpr "except" "else" "finally"))
@@ -98,8 +98,8 @@ Here's how you could write a simple macro using model patterns:
 .. code-block:: clj
 
     (defmacro pairs [#* args]
-      (import [funcparserlib.parser [many]])
-      (import [hy.model-patterns [whole SYM FORM]])
+      (import funcparserlib.parser [many])
+      (import hy.model-patterns [whole SYM FORM])
       (setv [args] (->> args (.parse (whole [
         (many (+ SYM FORM))]))))
       `[~@(->> args (map (fn [x]

--- a/docs/language/repl.rst
+++ b/docs/language/repl.rst
@@ -103,11 +103,11 @@ prompts. The following shows a number of possibilities::
   (import
     re
     json
-    [pathlib [Path]]
-    [hy.contrib.pprint [pp pformat]])
+    pathlib [Path]
+    hy.contrib.pprint [pp pformat])
 
   (require
-    [hy.extra.anaphoric [%]])
+    hy.extra.anaphoric [%])
 
   (setv
     ;; Spy and output-fn will be set automatically for all hy repls

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -14,7 +14,7 @@ To use these macros, you need to require them like so:
 
 .. code-block:: hy
 
-    (require [hy.contrib.destructure [setv+ fn+ defn+ let+ defn/a+ fn/a+]])
+    (require hy.contrib.destructure [setv+ fn+ defn+ let+ defn/a+ fn/a+])
 
 Destructuring allows one to easily peek inside a data structure and assign names to values within. For example,
 
@@ -105,11 +105,11 @@ Iterator Pattern
 Iterator patterns are specified using round brackets. They are the same as list patterns, but can be safely used with infinite generators. The iterator pattern does not allow for recursive destructuring within the ``:as`` special option.
 "
 
-(require [hy.contrib.walk [let]])
+(require hy.contrib.walk [let])
 (import
-  [itertools [starmap chain count]]
-  [functools [reduce]]
-  [hy.contrib.walk [by2s]])
+  itertools [starmap chain count]
+  functools [reduce]
+  hy.contrib.walk [by2s])
 
 (defmacro! ifp [o!pred o!expr #* clauses]
   "Takes a binary predicate ``pred``, an expression ``expr``, and a set of
@@ -331,7 +331,7 @@ Iterator patterns are specified using round brackets. They are the same as list 
         tee (hy.gensym))
   (if (in ':as (sfor  [x #* _] magics  x))
     (.extend result [diter `(do
-                              (import [itertools [tee :as ~tee]])
+                              (import itertools [tee :as ~tee])
                               (setv [~diter ~copy-iter] (~tee ~diter))
                               ~diter)])
     (.append result `(iter ~(.pop result))))

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -32,7 +32,7 @@ tail-call optimization (TCO) in their Hy code.
     -- Wikipedia (https://en.wikipedia.org/wiki/Tail_call)
 "
 
-(import [hy.contrib.walk [prewalk]])
+(import hy.contrib.walk [prewalk])
 
 (defn __trampoline__ [f]
   "Wrap f function and make it tail-call optimized."
@@ -60,7 +60,7 @@ tail-call optimization (TCO) in their Hy code.
     (fn [x] (if (= x 'recur) g!recur-fn x))
     body))
   `(do
-    (import [hy.contrib.loop [__trampoline__]])
+    (import hy.contrib.loop [__trampoline__])
     (with-decorator
       __trampoline__
       (defn ~g!recur-fn [~@signature] ~@new-body))
@@ -86,7 +86,7 @@ tail-call optimization (TCO) in their Hy code.
   Examples:
     ::
 
-       => (require [hy.contrib.loop [loop]])
+       => (require hy.contrib.loop [loop])
        => (defn factorial [n]
        ...  (loop [[i n] [acc 1]]
        ...    (if (= i 0)

--- a/hy/contrib/pprint.hy
+++ b/hy/contrib/pprint.hy
@@ -28,12 +28,12 @@ The differences that do exist are as follows:
 (import sys
         re
         collections
-        [pprint [PrettyPrinter :as PyPrettyPrinter
-                 _recursion
-                 _safe-tuple
-                 _safe-key]]
+        pprint [PrettyPrinter :as PyPrettyPrinter
+                _recursion
+                _safe-tuple
+                _safe-key]
         hy.core.hy-repr
-        [hy._compat [PY3_8 PY3_10]])
+        hy._compat [PY3_8 PY3_10])
 
 (setv __all__ ["pprint" "pformat" "saferepr" "PrettyPrinter" "is_readable" "is_recursive" "pp"])
 
@@ -41,7 +41,7 @@ The differences that do exist are as follows:
   (defn _safe-py-repr [object context maxlevels level sort-dicts]
     (._safe-repr (PyPrettyPrinter :sort-dicts sort-dicts)
       object context maxlevels level))
-  (import [pprint [_safe-repr :as _safe-py-repr]]))
+  (import pprint [_safe-repr :as _safe-py-repr]))
 
 (defn pprint [object #* args #** kwargs]
   "Pretty-print a Python object to a stream [default is sys.stdout].

--- a/hy/contrib/profile.hy
+++ b/hy/contrib/profile.hy
@@ -17,12 +17,12 @@ These macros make debugging where bottlenecks exist easier."
   Examples:
     ::
 
-       => (require [hy.contrib.profile [profile/calls]])
+       => (require hy.contrib.profile [profile/calls])
        => (profile/calls (print \"hey there\"))
   "
   `(do
-     (import [pycallgraph [PyCallGraph]]
-             [pycallgraph.output [GraphvizOutput]])
+     (import pycallgraph [PyCallGraph]
+             pycallgraph.output [GraphvizOutput])
      (with [(PyCallGraph :output (GraphvizOutput))]
            ~@body)))
 
@@ -33,7 +33,7 @@ These macros make debugging where bottlenecks exist easier."
   Examples:
     ::
 
-       => (require [hy.contrib.profile [profile/cpu]])
+       => (require hy.contrib.profile [profile/cpu])
        => (profile/cpu (print \"hey there\"))
 
     .. code-block:: bash
@@ -51,7 +51,7 @@ These macros make debugging where bottlenecks exist easier."
   `(do
      (import cProfile pstats)
 
-     (import [io [StringIO]])
+     (import io [StringIO])
 
      (setv ~g!hy-pr (.Profile cProfile))
      (.enable ~g!hy-pr)

--- a/hy/contrib/sequences.hy
+++ b/hy/contrib/sequences.hy
@@ -12,8 +12,8 @@ resulting in recursive computation.
 To use these macros, you need to require them and import some other names like
 so::
 
-   (require [hy.contrib.sequences [defseq seq]])
-   (import [hy.contrib.sequences [Sequence end-sequence]])
+   (require hy.contrib.sequences [defseq seq])
+   (import hy.contrib.sequences [Sequence end-sequence])
 
 The simplest sequence can be defined as ``(seq [n] n)``. This defines a sequence
 that starts as ``[0 1 2 3 ...]`` and continues forever. In order to define a
@@ -44,7 +44,7 @@ be defined as::
 This results in the sequence ``[0 1 1 2 3 5 8 13 21 34 ...]``.
 "
 
-(import [itertools [islice]])
+(import itertools [islice])
 
 (defclass Sequence []
   "Container for construction of lazy sequences."

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -7,12 +7,12 @@
 .. versionadded:: 0.11.0
 "
 
-(import [functools [partial]]
-        [itertools [islice]]
-        [importlib [import-module]]
-        [collections [OrderedDict]]
-        [hy.macros [macroexpand :as mexpand]]
-        [hy.compiler [HyASTCompiler calling-module]]
+(import functools [partial]
+        itertools [islice]
+        importlib [import-module]
+        collections [OrderedDict]
+        hy.macros [macroexpand :as mexpand]
+        hy.compiler [HyASTCompiler calling-module]
         hy.extra.reserved)
 
 (defn walk [inner outer form]
@@ -23,7 +23,7 @@
   Examples:
     ::
 
-       => (import [hy.contrib.walk [walk]])
+       => (import hy.contrib.walk [walk])
        => (setv a '(a b c d e f))
        => (walk ord (fn [x] x)  a)
        '(97 98 99 100 101 102)
@@ -49,7 +49,7 @@
   Examples:
     ::
 
-       => (import [hy.contrib.walk [postwalk]])
+       => (import hy.contrib.walk [postwalk])
        => (setv trail '([1 2 3] [4 [5 6 [7]]]))
        => (defn walking [x]
        ...   (print \"Walking\" x :sep \"\\n\")
@@ -115,7 +115,7 @@
   Examples:
     ::
 
-       => (import [hy.contrib.walk [prewalk]])
+       => (import hy.contrib.walk [prewalk])
        => (setv trail '([1 2 3] [4 [5 6 [7]]]))
        => (defn walking [x]
        ...  (print \"Walking\" x :sep \"\\n\")

--- a/hy/core/hy_repr.hy
+++ b/hy/core/hy_repr.hy
@@ -3,14 +3,14 @@
 ;; license. See the LICENSE.
 
 (import
-  [math [isnan]]
-  [fractions [Fraction]]
+  math [isnan]
+  fractions [Fraction]
   re
   datetime
   collections)
 
 (try
-  (import [_collections_abc [dict-keys dict-values dict-items]])
+  (import _collections_abc [dict-keys dict-values dict-items])
   (except [ImportError]
     (defclass C)
     (setv [dict-keys dict-values dict-items] [C C C])))

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -7,16 +7,10 @@
 ;;;;
 
 (import itertools)
-(import functools)
-(import operator)  ; shadow not available yet
-(import sys)
-(import [collections.abc :as cabc])
-(import [hy.models [Keyword Symbol]])
-(import [hy.lex [tokenize mangle unmangle read read-str]])
-(import [hy.lex.exceptions [LexException PrematureEndOfInput]])
-(import [hy.compiler [HyASTCompiler calling-module]])
-
-(import [hy.core.shadow [*]])
+(import collections.abc [Iterable])
+(import hy.models [Keyword Symbol]
+        hy.lex [mangle unmangle]
+        hy.compiler [HyASTCompiler calling-module])
 
 (defn butlast [coll]
   "Returns an iterator of all but the last item in *coll*.
@@ -39,7 +33,7 @@
 
     ::
 
-       => (import [itertools [count islice]])
+       => (import itertools [count islice])
        => (list (islice (butlast (count 10)) 0 5))
        [10 11 12 13 14]
   "
@@ -67,7 +61,7 @@
        False
   "
   (and
-    (isinstance coll cabc.Iterable)
+    (isinstance coll Iterable)
     (not (isinstance coll str))))
 
 (defn constantly [value]
@@ -205,11 +199,11 @@
 
     ::
 
-       => (import [itertools [count islice]])
+       => (import itertools [count islice])
        => (list (islice (drop-last 100 (count 10)) 5))
        [10 11 12 13 14]
   "
-  (import [itertools [tee islice]])
+  (import itertools [tee islice])
   (setv [copy1 copy2] (tee coll))
   (gfor  [x _] (zip copy1 (islice copy2 n None))  x))
 
@@ -243,7 +237,7 @@
     (.append result coll))
   result)
 
-(import [threading [Lock]])
+(import threading [Lock])
 (setv _gensym_counter 0)
 (setv _gensym_lock (Lock))
 
@@ -361,7 +355,7 @@
        => (list (rest []))
        []
   "
-  (import [itertools [islice]])
+  (import itertools [islice])
   (islice coll 1 None))
 
 (defn xor [a b]

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -69,7 +69,7 @@
 
     more convoluted example to load web page and retrieve data from it::
 
-       => (import [urllib.request [urlopen]])
+       => (import urllib.request [urlopen])
        => (as-> (urlopen \"http://docs.hylang.org/en/stable/\") it
        ...      (.read it)
        ...      (.decode it \"utf-8\")
@@ -653,7 +653,7 @@
    (setv symbol (str symbol))
    (setv mangled (hy.mangle symbol))
    (setv builtins (hy.gensym "builtins"))
-   `(do (import [builtins :as ~builtins])
+   `(do (import builtins :as ~builtins)
         (help (or (.get __macros__ ~mangled)
                   (.get (. ~builtins __macros__) ~mangled)
                   (raise (NameError f"macro {~symbol !r} is not defined"))))))

--- a/hy/core/shadow.hy
+++ b/hy/core/shadow.hy
@@ -6,9 +6,9 @@
 
 (import operator)
 
-(import [hy.lex [mangle]])
+(import hy.lex [mangle])
 
-(import [functools [reduce]])
+(import functools [reduce])
 
 (defn + [#* args]
   "Shadowed `+` operator adds `args`."

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -15,7 +15,7 @@ concise and easy to read.
 
 To use these macros you need to require the ``hy.extra.anaphoric`` module like so:
 
-``(require [hy.extra.anaphoric [*]])``
+``(require hy.extra.anaphoric *)``
 
 These macros are implemented by replacing any use of the designated
 anaphoric symbols (``it``, in most cases) with a gensym. Consequently,

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -272,36 +272,33 @@ def test_ast_import_mangle_dotted():
 
 def test_ast_good_import_from():
     "Make sure AST can compile valid selective import"
-    can_compile("(import [x [y]])")
+    can_compile("(import x [y])")
 
 
 def test_ast_require():
     "Make sure AST respects (require) syntax"
     can_compile("(require tests.resources.tlib)")
-    can_compile('(require [tests.resources.tlib [qplah parald "#taggart"]])')
-    can_compile("(require [tests.resources.tlib [*]])")
-    can_compile("(require [tests.resources.tlib :as foobar])")
-    can_compile("(require [tests.resources.tlib [qplah :as quiz]])")
-    can_compile("(require [tests.resources.tlib [qplah :as quiz parald]])")
+    can_compile('(require tests.resources.tlib [qplah parald "#taggart"])')
+    can_compile("(require tests.resources.tlib *)")
+    can_compile("(require tests.resources.tlib :as foobar)")
+    can_compile("(require tests.resources.tlib [qplah :as quiz])")
+    can_compile("(require tests.resources.tlib [qplah :as quiz parald])")
     cant_compile("(require [tests.resources.tlib])")
-    cant_compile("(require [tests.resources.tlib [* qplah]])")
-    cant_compile("(require [tests.resources.tlib [qplah *]])")
-    cant_compile("(require [tests.resources.tlib [* *]])")
-    cant_compile("(require [tests.resources.tlib [#taggart]]")
+    cant_compile("(require tests.resources.tlib [#taggart]")
 
 
 def test_ast_import_require_dotted():
     """As in Python, it should be a compile-time error to attempt to
 import a dotted name."""
-    cant_compile("(import [spam [foo.bar]])")
-    cant_compile("(require [spam [foo.bar]])")
+    cant_compile("(import spam [foo.bar])")
+    cant_compile("(require spam [foo.bar])")
 
 
 def test_ast_multi_require():
     # https://github.com/hylang/hy/issues/1903
     x = can_compile("""(require
-      [tests.resources.tlib [qplah]]
-      [tests.resources.macros [threadtail-set-cd]])""")
+      tests.resources.tlib [qplah]
+      tests.resources.macros [threadtail-set-cd])""")
     assert sum(1 for stmt in x.body if isinstance(stmt, ast.Expr)) == 2
     dump = ast.dump(x)
     assert "qplah" in dump
@@ -623,7 +620,7 @@ def test_futures_imports():
     """Make sure __future__ imports go first, especially when builtins are
     automatically added (e.g. via use of a builtin name like `rest`)."""
     hy_ast = can_compile((
-        '(import [__future__ [print_function]])\n'
+        '(import __future__ [print_function])\n'
         '(import sys)\n'
         '(setv some [1 2])'
         '(print (list (rest some)))'))

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -293,5 +293,5 @@ def test_docstring():
 
 def test_hy_python_require():
     # https://github.com/hylang/hy/issues/1911
-    test = "(do (require [tests.resources.macros [test-macro]]) (test-macro) blah)"
+    test = "(do (require tests.resources.macros [test-macro]) (test-macro) blah)"
     assert hy.eval(hy.read_str(test)) == 1

--- a/tests/native_tests/contrib/destructure.hy
+++ b/tests/native_tests/contrib/destructure.hy
@@ -4,9 +4,9 @@
 
 (import pytest)
 (import collections.abc)
-(import [itertools [cycle count islice]])
-(import [hy.contrib.destructure [destructure]])
-(require [hy.contrib.destructure [setv+ dict=: defn+ fn+ let+]])
+(import itertools [cycle count islice])
+(import hy.contrib.destructure [destructure])
+(require hy.contrib.destructure [setv+ dict=: defn+ fn+ let+])
 
 (defn iterator? [x]
   (isinstance x collections.abc.Iterator))

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(require [hy.contrib.loop [loop]])
+(require hy.contrib.loop [loop])
 (import sys)
 
 (defn tco-sum [x y]

--- a/tests/native_tests/contrib/sequences.hy
+++ b/tests/native_tests/contrib/sequences.hy
@@ -2,10 +2,10 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(require [hy.contrib.sequences [seq defseq]])
+(require hy.contrib.sequences [seq defseq])
 
 (import
-  [hy.contrib.sequences [Sequence end-sequence]])
+  hy.contrib.sequences [Sequence end-sequence])
 
 (defn test-infinite-sequence []
   "NATIVE: test creating infinite sequence"

--- a/tests/native_tests/contrib/slicing.hy
+++ b/tests/native_tests/contrib/slicing.hy
@@ -1,7 +1,7 @@
 (import pytest
-        [hy.errors [HyMacroExpansionError HySyntaxError]]
-        [hy.lex [hy-parse exceptions]])
-(require [hy.contrib.slicing [*]])
+        hy.errors [HyMacroExpansionError HySyntaxError]
+        hy.lex [hy-parse exceptions])
+(require hy.contrib.slicing *)
 
 (defn test-ncuts-slicing []
   (assert (= (hy.macroexpand-1 '(ncut df 1:5:-1))           '(get df (slice 1 5 -1))))

--- a/tests/native_tests/contrib/test_pprint.hy
+++ b/tests/native_tests/contrib/test_pprint.hy
@@ -1,9 +1,9 @@
 (import
   pytest
   io
-  [pprint :as pypprint]
-  [hy._compat [PY3_8]]
-  [hy.contrib.pprint :as pprint])
+  pprint :as pypprint
+  hy._compat [PY3_8]
+  hy.contrib.pprint :as pprint)
 
 (defn large-list-b []
   (list (range 200)))

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -2,8 +2,8 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy.contrib.walk [*]])
-(require [hy.contrib.walk [*]])
+(import hy.contrib.walk *)
+(require hy.contrib.walk *)
 
 (import pytest)
 
@@ -69,7 +69,7 @@
 
   (defmacro require-macro []
     `(do
-       (require [tests.resources.macros [test-macro :as my-test-macro]])
+       (require tests.resources.macros [test-macro :as my-test-macro])
        (my-test-macro)))
 
   (assert (= (get (macroexpand-all '(require-macro)) -1)

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -3,7 +3,7 @@
 ;; license. See the LICENSE.
 
 (import
-  [itertools [repeat cycle islice]]
+  itertools [repeat cycle islice]
   pytest)
 
 ;;;; some simple helpers

--- a/tests/native_tests/extra/anaphoric.hy
+++ b/tests/native_tests/extra/anaphoric.hy
@@ -2,8 +2,8 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy.errors [HyMacroExpansionError]])
-(require [hy.extra.anaphoric [*]])
+(import hy.errors [HyMacroExpansionError])
+(require hy.extra.anaphoric *)
 
 (defn even? [x] (= (% x 2) 0))
 (defn odd?  [x] (= (% x 2) 1))

--- a/tests/native_tests/extra/anaphoric_single.hy
+++ b/tests/native_tests/extra/anaphoric_single.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(require [hy.extra.anaphoric [ap-last]])
+(require hy.extra.anaphoric [ap-last])
 
 (defn test-anaphoric-single-require []
   ; https://github.com/hylang/hy/issues/1853#issuecomment-568192529

--- a/tests/native_tests/extra/reserved.hy
+++ b/tests/native_tests/extra/reserved.hy
@@ -2,7 +2,7 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [hy.extra.reserved [macros names]])
+(import hy.extra.reserved [macros names])
 
 (defn test-reserved-macros []
   (assert (is (type (macros)) frozenset))

--- a/tests/native_tests/hy_repr.hy
+++ b/tests/native_tests/hy_repr.hy
@@ -3,8 +3,8 @@
 ;; license. See the LICENSE.
 
 (import
-  [hy._compat [PY3_7]]
-  [math [isnan]])
+  hy._compat [PY3_7]
+  math [isnan])
 
 (defn test-hy-repr-roundtrip-from-value []
   ; Test that a variety of values round-trip properly.
@@ -91,7 +91,7 @@
   (assert (= (hy.repr (.items {1 2})) "(dict-items [(, 1 2)])")))
 
 (defn test-datetime []
-  (import [datetime :as D])
+  (import datetime :as D)
 
   (assert (= (hy.repr (D.datetime 2009 1 15 15 27 5 0))
     "(datetime.datetime 2009 1 15 15 27 5)"))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -2,21 +2,21 @@
 ;; This file is part of Hy, which is free software licensed under the Expat
 ;; license. See the LICENSE.
 
-(import [tests.resources [kwtest function-with-a-dash AsyncWithTest]]
-        [os.path [exists isdir isfile]]
-        [sys :as systest]
+(import tests.resources [kwtest function-with-a-dash AsyncWithTest]
+        os.path [exists isdir isfile]
+        sys :as systest
         re
-        [operator [or_]]
-        [itertools [repeat count islice]]
-        [fractions [Fraction]]
+        operator [or_]
+        itertools [repeat count islice]
+        fractions [Fraction]
         pickle
-        [typing [get-type-hints List Dict]]
+        typing [get-type-hints List Dict]
         asyncio
-        [hy.errors [HyLanguageError HySyntaxError]]
+        hy.errors [HyLanguageError HySyntaxError]
         pytest)
 (import sys)
 
-(import [hy._compat [PY3_8]])
+(import hy._compat [PY3_8])
 
 (defn test-sys-argv []
   "NATIVE: test sys.argv"
@@ -1332,21 +1332,22 @@ cee\"} dee" "ey bee\ncee dee"))
   (import sys os)
 
   ;; from os.path import basename
-  (import [os.path [basename]])
+  (import os.path [basename])
   (assert (= (basename "/some/path") "path"))
 
   ;; import os.path as p
-  (import [os.path :as p])
+  (import os.path :as p)
   (assert (= p.basename basename))
 
   ;; from os.path import basename as bn
-  (import [os.path [basename :as bn]])
+  (import os.path [basename :as bn])
   (assert (= bn basename))
 
   ;; Multiple stuff to import
-  (import sys [os.path [dirname]]
-          [os.path :as op]
-          [os.path [dirname :as dn]])
+  (import sys
+          os.path [dirname]
+          os.path :as op
+          os.path [dirname :as dn])
   (assert (= (dirname "/some/path") "/some"))
   (assert (= op.dirname dirname))
   (assert (= dn dirname)))
@@ -1432,7 +1433,7 @@ cee\"} dee" "ey bee\ncee dee"))
   (with [(pytest.raises NameError)]
     (hyx_XairplaneX 1 2 3 4))
 
-  (require [tests.resources.tlib [qplah]])
+  (require tests.resources.tlib [qplah])
   (assert (= (qplah 1 2 3) [8 1 2 3]))
   (with [(pytest.raises NameError)]
     (parald 1 2 3 4))
@@ -1445,7 +1446,7 @@ cee\"} dee" "ey bee\ncee dee"))
   (with [(pytest.raises NameError)]
     (parald 1 2 3 4))
 
-  (require [tests.resources.tlib :as T])
+  (require tests.resources.tlib :as T)
   (assert (= (T.parald 1 2 3) [9 1 2 3]))
   (assert (= (T.✈ "silly") "plane silly"))
   (assert (= (T.hyx_XairplaneX "foolish") "plane foolish"))
@@ -1453,25 +1454,25 @@ cee\"} dee" "ey bee\ncee dee"))
   (with [(pytest.raises NameError)]
     (parald 1 2 3 4))
 
-  (require [tests.resources.tlib [parald :as p]])
+  (require tests.resources.tlib [parald :as p])
   (assert (= (p 1 2 3) [9 1 2 3]))
   (with [(pytest.raises NameError)]
     (parald 1 2 3 4))
 
-  (require [tests.resources.tlib ["#taggart"]])
+  (require tests.resources.tlib ["#taggart"])
   (assert (= #taggart 15 [10 15]))
 
-  (require [tests.resources.tlib [*]])
+  (require tests.resources.tlib *)
   (assert (= (parald 1 2 3) [9 1 2 3]))
   (assert (= (✈ "silly") "plane silly"))
   (assert (= (hyx_XairplaneX "foolish") "plane foolish"))
 
-  (require [tests.resources [tlib macros :as m]])
+  (require tests.resources [tlib macros :as m])
   (assert (in "tlib.qplah" __macros__))
   (assert (in (hy.mangle "m.test-macro") __macros__))
-  (require [os [path]])
+  (require os [path])
   (with [(pytest.raises hy.errors.HyRequireError)]
-    (hy.eval '(require [tests.resources [does-not-exist]]))))
+    (hy.eval '(require tests.resources [does-not-exist]))))
 
 
 (defn test-require-native []
@@ -1481,19 +1482,19 @@ cee\"} dee" "ey bee\ncee dee"))
   (import tests.native_tests.native_macros)
   (with [(pytest.raises NameError)]
     (rev 1))
-  (require [tests.native_tests.native_macros [rev]])
+  (require tests.native_tests.native_macros [rev])
   (setv x [])
   (rev (.append x 1) (.append x 2) (.append x 3))
   (assert (= x [3 2 1])))
 
 (defn test-relative-require []
-  (require [..resources.macros [test-macro]])
+  (require ..resources.macros [test-macro])
   (assert (in "test_macro" __macros__))
 
-  (require [.native-macros [rev]])
+  (require .native-macros [rev])
   (assert (in "rev" __macros__))
 
-  (require [. [native-macros :as m]])
+  (require . [native-macros :as m])
   (assert (in "m.rev" __macros__)))
 
 
@@ -1570,7 +1571,7 @@ cee\"} dee" "ey bee\ncee dee"))
 (defn test-macroexpand-with-named-import []
   ; https://github.com/hylang/hy/issues/1207
   (defmacro m-with-named-import []
-    (import [math [pow]])
+    (import math [pow])
     (pow 2 3))
   (assert (= (hy.macroexpand '(m-with-named-import)) (hy.models.Float (** 2 3)))))
 
@@ -1621,7 +1622,7 @@ cee\"} dee" "ey bee\ncee dee"))
 
 (defn test-read []
   "NATIVE: test that read takes something for stdin and reads"
-  (import [io [StringIO]])
+  (import io [StringIO])
 
   (setv stdin-buffer (StringIO "(+ 2 2)\n(- 2 2)"))
   (assert (= (hy.eval (hy.read stdin-buffer)) 4))
@@ -1708,13 +1709,13 @@ cee\"} dee" "ey bee\ncee dee"))
   (assert (= (f3) "not a docstring")))
 
 (defn test-module-docstring []
-  (import [tests.resources.module-docstring-example :as m])
+  (import tests.resources.module-docstring-example :as m)
   (assert (= m.__doc__ "This is the module docstring."))
   (assert (= m.foo 5)))
 
 (defn test-relative-import []
   "Make sure relative imports work properly"
-  (import [..resources [tlib]])
+  (import ..resources [tlib])
   (assert (= tlib.SECRET-MESSAGE "Hello World")))
 
 

--- a/tests/native_tests/model_patterns.hy
+++ b/tests/native_tests/model_patterns.hy
@@ -4,8 +4,8 @@
 
 (defmacro do-until [#* args]
   (import
-    [hy.model-patterns [whole FORM notpexpr dolike]]
-    [funcparserlib.parser [many]])
+    hy.model-patterns [whole FORM notpexpr dolike]
+    funcparserlib.parser [many])
   (setv [body condition] (->> args (.parse (whole
     [(many (notpexpr "until")) (dolike "until")]))))
   (setv g (hy.gensym))
@@ -28,8 +28,8 @@
 
 (defmacro loop [#* args]
   (import
-    [hy.model-patterns [whole FORM sym SYM]]
-    [funcparserlib.parser [many]])
+    hy.model-patterns [whole FORM sym SYM]
+    funcparserlib.parser [many])
   (setv [loopers body] (->> args (.parse (whole [
     (many (|
       (>> (+ (sym "while") FORM) (fn [x] [x]))

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -5,7 +5,7 @@
 (import os sys
         importlib
         pytest
-        [hy.errors [HySyntaxError HyTypeError HyMacroExpansionError]])
+        hy.errors [HySyntaxError HyTypeError HyMacroExpansionError])
 
 (defmacro rev [#* body]
   "Execute the `body` statements in reverse"
@@ -149,8 +149,8 @@
 
 (defn test-gensym-in-macros []
   (import ast)
-  (import [hy.compiler [hy-compile]])
-  (import [hy.lex [hy-parse]])
+  (import hy.compiler [hy-compile])
+  (import hy.lex [hy-parse])
   (setv macro1 "(defmacro nif [expr pos zero neg]
       (setv g (hy.gensym))
       `(do
@@ -175,8 +175,8 @@
 
 (defn test-with-gensym []
   (import ast)
-  (import [hy.compiler [hy-compile]])
-  (import [hy.lex [hy-parse]])
+  (import hy.compiler [hy-compile])
+  (import hy.lex [hy-parse])
   (setv macro1 "(defmacro nif [expr pos zero neg]
       (with-gensyms [a]
         `(do
@@ -199,8 +199,8 @@
 
 (defn test-defmacro/g! []
   (import ast)
-  (import [hy.compiler [hy-compile]])
-  (import [hy.lex [hy-parse]])
+  (import hy.compiler [hy-compile])
+  (import hy.lex [hy-parse])
   (setv macro1 "(defmacro/g! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
@@ -228,8 +228,8 @@
 (defn test-defmacro! []
   ;; defmacro! must do everything defmacro/g! can
   (import ast)
-  (import [hy.compiler [hy-compile]])
-  (import [hy.lex [hy-parse]])
+  (import hy.compiler [hy-compile])
+  (import hy.lex [hy-parse])
   (setv macro1 "(defmacro! nif [expr pos zero neg]
         `(do
            (setv ~g!res ~expr)
@@ -349,7 +349,7 @@ in expansions."
 
   (setv nonlocal-test-macro (get __macros__ "nonlocal_test_macro"))
 
-  (require [tests.resources.macro-with-require [*]])
+  (require tests.resources.macro-with-require *)
 
   (setv module-name-var "tests.native_tests.native_macros.test-macro-namespace-resolution")
   (assert (= (+ "This macro was created in tests.resources.macros, "
@@ -394,7 +394,7 @@ in expansions."
   (assert (not (os.path.isfile pyc-file)))
 
   (defn require-macros []
-    (require [tests.resources.macros :as m])
+    (require tests.resources.macros :as m)
 
     (assert (in (hy.mangle "m.test-macro") __macros__))
     (for [macro-name __macros__]
@@ -443,8 +443,8 @@ in expansions."
   (assert (not (os.path.isfile pyc-file)))
 
   (defn test-requires-and-macros []
-    (require [tests.resources.macro-with-require
-              [test-module-macro]])
+    (require tests.resources.macro-with-require
+             [test-module-macro])
 
     ;; Make sure that `require` didn't add any of its `require`s
     (assert (not (in (hy.mangle "nonlocal-test-macro") __macros__)))
@@ -452,7 +452,7 @@ in expansions."
     (assert (not (in (hy.mangle "#test-module-tag") __macros__)))
 
     ;; Now, require everything.
-    (require [tests.resources.macro-with-require [*]])
+    (require tests.resources.macro-with-require *)
 
     ;; Again, make sure it didn't add its required macros and/or tags.
     (assert (not (in (hy.mangle "nonlocal-test-macro") __macros__)))
@@ -490,8 +490,8 @@ in expansions."
 
 
 (defn test-recursive-require-star []
-  "(require [foo [*]]) should pull in macros required by `foo`."
-  (require [tests.resources.macro-with-require [*]])
+  "(require foo *) should pull in macros required by `foo`."
+  (require tests.resources.macro-with-require *)
 
   (test-macro)
   (assert (= blah 1)))
@@ -499,7 +499,7 @@ in expansions."
 
 (defn test-macro-errors []
   (import traceback
-          [hy.importer [hy-parse]])
+          hy.importer [hy-parse])
 
   (setv test-expr (hy-parse "(defmacro blah [x] `(print ~@z)) (blah y)"))
 

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -12,7 +12,7 @@
   ;
   ; `op` can also be a list of operators, in which case two tests are
   ; created for each operator.
-  (import [collections.abc [Iterable]])
+  (import collections.abc [Iterable])
   (setv defns [])
   (for [o (if (isinstance op hy.models.Symbol) [op] op)]
     (defn replace [x]

--- a/tests/native_tests/py3_10_only_tests.hy
+++ b/tests/native_tests/py3_10_only_tests.hy
@@ -1,8 +1,8 @@
 (import pytest
-        [dataclasses [dataclass]]
-        [hy.errors [HySyntaxError]])
+        dataclasses [dataclass]
+        hy.errors [HySyntaxError])
 
-(require [hy.contrib.walk [let]])
+(require hy.contrib.walk [let])
 
 (defn test-pattern-matching []
   (assert (is (match 0

--- a/tests/native_tests/tag_macros.hy
+++ b/tests/native_tests/tag_macros.hy
@@ -3,7 +3,7 @@
 ;; license. See the LICENSE.
 
 (import pytest
-        [functools [wraps]])
+        functools [wraps])
 
 
 (defn test-tag-macro []

--- a/tests/resources/bin/circular_macro_require.hy
+++ b/tests/resources/bin/circular_macro_require.hy
@@ -2,7 +2,7 @@
   `(print ~expr))
 
 (defmacro foo [expr]
-  `(do (require [tests.resources.bin.circular-macro-require [bar]])
+  `(do (require tests.resources.bin.circular-macro-require [bar])
        (bar ~expr)))
 
 (foo 42)

--- a/tests/resources/bin/require_and_eval.hy
+++ b/tests/resources/bin/require_and_eval.hy
@@ -1,3 +1,3 @@
-(require [hy.extra.anaphoric [ap-if]])
+(require hy.extra.anaphoric [ap-if])
 
 (print (hy.eval '(ap-if (+ "a" "b") (+ it "c"))))

--- a/tests/resources/macro_with_require.hy
+++ b/tests/resources/macro_with_require.hy
@@ -1,6 +1,6 @@
 ;; Require all the macros and make sure they don't pollute namespaces/modules
 ;; that require `*` from this.
-(require [tests.resources.macros [*]])
+(require tests.resources.macros *)
 
 (defmacro test-module-macro [a]
   "The variable `macro-level-var' here should not bind to the same-named symbol

--- a/tests/resources/pydemo.hy
+++ b/tests/resources/pydemo.hy
@@ -39,7 +39,7 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
 (setv mysetcomp (sfor x (range 5) :if (not (% x 2)) x))
 (setv mydictcomp (dfor k "abcde" :if (!= k "c") [k (.upper k)]))
 
-(import [itertools [cycle]])
+(import itertools [cycle])
 (setv mygenexpr (gfor x (cycle [1 2 3]) :if (!= x 2) x))
 
 (setv attr-ref str.upper)
@@ -64,9 +64,9 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
 (del (get delstatement 1))
 
 (import math)
-(import [math [sqrt]])
-(import [math [sin :as sine]])
-(import [datetime [*]])
+(import math [sqrt])
+(import math [sin :as sine])
+(import datetime *)
 
 (setv if-block "")
 (if 0
@@ -153,7 +153,7 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
   (setv attr1 5)
   (setv attr2 6))
 
-(import [contextlib [closing]])
+(import contextlib [closing])
 (setv closed [])
 (defclass Closeable []
   (defn close [self] (.append closed self.x)))
@@ -173,7 +173,8 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
 (setv py-accum (py "''.join(map(str, pys_accum))"))
 
 (defn/a coro []
-  (import asyncio [tests.resources [AsyncWithTest async-loop]])
+  (import asyncio
+          tests.resources [AsyncWithTest async-loop])
   (await (asyncio.sleep 0))
   (setv values ["a"])
   (with/a [t (AsyncWithTest "b")]

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -165,7 +165,7 @@ def test_bin_hy_error_parts_length():
     expression."""
     prg_str = """
     (import hy.errors
-            [hy.importer [hy-parse]])
+            hy.importer [hy-parse])
 
     (setv test-expr (hy-parse "(+ 1\n\n'a 2 3\n\n 1)"))
     (setv test-expr.start-line {})
@@ -223,7 +223,7 @@ def test_bin_hy_syntax_errors():
     assert 'SyntaxError: duplicate argument' in err
 
     # https://github.com/hylang/hy/issues/2014
-    _, err = run_cmd("hy", "(defn foo []\n(import [re [*]]))")
+    _, err = run_cmd("hy", "(defn foo []\n(import re *))")
     assert 'SyntaxError: import * only allowed' in err
     assert 'PrematureEndOfInput' not in err
 


### PR DESCRIPTION
Closes #1612.
Obsoletes #851 and #1614.

It's been several years now since the :-1: votes on #851, and we're revamping much of Hy's syntax anyway, so now's as good a time as any to try this (again).

Flattens `import`/`require` syntax to remove outer brackets.
Also removes brackets around `*` imports to "fix" a (very niche) edge case.

```hy
;;;; new syntax
(import foo            ; import foo
        bar [baz qux]  ; from bar import baz, qux
        twarp :as tw)  ; import twarp as tw

;; as one line, using double-space grouping style
(import foo  bar [baz qux]  twarp :as tw)

;; the "edge case"
(require my-operators *)    ; imports all macros from `my-operators`
(require my-operators [*])  ; imports just the single macro called `*`
```