### PR TITLE
Handle pyreadline failure (Windows + Python 3.10+)

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,10 +9,12 @@ Other Breaking Changes
   `(import [foo [bar]])` is now `(import foo [bar])`
   and `(import [foo :as baz])` is now `(import foo :as baz)`.
   To import all names from a module, use `(import foo *)`.
+* Dropped support for `pyreadline`
 
 Bug Fixes
 ------------------------------
 * Improved error messages for illegal uses of `finally` and `else`.
+* Fixed a crash on Windows due to Readline
 
 1.0a3 (released 2021-07-09)
 ==============================

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -16,13 +16,14 @@ docomplete = True
 
 try:
     import readline
-except ImportError:
-    try:
-        import pyreadline.rlmain
-        import pyreadline.unicode_helper  # NOQA
-        import readline
-    except ImportError:
+except AttributeError as e:
+    # https://github.com/pyreadline/pyreadline/issues/65
+    if "module 'collections' has no attribute 'Callable'" in str(e):
         docomplete = False
+    else:
+        raise
+except ImportError:
+    docomplete = False
 
 if docomplete:
     if sys.platform == 'darwin' and 'libedit' in readline.__doc__:

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'funcparserlib>=0.3.6',
         'colorama',
         'astor>=0.8 ; python_version < "3.9"',
-        'pyreadline>=2.1 ; os_name == "nt"',
     ],
     cmdclass=dict(install=Install),
     entry_points={


### PR DESCRIPTION
Closes #2114

This is a bit hacky, but I'm not sure if there's a better way.  I'm confident on the `setup.py` change to avoid even installing `pyreadline` on Python 3.10+ (which in itself is enough to fix the problem since then the fallback happens properly), but I added more code to handle the `AttributeError` for cases where `pyreadline` gets installed separately and thus `import readline` still pulls it in (I'm not sure which cases actually invoke the `import pyreadline` fallback code -- maybe older versions of `pyreadline`?  older versions of Python's built-in `readline` module?).