### PR TITLE
Compile "quote" forms more compactly

### DIFF
--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -139,17 +139,10 @@ def render_quoted_form(compiler, form, level):
         for x in form:
             f_contents, splice = render_quoted_form(compiler, x, level)
             if splice:
-                contents.append(Expression([
-                    Symbol("list"),
-                    Expression([Symbol("or"), f_contents, List()])]))
-            else:
-                contents.append(List([f_contents]))
-        if form:
-            # If there are arguments, they can be spliced
-            # so we build a sum...
-            body = [Expression([Symbol("+"), List()] + contents)]
-        else:
-            body = [List()]
+                f_contents = Expression([Symbol("unpack-iterable"),
+                                         Expression([Symbol("or"), f_contents, List()])])
+            contents.append(f_contents)
+        body = [List(contents)]
 
         if isinstance(form, FString) and form.brackets is not None:
             body.extend([Keyword("brackets"), form.brackets])
@@ -166,7 +159,7 @@ def render_quoted_form(compiler, form, level):
         if form.brackets is not None:
             body.extend([Keyword("brackets"), form.brackets])
 
-    ret = Expression([Symbol(name)] + body).replace(form)
+    ret = Expression([Symbol(name), *body]).replace(form)
     return ret, False
 
 # ------------------------------------------------


### PR DESCRIPTION
No user-visible changes, just a pet peeve of mine.
This makes quote forms such as `(a ~b ~@c)` compile to the somewhat simpler
```python
hy.models.Expression([hy.models.Symbol('a'), b, *(c or [])])
```
instead of the more complex
```python
hy.models.Expression([] + [hy.models.Symbol('a')] + [b] + list(c or []))
```

I don't think it actually affects anything, but all those unnecessary array additions were getting to me, especially on longer quoted forms.