### PR TITLE
Keep `let` from duplicating lambda lists

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,12 +9,11 @@ Other Breaking Changes
   `(import [foo [bar]])` is now `(import foo [bar])`
   and `(import [foo :as baz])` is now `(import foo :as baz)`.
   To import all names from a module, use `(import foo *)`.
-* Dropped support for `pyreadline`
 
 Bug Fixes
 ------------------------------
+* `let` should no longer re-evaluate default arguments.
 * Improved error messages for illegal uses of `finally` and `else`.
-* Fixed a crash on Windows due to Readline
 
 1.0a3 (released 2021-07-09)
 ==============================

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -400,17 +400,18 @@
 
   (defn handle-fn [self]
     (setv [protected argslist] (.handle-args-list self))
+    (setv defn? (= (.head self) 'defn))
     `(; The operator
       ~(.head self)
       ; The name of the function, in the case of `defn`
-      ~@(if (= (.head self) 'defn)
+      ~@(if defn?
         [(get (.tail self) 0)]
         [])
       ; The lambda list
       ~argslist
       ; The function body
       ~@(self.traverse
-        (cut (.tail self) 1 None)
+        (cut (.tail self) (if defn? 2 1) None)
         (| protected self.protected))))
 
   ;; don't expand symbols in quotations

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -399,11 +399,19 @@
     (, protected argslist))
 
   (defn handle-fn [self]
-    (setv [protected argslist] (self.handle-args-list))
-    `(~(self.head) ~@(if (= (self.head) (hy.models.Symbol "defn"))
-                        [(get (.tail self) 0)]
-                        []) ~argslist
-       ~@(self.traverse (cut (self.tail) 1 None)(| protected self.protected))))
+    (setv [protected argslist] (.handle-args-list self))
+    `(; The operator
+      ~(.head self)
+      ; The name of the function, in the case of `defn`
+      ~@(if (= (.head self) 'defn)
+        [(get (.tail self) 0)]
+        [])
+      ; The lambda list
+      ~argslist
+      ; The function body
+      ~@(self.traverse
+        (cut (.tail self) 1 None)
+        (| protected self.protected))))
 
   ;; don't expand symbols in quotations
   (defn handle-quoted [self]

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -419,6 +419,18 @@
     (assert (= head 0))
     (assert (= tail [:bar [1 2]]))))
 
+(defn test-no-extra-eval-of-function-args []
+  ; https://github.com/hylang/hy/issues/2116
+  (setv l [])
+  (defn f []
+    (.append l 1))
+  (let [a 1]
+    (assert (= a 1))
+    (defn g [[b (f)]]
+      5))
+  (assert (= (g) 5))
+  (assert (= l [1])))
+
 (defn test-let-optional []
   (let [a 1
         b 6


### PR DESCRIPTION
Fixes #2116.