### PR TITLE
Get Hy installing again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     },
     packages=find_packages(exclude=['tests*']),
     package_data={
+        'hy': ['*.hy', '__pycache__/*'],
         'hy.contrib': ['*.hy', '__pycache__/*'],
         'hy.core': ['*.hy', '__pycache__/*'],
         'hy.extra': ['*.hy', '__pycache__/*'],


### PR DESCRIPTION
In #2121, I broke installation. `pip install -e` works, as we use in GitHub Actions for testing, but not without `-e`, because then `Install.__compile_hy_bytecode` runs, which tries to call `importlib.util.cache_from_source` with a nonexistent keyword argument `optimize` (a typo for `optimization`). The `cache_from_source` call was never previously executed because the glob `"hy/**.hy"` matched nothing (what was meant was `"hy/**/*.hy"`) until I added `hy.pyops`. If fixed, this code still wouldn't help, because `cache_from_source` just returns a path, without compiling anything. In short, I don't think #1865 ever really worked.

Rather than try to fix bytecode compilation, I've just removed the custom `Install` class, which makes `pip install` without `-e` work again. #1747 can be regarded as already covering the question of compiling and installing bytecode for Hy's standard library, so I haven't made any new issues.