### PR TITLE
properly format bracketed strings in hy-repr

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -12,12 +12,15 @@ Other Breaking Changes
 * Functions that provide first-class Python operators, such as ``+``
   in constructs like ``(reduce + xs)``, are no longer brought
   into scope automatically. Say ``(import hy.pyops *)`` to get them.
+* The constructors of `String` and `FString` now check that the input
+  would be syntactically legal.
 
 Bug Fixes
 ------------------------------
 * `let` should no longer re-evaluate default arguments.
 * Improved error messages for illegal uses of `finally` and `else`.
 * `match` should no longer re-evaluate subect.
+* `hy-repr` now properly formats bracketed strings.
 
 New Features
 ------------------------------

--- a/hy/models.py
+++ b/hy/models.py
@@ -436,7 +436,9 @@ def recwrap(f):
     return lambda l: f(as_model(x) for x in l)
 
 _wrappers[FComponent] = recwrap(FComponent)
-_wrappers[FString] = recwrap(FString)
+_wrappers[FString] = lambda fstr: FString(
+    (as_model(x) for x in fstr), brackets=fstr.brackets
+)
 _wrappers[List] = recwrap(List)
 _wrappers[list] = recwrap(List)
 _wrappers[tuple] = recwrap(List)

--- a/tests/native_tests/hy_repr.hy
+++ b/tests/native_tests/hy_repr.hy
@@ -63,6 +63,10 @@
     "'{1 10  2 20}" "'{2 20  1 10}"
     "'asymbol"
     ":akeyword"
+    "'#[[bracketed string]]"
+    "'#[delim[bracketed string]delim]"
+    "'#[delim[brack'eted string]delim]"
+    "'#[f-delim[the answer is {(+ 2 2) :{(+ 2 3)}}]f-delim]"
     "'(f #* args #** kwargs)"])
   (for [original-str strs]
     (setv rep (hy.repr (hy.eval (hy.read-str original-str))))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ import copy
 import pytest
 import hy
 from hy.models import (
-    as_model, replace_hy_obj, Symbol, Keyword, String, Integer,
+    FComponent, FString, as_model, replace_hy_obj, Symbol, Keyword, String, Integer,
     List, Dict, Set, Expression, Complex, Float, pretty)
 
 hy.models.COLORED = False
@@ -46,6 +46,19 @@ def test_replace_int():
     """ Test replacing integers."""
     replaced = replace_hy_obj(0, Integer(13))
     assert replaced == Integer(0)
+
+
+def test_invalid_bracket_strings():
+    for string, brackets in [("]foo]", "foo"), ("something ]f] else", "f")]:
+        with pytest.raises(ValueError):
+            String(string, brackets)
+    for nodes, brackets in [
+        ([String("hello"), String("world ]foo]")], "foo"),
+        ([String("something"), FComponent([String("world")]), String("]f]")], "f"),
+        ([String("something"), FComponent([Integer(1), String("]f]")])], "f"),
+    ]:
+        with pytest.raises(ValueError):
+            FString(nodes, brackets=brackets)
 
 
 def test_replace_string_type():


### PR DESCRIPTION
Also fixes a bug where FStrings models lost `brackets` information
after going through `as_model`.
