### PR TITLE
better require interface

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1108,6 +1108,23 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
       to do introspection of the current module's set of defined macros, which isn't
       really supported anyway.
 
+   .. note::
+
+      :strong:`Re-requiring shadowed macros`
+
+      Note that it's possible for a user to define a ``require`` macro that would
+      block ``require`` statements from working correctly. The core ``require`` macro
+      is syntactic sugar for the underlying ``hy.macros.require`` method which can be
+      used to re-require a shadowed ``require`` form::
+
+         => (defmacro require [x] "will block subsequent require statements")
+         => (require [hy.contrib.walk [let]])
+         "will block subsequent require statements"
+
+         => (hy.macros.require "hy.core.result_macros" ["require"])
+         => (require [hy.contrib.walk [let]])  ; will compile correctly
+
+
 .. hy:function:: (return [object])
 
    ``return`` compiles to a :py:keyword:`return` statement. It exits the

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -268,11 +268,11 @@ class HyREPL(code.InteractiveConsole, object):
                 self.locals.update(imports)
 
                 # load module macros
-                require(mod, self.module, assignments='ALL')
+                require(mod, 'ALL', target_module=self.module)
             except Exception as e:
                 print(e)
         # Load cmdline-specific macros.
-        require('hy.cmdline', self.module, assignments='ALL')
+        require('hy.cmdline', 'ALL', target_module=self.module)
 
         self.hy_compiler = HyASTCompiler(self.module)
 
@@ -463,7 +463,7 @@ def set_path(filename):
 
 def run_command(source, filename=None):
     __main__ = importlib.import_module('__main__')
-    require("hy.cmdline", __main__, assignments="ALL")
+    require("hy.cmdline", "ALL", __main__)
     try:
         tree = hy_parse(source, filename=filename)
     except HyLanguageError:

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1438,7 +1438,7 @@ def compile_import_or_require(compiler, expr, root, entries):
             ret += node(
                 expr, module=module or None, names=names, level=level)
 
-        elif require(ast_module, compiler.module, assignments=assignments,
+        elif require(ast_module, assignments, compiler.module,
                      prefix=prefix):
             # Actually calling `require` is necessary for macro expansions
             # occurring during compilation.
@@ -1447,8 +1447,6 @@ def compile_import_or_require(compiler, expr, root, entries):
             ret += compiler.compile(Expression([
                 Symbol('hy.macros.require'),
                 String(ast_module),
-                Symbol('None'),
-                Keyword('assignments'),
                 (String("ALL") if assignments == "ALL" else
                     [[String(k), String(v)] for k, v in assignments]),
                 Keyword('prefix'),

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -8,6 +8,7 @@ import inspect
 import pkgutil
 import traceback
 from ast import AST
+from collections.abc import Iterable
 
 from funcparserlib.parser import NoParseError
 
@@ -113,7 +114,7 @@ def _same_modules(source_module, target_module):
             source_filename == target_filename)
 
 
-def require(source_module, target_module, assignments, prefix=""):
+def require(source_module, assignments, target_module=None, prefix=""):
     """Load macros from one module into the namespace of another.
 
     This function is called from the macro also named `require`.
@@ -184,11 +185,12 @@ def require(source_module, target_module, assignments, prefix=""):
 
     if not source_module.__macros__:
         if assignments != "ALL":
-            for name, alias in assignments:
+            for binding in assignments:
+                name, alias = binding if isinstance(binding, Iterable) else (binding, binding)
                 try:
                     require(f"{source_module.__name__}.{mangle(name)}",
-                            target_module,
                             "ALL",
+                            target_module,
                             prefix=alias)
                 except HyRequireError as e:
                     raise HyRequireError(f"Cannot import name '{name}'"


### PR DESCRIPTION
closes #1689 

this makes the `hy.macros.require` method easier to call manually and makes a note about re-requiring macros in the api.