### PR TITLE
yet another let implementation

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -23,11 +23,17 @@ Other Breaking Changes
 
   * Functions: `butlast`, `coll?`, `constantly`, `dec`, `destructure`, `distinct`, `drop-last`, `end-sequence`, `flatten`, `inc`, `macroexpand-all`, `parse-args`, `pformat`, `postwalk`, `pp`, `pprint`, `prewalk`, `readable?`, `recursive?`, `rest`, `saferepr`, `walk`
   * Classes: `PrettyPrinter`, `Sequence`
-  * Macros: `#%`, `#:`, `->`, `->>`, `ap-dotimes`, `ap-each`, `ap-each-while`, `ap-filter`, `ap-first`, `ap-if`, `ap-last`, `ap-map`, `ap-map-when`, `ap-reduce`, `ap-reject`, `as->`, `assoc`, `cfor`, `comment`, `defmacro!`, `defmacro/g!`, `defmain`, `defn+`, `defn/a+`, `defseq`, `dict=:`, `do-n`, `doto`, `fn+`, `fn/a+`, `ifp`, `let`, `let+`, `lif`, `list-n`, `loop`, `ncut`, `of`, `profile/calls`, `profile/cpu`, `seq`, `setv+`, `smacrolet`, `unless`, `with-gensyms`
+  * Macros: `#%`, `#:`, `->`, `->>`, `ap-dotimes`, `ap-each`, `ap-each-while`, `ap-filter`, `ap-first`, `ap-if`, `ap-last`, `ap-map`, `ap-map-when`, `ap-reduce`, `ap-reject`, `as->`, `assoc`, `cfor`, `comment`, `defmacro!`, `defmacro/g!`, `defmain`, `defn+`, `defn/a+`, `defseq`, `dict=:`, `do-n`, `doto`, `fn+`, `fn/a+`, `ifp`, `let+`, `lif`, `list-n`, `loop`, `ncut`, `of`, `profile/calls`, `profile/cpu`, `seq`, `setv+`, `smacrolet`, `unless`, `with-gensyms`
 
 * The constructors of `String` and `FString` now check that the input
   would be syntactically legal.
 * `hy.extra.reserved` has been renamed to `hy.reserved`.
+* Hy scoping rules more closely follow Python scoping in certain edge cases.
+* `let` is now a core macro. Semantics of `let` have changed in certain
+  edge cases: Any assignment or assignment-like operations (`with`, `match`,
+  etc.) will *assign* to the let-bound name, while any definintions or
+  definition-like operations (`defn`, `defclass`, `import`) will *shadow* the
+  let-bound name (and will also continue to be defined after the `let`-scope ends).
 
 Bug Fixes
 ------------------------------
@@ -40,6 +46,9 @@ Bug Fixes
 * Fixed a bug with self-requiring files on Windows.
 * The `repr` and `str` of string models now include `brackets` if
   necessary.
+* Complex comprehensions are now always treated as inline expressions for
+  variable scoping, rather than creating a new block scope. Specifically,
+  assignments within comprehensions are now always visible to the surrounding code.
 
 New Features
 ------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -869,6 +869,12 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
        ...   (x))
        1
 
+   Note that let-bound variables continue to exist in the surrounding
+   Python scope. As such, ``let``-bound objects may not be eligible for
+   garbage collection as soon as the ``let`` ends. To ensure there are
+   no references to ``let``-bound objects as soon as possible, use
+   ``del`` at the end of the ``let``, or wrap the ``let`` in a function.
+
    .. _extended iterable unpacking: https://www.python.org/dev/peps/pep-3132/#specification
 
 

--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -76,6 +76,7 @@
           "sfor",
           "setv",
           "setx",
+          "let",
           "match",
           "defclass",
           "del",

--- a/docs/whyhy.rst
+++ b/docs/whyhy.rst
@@ -132,7 +132,7 @@ the same time, Hy goes to some lengths to allow you to do typical Lisp things
 that aren't straightforward in Python. For example, Hy provides the
 aforementioned mixing of statements and expressions, :ref:`name mangling
 <mangling>` that transparently converts symbols with names like ``valid?`` to
-Python-legal identifiers, and a :hy:func:`let <hy.contrib.walk.let>` macro to provide block-level scoping
+Python-legal identifiers, and a :hy:func:`let` macro to provide block-level scoping
 in place of Python's usual function-level scoping.
 
 Overall, Hy, like Common Lisp, is intended to be an unopinionated big-tent

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1,4 +1,4 @@
-import ast, copy, importlib, inspect, keyword, pkgutil
+import ast, copy, importlib, inspect, keyword
 import traceback, types
 
 from funcparserlib.parser import NoParseError, many

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -10,6 +10,7 @@ from hy.model_patterns import (FORM, KEYWORD, unpack)
 from hy.errors import (HyCompileError, HyLanguageError, HySyntaxError)
 from hy.lex import mangle
 from hy.macros import macroexpand
+from hy.scoping import ScopeGlobal
 
 
 hy_ast_compile_flags = 0
@@ -322,6 +323,8 @@ class HyASTCompiler:
         # Hy expects this to be present, so we prep the module for Hy
         # compilation.
         self.module.__dict__.setdefault('__macros__', {})
+
+        self.scope = ScopeGlobal(self)
 
     def get_anon_var(self, base="_hy_anon_var"):
         self.anon_var_count += 1
@@ -804,7 +807,8 @@ def hy_compile(
         # Import hy for compile time, but save the compiled AST.
         stdlib_ast = compiler.compile(mkexpr("eval-and-compile", mkexpr("import", "hy")))
 
-    result = compiler.compile(tree)
+    with compiler.scope:
+        result = compiler.compile(tree)
     expr = result.force_expr
 
     if not get_expr:

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -323,9 +323,9 @@ class HyASTCompiler:
         # compilation.
         self.module.__dict__.setdefault('__macros__', {})
 
-    def get_anon_var(self):
+    def get_anon_var(self, base="_hy_anon_var"):
         self.anon_var_count += 1
-        return "_hy_anon_var_%s" % self.anon_var_count
+        return f"{base}_{self.anon_var_count}"
 
     def compile_atom(self, atom):
         # Compilation methods may mutate the atom, so copy it first.

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1459,6 +1459,7 @@ def compile_import_or_require(compiler, expr, root, entries):
                 node = asty.ImportFrom
                 names = [asty.alias(module, name="*", asname=None)]
             elif assignments == "ALL":
+                compiler.scope.define(mangle(prefix))
                 node = asty.Import
                 names = [asty.alias(
                     module,
@@ -1466,12 +1467,14 @@ def compile_import_or_require(compiler, expr, root, entries):
                     asname=mangle(prefix) if prefix != module else None)]
             else:
                 node = asty.ImportFrom
-                names = [
-                    asty.alias(
-                        module,
-                        name=mangle(k),
-                        asname=None if v == k else mangle(v))
-                    for k, v in assignments]
+                names = []
+                for k, v in assignments:
+                    compiler.scope.define(mangle(v))
+                    names.append(
+                        asty.alias(
+                            module,
+                            name=mangle(k),
+                            asname=None if v == k else mangle(v)))
             ret += node(
                 expr, module=module_name or None, names=names, level=level)
 

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -78,7 +78,8 @@ def compile_inline_python(compiler, expr, root, code):
     exec_mode = root == "pys"
 
     try:
-        o = ast.parse(
+        o = asty.parse(
+            expr,
             textwrap.dedent(code) if exec_mode else code,
             compiler.filename,
             'exec' if exec_mode else 'eval').body
@@ -645,7 +646,8 @@ def compile_comprehension(compiler, expr, root, parts, final):
     if is_for:
         parts = parts[0]
     if not parts:
-        return Result(expr=ast.parse({
+        return Result(expr=asty.parse(
+            expr, {
             asty.For: "None",
             asty.ListComp: "[]",
             asty.DictComp: "{}",
@@ -717,7 +719,8 @@ def compile_comprehension(compiler, expr, root, parts, final):
         # `{}.__class__(...)` or `{1}.__class__(...)` to get the
         # right type. We don't want to just use e.g. `list(...)`
         # because the name `list` might be rebound.
-        return ret + Result(expr=ast.parse(
+        return ret + Result(expr=asty.parse(
+            expr,
             "{}({}())".format(
                 {asty.ListComp: "[].__class__",
                  asty.DictComp: "{}.__class__",
@@ -912,7 +915,7 @@ def compile_match_expression(compiler, expr, root, subject, clauses):
                     decorator_list=[],
                 )
                 lifted_if_defs.append(guardret)
-                guard = Result(expr=ast.parse(f"{fname}()").body[0].value)
+                guard = Result(expr=asty.parse(guard, f"{fname}()").body[0].value)
 
         match_cases.append(
             ast.match_case(

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1009,7 +1009,7 @@ def compile_pattern(compiler, pattern):
             kwd_patterns=[compile_pattern(compiler, value) for value in values],
         )
     else:
-        raise compiler._syntax_error(value, "unsuported")
+        raise compiler._syntax_error(value, "unsupported")
 
 # ------------------------------------------------
 # * `raise` and `try`

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1132,7 +1132,12 @@ def compile_catch_expression(compiler, expr, var, exceptions, body):
     else:
         types = compiler.compile(exceptions_list)
 
-    body = compiler._compile_branch(body)
+    # Create a "fake" scope for the exception variable.
+    # See: https://docs.python.org/3/reference/compound_stmts.html#the-try-statement
+    with compiler.scope.create(ScopeLet) as scope:
+        if name:
+            scope.add(name, name)
+        body = compiler._compile_branch(body)
     body += asty.Assign(expr, targets=[var], value=body.force_expr)
     body += body.expr_as_stmt()
 

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -24,6 +24,7 @@ from hy.lex import mangle, unmangle
 from hy.macros import pattern_macro, require
 from hy.errors import (HyTypeError, HyEvalError, HyInternalError)
 from hy.compiler import Result, asty, mkexpr, hy_eval
+from hy.scoping import ScopeFn, ScopeGen, ScopeGlobal, ScopeLet
 
 # ------------------------------------------------
 # * Helpers

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -374,7 +374,7 @@ def compile_assign(compiler, ann, name, value, *, is_assignment_expr = False):
     if (result.temp_variables
             and isinstance(name, Symbol)
             and '.' not in name):
-        result.rename(compiler._nonconst(name))
+        result.rename(compiler, compiler._nonconst(name))
         if not is_assignment_expr:
             # Throw away .expr to ensure that (setv ...) returns None.
             result.expr = None

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1386,13 +1386,17 @@ def compile_class_expression(compiler, expr, root, name, rest):
     if docstring is not None:
         bodyr += compiler.compile(docstring).expr_as_stmt()
 
-    e = compiler._compile_branch(body)
-    bodyr += e + e.expr_as_stmt()
+    name = mangle(compiler._nonconst(name))
+    compiler.scope.define(name)
+
+    with compiler.scope.create(ScopeFn):
+        e = compiler._compile_branch(body)
+        bodyr += e + e.expr_as_stmt()
 
     return bases + asty.ClassDef(
         expr,
         decorator_list=[],
-        name=mangle(compiler._nonconst(name)),
+        name=name,
         keywords=keywords,
         starargs=None,
         kwargs=None,

--- a/hy/scoping.py
+++ b/hy/scoping.py
@@ -1,0 +1,369 @@
+"Scope and variable tracking for Hy/Python scopes."
+
+import ast
+import itertools
+from abc import ABC, abstractmethod
+
+import hy._compat
+from hy.errors import HyInternalError
+from hy.lex import mangle
+from hy.models import Expression, List, Symbol
+
+
+def is_function_scope(scope):
+    return isinstance(scope, ScopeFn) and scope.is_fn
+
+
+def is_inside_function_scope(scope):
+    "True if any enclosing scope (including this one) is a function scope."
+    cur = scope
+    while not isinstance(cur, ScopeGlobal):
+        if is_function_scope(cur):
+            return True
+        cur = cur.parent
+    return False
+
+
+def nearest_python_scope(scope):
+    "Return the closest enclosing scope that corresponds to a Python scope."
+    cur = scope
+    while isinstance(cur, (ScopeLet, ScopeGen)):
+        cur = cur.parent
+    return cur
+
+
+class NodeRef:
+    """
+    Wrapper for AST nodes that have symbol names, so that we can rename them if
+    necessary. Each `NodeRef` corresponds to one Python identifier. `ast` nodes
+    that accept multiple identifier names (`global`, `nonlocal`, etc) have
+    their specific identifier referenced by their `index` in the list of
+    `names` provided by the `ast` node.
+    """
+
+    ACCESSOR = {
+        ast.Name: "id",
+        ast.Global: "names",
+        ast.Nonlocal: "names",
+    }
+    if hy._compat.PY3_10:
+        ACCESSOR.update(
+            {
+                ast.MatchAs: "name",
+                ast.MatchStar: "name",
+                ast.MatchMapping: "rest",
+            }
+        )
+
+    def __init__(self, node, index=None):
+        self.node = node
+        self.index = index
+        self._accessor = NodeRef.ACCESSOR[type(self.node)]
+
+    @property
+    def name(self):
+        res = getattr(self.node, self._accessor)
+        if self.index is not None:
+            return res[self.index]
+        return res
+
+    @name.setter
+    def name(self, new_name):
+        "Used to rename `ast` identifiers"
+        if self.index is not None:
+            getattr(self.node, self._accessor)[self.index] = new_name
+        else:
+            setattr(self.node, self._accessor, new_name)
+
+    @staticmethod
+    def wrap(f):
+        "Decorator to convert AST node parameter to NodeRef."
+
+        def _wrapper(self, node, index=None):
+            if not isinstance(node, NodeRef):
+                node = NodeRef(node, index)
+            return f(self, node)
+
+        return _wrapper
+
+    def __repr__(self):
+        return (
+            f"NodeRef(name={self.name}, node={type(self.node).__name__},"
+            f" index={self.index})"
+        )
+
+
+class ScopeBase(ABC):
+    def __init__(self, compiler):
+        self.parent = None
+        self.compiler = compiler
+
+    def create(self, scope_type, *args):
+        "Create new scope from this one."
+        return scope_type(self.compiler, *args)
+
+    def __enter__(self):
+        self.parent = self.compiler.scope
+        self.compiler.scope = self
+        return self
+
+    def __exit__(self, *args):
+        self.compiler.scope = self.parent
+        self.parent = None
+        return False
+
+    # Scope interface
+    @abstractmethod
+    def access(self, node, index=None):
+        "Called when a symbol is accessed."
+        ...
+
+    @abstractmethod
+    def assign(self, node, index=None):
+        "Called when a symbol is assigned to."
+        ...
+
+    @abstractmethod
+    def define(self, name):
+        """
+        Called when a symbol is defined.
+        (e.g., function names, class names, imports)
+        """
+        ...
+
+    @abstractmethod
+    def define_nonlocal(self, node, root):
+        "Called when a symbol is declared nonlocal or global."
+        ...
+
+
+class ScopeGlobal(ScopeBase):
+    """Global scope."""
+
+    def __init__(self, compiler):
+        super().__init__(compiler)
+        self.defined = set()
+        "set: of all symbols created or assigned to in this scope"
+
+        self.nonlocal_vars = []
+        """
+        list: of all `nonlocal`'s defined in this scope.
+
+        Explicitly not a `set` so that we maintain the order they were defined in
+        """
+
+    def __exit__(self, *args):
+        nonlocal_vars = self.nonlocal_vars
+        self.nonlocal_vars = []
+        if not self.defined.issuperset(nonlocal_vars):
+            raise SyntaxError(f"no binding for nonlocal '{nonlocal_vars[0]}'")
+        return super().__exit__(*args)
+
+    @NodeRef.wrap
+    def access(self, node, index=0):
+        return node.node
+
+    @NodeRef.wrap
+    def assign(self, node):
+        self.define(node.name)
+        return node.node
+
+    def define(self, name):
+        self.defined.add(name)
+
+    def define_nonlocal(self, node, root):
+        if root == "nonlocal":
+            self.nonlocal_vars.extend(node.names)
+        else:
+            self.defined.update(node.names)
+
+
+class ScopeLet(ScopeBase):
+    """
+    Scope that supports let-binding by renaming bound symbols as they are
+    accessed/assigned. Defined symbols are never renamed.
+    """
+
+    def __init__(self, compiler):
+        super().__init__(compiler)
+        self.bindings = {}
+
+    def _rename_if_bound(self, node):
+        if node.name in self.bindings:
+            node.name = self.bindings[node.name]
+            return True
+        return False
+
+    @NodeRef.wrap
+    def access(self, node):
+        self._rename_if_bound(node) or self.parent.access(node)
+        return node.node
+
+    @NodeRef.wrap
+    def assign(self, node):
+        self._rename_if_bound(node) or self.parent.assign(node)
+        return node.node
+
+    def define(self, name):
+        self.bindings.pop(name, None)
+        self.parent.define(name)
+
+    def define_nonlocal(self, node, root):
+        # remove nonlocal defs of any let scopes in this Python scope
+        cur = self
+        while isinstance(cur, ScopeLet):
+            for name in node.names:
+                if root == "nonlocal":
+                    if name in cur.bindings and cur is not self:
+                        node.names.remove(name)
+                else:
+                    cur.bindings[name] = name
+            cur = cur.parent
+        cur.define_nonlocal(node, root)
+
+    def add(self, target, new_name=None):
+        """Add a new let-binding target, mapped to a new, unique name."""
+        if isinstance(target, (str, Symbol)):
+            if "." in target:
+                raise ValueError("binding target may not contain a dot")
+            name = mangle(target)
+            if new_name is None:
+                new_name = self.compiler.get_anon_var(f"_hy_let_{name}")
+            self.bindings[name] = new_name
+            if isinstance(target, Symbol):
+                return Symbol(new_name).replace(target)
+            return new_name
+        if new_name is not None:
+            raise ValueError("cannot specify name for compound targets")
+        if isinstance(target, List):
+            return List(map(self.add, target)).replace(target)
+        if (isinstance(target, Expression) and target and
+                target[0] in (Symbol(","), Symbol("unpack-iterable"))):
+            return Expression([target[0], *map(self.add, target[1:])]).replace(
+                target
+            )
+        raise ValueError(f"invalid binding target: {type(target)}")
+
+
+class ScopeFn(ScopeBase):
+    """Scope that corresponds to Python's own function or class scopes."""
+
+    def __init__(self, compiler, args=None):
+        super().__init__(compiler)
+        self.defined = set()
+        "set: of all vars defined in this scope"
+        self.seen = []
+        "list: of all vars accessedto in this scope"
+        self.nonlocal_vars = set()
+        "set: of all `nonlocal`'s defined in this scope"
+        self.is_fn = args is not None
+        """
+        bool: `True` if this scope is being used to track a python
+        function `False` for classes
+        """
+
+        if args:
+            for arg in itertools.chain(
+                args.args, args.posonlyargs, args.kwonlyargs, [args.vararg, args.kwarg]
+            ):
+                if arg:
+                    self.define(arg.arg)
+
+    def __exit__(self, *args):
+        for node in self.seen:
+            if node.name not in self.defined or node.name in self.nonlocal_vars:
+                # pass unbound/nonlocal names up to parent scope
+                self.parent.access(node)
+        return super().__exit__(*args)
+
+    @NodeRef.wrap
+    def access(self, node):
+        self.seen.append(node)
+        return node.node
+
+    @NodeRef.wrap
+    def assign(self, node):
+        self.access(node)
+        self.define(node.name)
+        return node.node
+
+    def define(self, name):
+        self.defined.add(name)
+
+    def define_nonlocal(self, node, root):
+        ((self.nonlocal_vars if root == "nonlocal" else self.defined)
+            .update(node.names))
+        for n in self.seen:
+            if n.name in node.names:
+                raise SyntaxError(
+                    f"name '{n.name}' is declared {root} after being used"
+                )
+        if root == "nonlocal":
+            # toss all nonlocal names up to parent scope
+            for i in range(len(node.names)):
+                self.parent.access(node, i)
+
+
+class ScopeGen(ScopeFn):
+    """
+    Scope that supports generator forms (`lfor`, `gfor`, ...). If this scope is
+    contained within a function scope or the global scope, then any variable
+    assignments are "leaked out" to the parent scope, mimicking Python's inline
+    generator semantics.
+
+    .. note::
+       see :pep:`572#why-not-use-a-sublocal-scope-and-prevent-namespace-pollution`
+       for more details on how and when variables are leaked into enclosing scopes.
+    """
+
+    def __init__(self, compiler):
+        super().__init__(compiler)
+        self.iterators = set()
+        self.assignments = []
+        self.nonlocals = set()
+        self.exposing_assignments = False
+
+    def __enter__(self):
+        super().__enter__()
+        enclosing = nearest_python_scope(self.parent)
+        if isinstance(enclosing, ScopeGlobal) or is_function_scope(enclosing):
+            # only "leak out" assignments if we're contained in a function
+            # (or global) scope
+            self.exposing_assignments = True
+        return self
+
+    def finalize(self):
+        """
+        Access and return all the identifiers created and potentially leaked
+        out by this generator. This should be called once and only once we've
+        processed all of the iterators in this generators so as not to leak out
+        any unwanted identifiers
+        """
+        res = set()
+        for node in self.assignments:
+            if node.name not in self.nonlocal_vars:
+                self.parent.access(node)
+                res.add(node.name)
+        return sorted(res)
+
+    @NodeRef.wrap
+    def assign(self, node):
+        self.access(node)
+        if node.name not in self.defined:
+            self.assignments.append(node)
+        return node.node
+
+    def iterator(self, target):
+        """
+        Declare an iteration variable name for this scope; as in Python, the
+        iteration variable(s) cannot be reassigned.
+        """
+        self.iterators.update(
+            name.id for name in ast.walk(target) if isinstance(name, ast.Name)
+        )
+        # remove potentially leakable identifiers that were actually iteration
+        # variables found in `target`
+        self.assignments = [
+            node for node in self.assignments if node.name not in self.iterators
+        ]
+        self.seen = [node for node in self.seen if node.name not in self.iterators]

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -194,8 +194,8 @@ def test_ast_bad_global():
 
 def test_ast_good_nonlocal():
     "Make sure AST can compile valid nonlocal"
-    can_compile("(nonlocal a)")
-    can_compile("(nonlocal foo bar)")
+    can_compile("(do (setv a 0) (nonlocal a))")
+    can_compile("(do (setv foo 0 bar 0) (nonlocal foo bar))")
 
 
 def test_ast_bad_nonlocal():

--- a/tests/native_tests/let.hy
+++ b/tests/native_tests/let.hy
@@ -1,0 +1,422 @@
+(require
+  hyrule [let smacrolet])
+(import
+  sys)
+
+
+(defn test-smacrolet []
+  (setv form '(do
+                (setv foo (fn [a [b 1]] (* b (inc a))))
+                (* b (foo 7)))
+        form1 (hy.macroexpand
+                '(smacrolet [b c]
+                   (setv foo (fn [a [b 1]] (* b (inc a))))
+                   (* b (foo 7))))
+        form2 (hy.macroexpand
+                '(smacrolet [a c]
+                   (setv foo (fn [a [b 1]] (* b (inc a))))
+                   (* b (foo 7))))
+        form3 (hy.macroexpand
+                '(smacrolet [foo bar]
+                   (setv foo (fn [a [b 1]] (* b (inc a))))
+                   (* b (foo 7)))))
+  (assert (= form1 '(do
+                      (setv foo (fn [a [b 1]] (* b (inc a))))
+                      (* c (foo 7)))))
+  (assert (= form2 form))
+  (assert (= form3 '(do
+                      (setv bar (fn [a [b 1]] (* b (inc a))))
+                      (* b (bar 7))))))
+
+
+(defn test-let-basic []
+  (assert (= (let [a 0] a) 0))
+  (setv a "a"
+        b "b")
+  (let [a "x"
+        b "y"]
+    (assert (= (+ a b)
+               "xy"))
+    (let [a "z"]
+      (assert (= (+ a b)
+                 "zy")))
+    ;; let-shadowed variable doesn't get clobbered.
+    (assert (= (+ a b)
+               "xy")))
+  (let [q "q"]
+    (assert (= q "q")))
+  (assert (= a "a"))
+  (assert (= b "b"))
+  (assert (in "a" (.keys (vars))))
+  ;; scope of q is limited to let body
+  (assert (not-in "q" (.keys (vars)))))
+
+
+;; let should substitute within f-strings
+;; related to https://github.com/hylang/hy/issues/1843
+(defn test-let-fstring []
+  (assert (= (let [a 0] a) 0))
+  (setv a "a"
+        b "b")
+  (let [a "x"
+        b "y"]
+    (assert (= f"res: {(+ a b)}!"
+               "res: xy!"))
+    (let [a 4]
+      (assert (= f"double f >{b :^{(+ a 1)}}<"
+                 "double f >  y  <")))))
+
+
+(defn test-let-sequence []
+  ;; assignments happen in sequence, not parallel.
+  (let [a "a"
+        b "b"
+        ab (+ a b)]
+    (assert (= ab "ab"))
+    (let [c "c"
+          abc (+ ab c)]
+      (assert (= abc "abc")))))
+
+
+(defn test-let-early []
+  (setv a "a")
+  (let [q (+ a "x")
+        a 2  ; should not affect q
+        b 3]
+    (assert (= q "ax"))
+    (let [q (* a b)
+          a (+ a b)
+          b (* a b)]
+      (assert (= q 6))
+      (assert (= a 5))
+      (assert (= b 15))))
+  (assert (= a "a")))
+
+
+(defn test-let-special []
+  ;; special forms in function position still work as normal
+  (let [, 1]
+    (assert (= (, , ,)
+               (, 1 1)))))
+
+
+(defn test-let-quasiquote []
+  (setv a-symbol 'a)
+  (let [a "x"]
+    (assert (= a "x"))
+    (assert (= 'a a-symbol))
+    (assert (= `a a-symbol))
+    (assert (= (hy.as-model `(foo ~a))
+               '(foo "x")))
+    (assert (= (hy.as-model `(foo `(bar a ~a ~~a)))
+               '(foo `(bar a ~a ~"x"))))
+    (assert (= (hy.as-model `(foo ~@[a]))
+               '(foo "x")))
+    (assert (= (hy.as-model `(foo `(bar [a] ~@[a] ~@~(hy.models.List [a 'a `a]) ~~@[a])))
+               '(foo `(bar [a] ~@[a] ~@["x" a a] ~"x"))))))
+
+
+(defn test-let-except []
+  (let [foo 42
+        bar 33]
+    (assert (= foo 42))
+    (try
+      (do
+        1/0
+        (assert False))
+      (except [foo Exception]
+        ;; let bindings should work in except block
+        (assert (= bar 33))
+        ;; but exception bindings can shadow let bindings
+        (assert (isinstance foo Exception))))
+    ;; let binding did not get clobbered.
+    (assert (= foo 42))))
+
+
+(defn test-let-mutation []
+  (setv foo 42)
+  (setv error False)
+  (let [foo 12
+        bar 13]
+    (assert (= foo 12))
+    (setv foo 14)
+    (assert (= foo 14))
+    (del foo)
+    ;; deleting a let binding should not affect others
+    (assert (= bar 13))
+    (try
+      ;; foo=42 is still shadowed, but the let binding was deleted.
+      (do
+        foo
+        (assert False))
+      (except [le LookupError]
+        (setv error le)))
+    (setv foo 16)
+    (assert (= foo 16))
+    (setv [foo bar baz] [1 2 3])
+    (assert (= foo 1))
+    (assert (= bar 2))
+    (assert (= baz 3)))
+  (assert error)
+  (assert (= foo 42))
+  (assert (= baz 3)))
+
+
+(defn test-let-break []
+  (for [x (range 3)]
+    (let [done (% x 2)]
+      (if done (break))))
+  (assert (= x 1)))
+
+
+(defn test-let-continue []
+  (let [foo []]
+    (for [x (range 10)]
+      (let [odd (% x 2)]
+        (if odd (continue))
+        (.append foo x)))
+    (assert (= foo [0 2 4 6 8]))))
+
+
+(defn test-let-yield []
+  (defn grind []
+    (yield 0)
+    (let [a 1
+          b 2]
+      (yield a)
+      (yield b)))
+  (assert (= (tuple (grind))
+             (, 0 1 2))))
+
+
+(defn test-let-return []
+  (defn get-answer []
+    (let [answer 42]
+      (return answer)))
+  (assert (= (get-answer)
+             42)))
+
+
+(defn test-let-import []
+  (let [types 6]
+    ;; imports don't fail, even if using a let-bound name
+    (import types)
+    ;; let-bound name is not affected
+    (assert (= types 6)))
+  ;; import happened in Python scope.
+  (assert (in "types" (vars)))
+  (assert (isinstance types types.ModuleType)))
+
+
+(defn test-let-defclass []
+  (let [Foo 42
+        quux object]
+    ;; the name of the class is just a symbol, even if it's a let binding
+    (defclass Foo [quux]  ; let bindings apply in inheritance list
+      ;; let bindings apply inside class body
+      (setv x Foo)
+      ;; quux is not local
+      (setv quux "quux"))
+    (assert (= quux "quux")))
+  ;; defclass always creates a python-scoped variable, even if it's a let binding name
+  (assert (= Foo.x 42)))
+
+
+(defn test-let-dot []
+  (setv foo (fn [])
+        foo.a 42)
+  (let [a 1
+        b []
+        bar (fn [])]
+    (setv bar.a 13)
+    (assert (= bar.a 13))
+    (setv (. bar a) 14)
+    (assert (= bar.a 14))
+    (assert (= a 1))
+    (assert (= b []))
+    ;; method syntax not affected
+    (.append b 2)
+    (assert (= b [2]))
+    ;; attrs access is not affected
+    (assert (= foo.a 42))
+    (assert (= (. foo a)
+               42))
+    ;; but indexing is
+    (assert (= (. [1 2 3]
+                  [a])
+               2))))
+
+
+(defn test-let-positional []
+  (let [a 0
+        b 1
+        c 2]
+    (defn foo [a b]
+      (, a b c))
+    (assert (= (foo 100 200)
+               (, 100 200 2)))
+    (setv c 300)
+    (assert (= (foo 1000 2000)
+               (, 1000 2000 300)))
+    (assert (= a 0))
+    (assert (= b 1))
+    (assert (= c 300))))
+
+
+(defn test-let-rest []
+  (let [xs 6
+        a 88
+        c 64
+        &rest 12]
+    (defn foo [a b #* xs]
+      (-= a 1)
+      (setv xs (list xs))
+      (.append xs 42)
+      (, &rest a b c xs))
+    (assert (= xs 6))
+    (assert (= a 88))
+    (assert (= (foo 1 2 3 4)
+               (, 12 0 2 64 [3 4 42])))
+    (assert (= xs 6))
+    (assert (= c 64))
+    (assert (= a 88))))
+
+
+(defn test-let-kwargs []
+  (let [kws 6
+        &kwargs 13]
+    (defn foo [#** kws]
+      (, &kwargs kws))
+    (assert (= kws 6))
+    (assert (= (foo :a 1)
+               (, 13 {"a" 1})))))
+
+
+(defn test-let-optional []
+  (let [a 1
+        b 6
+        d 2]
+    (defn foo [[a a] [b None] [c d]]
+      (, a b c))
+    (assert (= (foo)
+               (, 1 None 2)))
+    (assert (= (foo 10 20 30)
+               (, 10 20 30)))))
+
+
+(defn test-let-closure []
+  (let [count 0]
+    (defn +count [[x 1]]
+      (+= count x)
+      count))
+  ;; let bindings can still exist outside of a let body
+  (assert (= 1 (+count)))
+  (assert (= 2 (+count)))
+  (assert (= 42 (+count 40))))
+
+
+(defmacro triple [a]
+  (setv g!a (hy.gensym a))
+  `(do
+     (setv ~g!a ~a)
+     (+ ~g!a ~g!a ~g!a)))
+
+
+(defmacro ap-triple []
+  '(+ a a a))
+
+
+(defn test-let-macros []
+  (let [a 1
+        b (triple a)
+        c (ap-triple)]
+    (assert (= (triple a)
+               3))
+    (assert (= (ap-triple)
+               3))
+    (assert (= b 3))
+    (assert (= c 3))))
+
+
+(defn test-let-rebind []
+  (let [x "foo"
+        y "bar"
+        x (+ x y)
+        y (+ y x)
+        x (+ x x)]
+    (assert (= x "foobarfoobar"))
+    (assert (= y "barfoobar"))))
+
+
+(defn test-let-unpacking []
+  (let [[a b] [1 2]
+        [lhead #* ltail] (range 3)
+        (, thead #* ttail) (range 3)
+        [nhead #* (, c #* nrest)] [0 1 2]]
+    (assert (= a 1))
+    (assert (= b 2))
+    (assert (= lhead 0))
+    (assert (= ltail [1 2]))
+    (assert (= thead 0))
+    (assert (= ttail [1 2]))
+    (assert (= nhead 0))
+    (assert (= c 1))
+    (assert (= nrest [2]))))
+
+
+(defn test-let-unpacking-rebind []
+  (let [[a b] [:foo :bar]
+        [a #* c] (range 3)
+        [head #* tail] [a b c]]
+    (assert (= a 0))
+    (assert (= b :bar))
+    (assert (= c [1 2]))
+    (assert (= head 0))
+    (assert (= tail [:bar [1 2]]))))
+
+
+(defn test-no-extra-eval-of-function-args []
+  ; https://github.com/hylang/hy/issues/2116
+  (setv l [])
+  (defn f []
+    (.append l 1))
+  (let [a 1]
+    (assert (= a 1))
+    (defn g [[b (f)]]
+      5))
+  (assert (= (g) 5))
+  (assert (= l [1])))
+
+
+(defn test-let-optional []
+  (let [a 1
+        b 6
+        d 2]
+       (defn foo [* [a a] b [c d]]
+         (, a b c))
+       (assert (= (foo :b "b")
+                  (, 1 "b" 2)))
+       (assert (= (foo :b 20 :a 10 :c 30)
+                  (, 10 20 30)))))
+
+
+(when (>= sys.version-info (, 3 10)) (hy.eval
+'(defn test-let-with-pattern-matching []
+  (let [x [1 2 3]
+        y (dict :a 1 :b 2 :c 3)
+        b 1
+        a 1
+        _ 42]
+    (assert (= [2 3]
+               (match x
+                      [1 #* x] x)))
+    (assert (= [3 [1 2 3] [1 2 3]]
+               (match x
+                      [_ _ 3 :as a] :as b :if (= a 3) [a b x])))
+    (assert (= [1 2]
+               (match [1 2]
+                      x x)))
+    (assert (= 42
+               (match [1 2 3]
+                    _ _)))))))
+

--- a/tests/native_tests/let.hy
+++ b/tests/native_tests/let.hy
@@ -492,24 +492,3 @@
        (assert (= (foo :b 20 :a 10 :c 30)
                   (, 10 20 30)))))
 
-
-(when (>= sys.version-info (, 3 10)) (hy.eval
-'(defn test-let-with-pattern-matching []
-  (let [x [1 2 3]
-        y (dict :a 1 :b 2 :c 3)
-        b 1
-        a 1
-        _ 42]
-    (assert (= [2 3]
-               (match x
-                      [1 #* x] x)))
-    (assert (= [3 [1 2 3] [1 2 3]]
-               (match x
-                      [_ _ 3 :as a] :as b :if (= a 3) [a b x])))
-    (assert (= [1 2]
-               (match [1 2]
-                      x x)))
-    (assert (= 42
-               (match [1 2 3]
-                    _ _)))))))
-

--- a/tests/native_tests/py3_10_only_tests.hy
+++ b/tests/native_tests/py3_10_only_tests.hy
@@ -140,3 +140,123 @@
          n (assert (= n 4)))
   (match (do (foo) (foo) x)
          n (assert (= n 6))))
+
+(defn test-let-match []
+  (let [x 3]
+    (assert (match x 3 True))))
+
+(defn test-let-match-simple []
+  (let [x 3  y 4]
+    (match x
+           y (assert (= x y)))
+    (match 7
+           y (assert (= 7 y))))
+
+  (setv [x y] [3 4])
+  (let [x 1  y 2]
+    (assert (= [x y] [1 2]))
+    (match [5 6]
+           [x y] (assert (= [x y] [5 6]))
+           _ (assert False))
+    (assert (= [x y] [5 6])))
+  (assert (= [x y] [3 4])))
+
+#@(dataclass
+  (defclass Point []
+    (^int x)
+    (^int y)))
+
+(defn test-let-match-pattern []
+  (setv [x y] [1 2]
+        p (Point 5 6))
+  (let [x 3  y 4]
+    (match p
+      (Point x y)
+        (assert (= [x y] [5 6]))
+      _ (assert False))
+    (assert (= [x y] [5 6])))
+  (assert (= [x y] [1 2]))
+
+  (let [x 3  y 4]
+    (match p
+      (Point :x n  :y m)
+        (assert (= [n m] [5 6]))
+      _ (assert False)))
+
+  (let [x 3  y 4]
+    (match p
+      (Point :x x  :y y)
+        (assert (= [x y] [5 6]))
+      _ (assert False))
+    (assert (= [x y] [5 6])))
+  (assert (= [x y] [1 2]))
+
+  (with [(pytest.raises TypeError)]
+    (let [Point [x y]]
+      (match p
+        (Point x y)
+          (assert False))))
+
+  (assert (= "right" (let [x (Point 3 4)]
+    (match 3
+      x.x "right"
+      _ "wrong"))))
+
+  (let [x (Point 3 6)
+        y 9]
+    (match p
+      (Point :y x.y) :as y
+        (assert (= y.y x.y))
+      _ (assert False))
+    (match p
+      (Point :x x) :as q
+        (assert (= x q.x))
+      _ (assert False))
+    (assert (= x 5))
+    (assert (= y.y p.y)))
+
+  (let [x (Point 3 6)
+        y 9]
+    (match p
+      (Point :y (. x y)) :as y
+        (assert (= (. y y) (. x y)))
+      _ (assert False))
+    (assert (= y.y p.y))))
+
+(defn test-let-match-guard []
+  (setv x 1  y 2)
+  (let [x 3  y 4]
+    (match (Point 3 4)
+      (Point :y m :x n) :if (= [n m] [x y]) True
+      _ (assert False)))
+  (let [x 3  y 4
+        n 5  m 6]
+    (match (Point 3 4)
+      (Point :y m :x n) :if (= [n m] [x y]) True
+      _ (assert False))))
+
+(defn test-let-with-pattern-matching []
+  (let [x [1 2 3]
+        y (dict :a 1 :b 2 :c 3)
+        b 1
+        a 1
+        _ 42]
+    (assert (= [2 3]
+               (match x
+                      [1 #* x] x)))
+    (assert (= [3 [2 3] [2 3]]
+               (match x
+                      [_ 3 :as a] :as b :if (= a 3) [a b x])))
+    (assert (= [1 2]
+               (match [1 2]
+                      x x)))
+    (assert (= 42
+               (match [1 2 3]
+                    _ _)))
+    (assert (= {"a" 1  "c" 3}
+               (match y
+                      {"b" b #**e} e)))
+    (assert (= {"a" 1  "c" 3}
+               (match y
+                      {"b" b #**a} a)))
+    (assert (= b 2))))

--- a/tests/native_tests/py3_8_only_tests.hy
+++ b/tests/native_tests/py3_8_only_tests.hy
@@ -23,3 +23,35 @@
   (assert (= v "banana"))
   (with [(pytest.raises NameError)]
     i))
+
+(defn test-setx-generator-scope []
+  ;; https://github.com/hylang/hy/issues/1994
+  (setv x 20)
+  (lfor n (range 10) (setx x n))
+  (assert (= x 9))
+
+  (setv x 20)
+  (lfor n (range 10) :do x (setx x n))  ; force making a function
+  (assert (= x 9))
+
+  (lfor n (range 10) :do x (setx y n))
+  (assert (= y 9))
+
+  (lfor n (range 0) :do x (setx y n))
+  (with [(pytest.raises NameError)]
+    n)
+
+  (lfor n (range 0) :setv t (+ n 2) (setx y n))
+  (with [(pytest.raises NameError)]
+    t)
+
+  (lfor n (range 0) :do x (setx z n))
+  (with [(pytest.raises UnboundLocalError)]
+    z))
+
+(defn test-let-setx []
+  (let [x 40
+        y 13]
+    (setv y (setx x 2))
+    (assert (= x 2))
+    (assert (= y 2))))


### PR DESCRIPTION
Once again, a major breaking change that nobody asked for, even though I haven't even finished the last one.

Here's a (draft) implementation that adds tracking of scoping information, allowing us to implement `let` as a first-class result macro.

I did my best to have `let` bindings interact nicely with Python's normal scoping rules; that is, let bindings are as close to possible as standard assignment.

### Examples!

This example is fairly straightforward; `x` refers to the name outside the function.
```hy
(let [x 1]
  (defn foo []
    (print x)))
(foo)
```
```python
_hy_scope_1_x = 1
def foo():
    return print(_hy_scope_1_x)
foo()
```

If we assign to `x` inside the function, then per Python scoping rules, `x` is entirely local to the function despite any assignment outside:
```python
# showing "actual" assignment for this example
x = 1
def foo():
    print(x)  # UnboundLocalError
    x = 8
foo()
```
Therefore, this is how the corresponding Hy compiles:
```hy
(let [x 1]
  (defn foo []
    (print x)
    (setv x 8)))
(foo)
```
```python
_hy_scope_1_x = 1
def foo():
    print(x)  # UnboundLocalError, as "expected"
    x = 8
foo()
```
However, if we use a `nonlocal`/`global`, then all is well again!
```hy
(let [x 1]
  (defn foo []
    (global x)
    (print x)
    (setv x 8)))
(foo)
```
```python
_hy_scope_1_x = 1
def foo():
    global _hy_scope_1_x
    print(_hy_scope_1_x)
    _hy_scope_1_x = 8  # assigns to outer `x`!
foo()
```

I need to experiment further, but I think the scope tracking can also help us solve the problem from #1994 with `setx` and scope weirdness with generator forms.