### PR TITLE
Use "environment markers" for conditional install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,19 +61,16 @@ class Install(install):
         # https://github.com/pypa/setuptools/issues/456
         return install.run(self)
 
-install_requires = [
-    'rply>=0.7.7',
-    'funcparserlib>=0.3.6',
-    'colorama']
-if sys.version_info < (3, 9):
-    install_requires.append('astor>=0.8')
-if os.name == 'nt':
-    install_requires.append('pyreadline>=2.1')
-
 setup(
     name=PKG,
     version=__version__,
-    install_requires=install_requires,
+    install_requires=[
+        'rply>=0.7.7',
+        'funcparserlib>=0.3.6',
+        'colorama',
+        'astor>=0.8 ; python_version < "3.9"',
+        'pyreadline>=2.1 ; os_name == "nt"',
+    ],
     cmdclass=dict(install=Install),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
These are defined in PEP 508: https://www.python.org/dev/peps/pep-0508/#environment-markers

The current implementation means that installing 1.0a2 from the published wheel on Python 3.8 does not include `astor` (and thus does not work) because "the Python version that is building the wheel is different from the Python version that is installing it" (from https://hynek.me/articles/conditional-python-dependencies/).

I don't think Windows and Linux can share wheels, so `pyreadline` doesn't strictly have to be included here, but it seems more correct to use this method for both.

(Refs https://github.com/hylang/hy/commit/06f34b018e8bab6170c6a72c4a6e25201268cdb6 / https://github.com/hylang/hy/pull/1999)