### PR TITLE
 Remove copyright and license headers from code

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,21 +52,6 @@ unsure of the proposed change, create an issue to discuss it before
 you write any code. This will allow others to give feedback on your
 idea, and it can avoid wasted work.
 
-File headers
-------------
-
-Every Python or Hy file in the source tree that is potentially
-copyrightable should have the following header (but with ``;;`` in
-place of ``#`` for Hy files)::
-
-      # Copyright [current year] the authors.
-      # This file is part of Hy, which is free software licensed under the Expat
-      # license. See the LICENSE.
-
-As a rule of thumb, a file can be considered potentially copyrightable
-if it includes at least 10 lines that contain something other than
-comments or whitespace. If in doubt, include the header.
-
 Commit formatting
 -----------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This file is execfile()d with the current directory set to its containing dir.
 
 import re, os, sys, time, html

--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import sys
 
 PY3_7 = sys.version_info >= (3, 7)

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import colorama
 colorama.init()
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # Copyright 2021 the authors.
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import ast, copy, importlib, inspect, keyword, pkgutil
 import traceback, types
 

--- a/hy/completer.py
+++ b/hy/completer.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import contextlib
 import os
 import re

--- a/hy/contrib/destructure.hy
+++ b/hy/contrib/destructure.hy
@@ -1,7 +1,4 @@
 ;;; Hy destructuring bind
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 "
 This module is heavily inspired by destructuring from Clojure and provides very
 similar semantics. It provides several macros that allow for destructuring within

--- a/hy/contrib/loop.hy
+++ b/hy/contrib/loop.hy
@@ -1,7 +1,4 @@
 ;;; Hy tail-call optimization
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 
 "The loop/recur macro allows you to construct functions that use tail-call
 optimization to allow arbitrary levels of recursion.

--- a/hy/contrib/profile.hy
+++ b/hy/contrib/profile.hy
@@ -1,9 +1,3 @@
-;;; Hy profiling macros
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
-;;; These macros make debugging where bottlenecks exist easier.
 "Hy Profiling macros
 
 These macros make debugging where bottlenecks exist easier."

--- a/hy/contrib/sequences.hy
+++ b/hy/contrib/sequences.hy
@@ -1,6 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 ".. versionadded:: 0.12.0
 
 The sequences module contains a few macros for declaring sequences that are

--- a/hy/contrib/slicing.hy
+++ b/hy/contrib/slicing.hy
@@ -1,7 +1,4 @@
 ;;; Hy Multi-Index Slicing module
-;; Copyright 2021 the authors.
-;; this file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 "Macros for elegantly slicing and dicing multi-axis and multidimensional sequences.
 
 Libraries like ``numpy`` and ``pandas`` make extensive use of python's slicing syntax

--- a/hy/contrib/walk.hy
+++ b/hy/contrib/walk.hy
@@ -1,7 +1,3 @@
-;;; Hy AST walker
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 "Hy AST walker
 
 .. versionadded:: 0.11.0

--- a/hy/core/hy_repr.hy
+++ b/hy/core/hy_repr.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import
   math [isnan]
   fractions [Fraction]

--- a/hy/core/language.hy
+++ b/hy/core/language.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 ;;;; This contains some of the core Hy functions used
 ;;;; to make functional programming slightly easier.
 ;;;;

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -1,7 +1,4 @@
 ;;; Hy core macros
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 
 ;;; These macros form the hy language
 ;;; They are automatically required in every module, except inside hy.core

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 """This file contains Hy's core macros that are written in Python and
 return compiler Result objects (or Python AST objects) rather than Hy
 model trees. These macros serve the role of special forms in other

--- a/hy/errors.py
+++ b/hy/errors.py
@@ -1,6 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
 import os
 import re
 import sys

--- a/hy/errors.py
+++ b/hy/errors.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # Copyright 2021 the authors.
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.

--- a/hy/extra/anaphoric.hy
+++ b/hy/extra/anaphoric.hy
@@ -1,7 +1,4 @@
 ;;; Hy anaphoric macros
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 ".. versionadded:: 0.9.12
 
 The anaphoric macros module makes functional programming in Hy very

--- a/hy/extra/reserved.hy
+++ b/hy/extra/reserved.hy
@@ -1,7 +1,4 @@
 ;;; Get a frozenset of Hy reserved words
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 
 (import sys keyword)
 

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import sys
 import os
 import inspect

--- a/hy/lex/__init__.py
+++ b/hy/lex/__init__.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import keyword
 import re
 import sys

--- a/hy/lex/exceptions.py
+++ b/hy/lex/exceptions.py
@@ -1,6 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
 from hy.errors import HySyntaxError
 
 

--- a/hy/lex/lexer.py
+++ b/hy/lex/lexer.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 from rply import LexerGenerator
 
 

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import re
 from functools import wraps
 

--- a/hy/lex/parser.py
+++ b/hy/lex/parser.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # Copyright 2021 the authors.
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -1,6 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
 import sys
 import builtins
 import importlib

--- a/hy/model_patterns.py
+++ b/hy/model_patterns.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 "Parser combinators for pattern-matching Hy model trees."
 
 from hy.models import Expression, Symbol, Keyword, String, List, Dict, Integer, Float, Complex, Bytes

--- a/hy/models.py
+++ b/hy/models.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 from contextlib import contextmanager
 import re
 from math import isnan, isinf

--- a/hy/pyops.hy
+++ b/hy/pyops.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 "Python provides various :ref:`binary and unary operators
 <py:expressions>`. These are usually invoked in Hy using core macros of
 the same name: for example, ``(+ 1 2)`` calls the core macro named

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
 
 import glob
 import importlib

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # Copyright 2021 the authors.
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 from hy.compiler import hy_compile, hy_eval
 from hy.errors import HyLanguageError, HyError
 from hy.lex import hy_parse

--- a/tests/compilers/test_compiler.py
+++ b/tests/compilers/test_compiler.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import ast
 
 from hy import compiler

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import os
 import sys
 import ast

--- a/tests/importer/test_pyc.py
+++ b/tests/importer/test_pyc.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import os
 import importlib.util
 import py_compile

--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 from hy.macros import macro, macroexpand, macroexpand_1
 from hy.lex import tokenize
 

--- a/tests/native_tests/contrib/destructure.hy
+++ b/tests/native_tests/contrib/destructure.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import pytest)
 (import collections.abc)
 (import itertools [cycle count islice])

--- a/tests/native_tests/contrib/loop.hy
+++ b/tests/native_tests/contrib/loop.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (require hy.contrib.loop [loop])
 (import sys)
 

--- a/tests/native_tests/contrib/sequences.hy
+++ b/tests/native_tests/contrib/sequences.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (require hy.contrib.sequences [seq defseq])
 
 (import

--- a/tests/native_tests/contrib/walk.hy
+++ b/tests/native_tests/contrib/walk.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import hy.contrib.walk *)
 (require hy.contrib.walk *)
 

--- a/tests/native_tests/core.hy
+++ b/tests/native_tests/core.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import
   itertools [repeat cycle islice]
   pytest)

--- a/tests/native_tests/defclass.hy
+++ b/tests/native_tests/defclass.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (defn test-defclass []
   (defclass A)
   (assert (isinstance (A) A)))

--- a/tests/native_tests/extra/anaphoric.hy
+++ b/tests/native_tests/extra/anaphoric.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import  hy.errors [HyMacroExpansionError]  hy.pyops *)
 (require hy.extra.anaphoric *)
 

--- a/tests/native_tests/extra/anaphoric_single.hy
+++ b/tests/native_tests/extra/anaphoric_single.hy
@@ -1,7 +1,3 @@
-;; Copyright 2019 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (require hy.extra.anaphoric [ap-last])
 
 (defn test-anaphoric-single-require []

--- a/tests/native_tests/extra/reserved.hy
+++ b/tests/native_tests/extra/reserved.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import hy.extra.reserved [macros names])
 
 (defn test-reserved-macros []

--- a/tests/native_tests/hy_repr.hy
+++ b/tests/native_tests/hy_repr.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import
   hy._compat [PY3_7]
   math [isnan])

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import tests.resources [kwtest function-with-a-dash AsyncWithTest]
         os.path [exists isdir isfile]
         os

--- a/tests/native_tests/mangling.hy
+++ b/tests/native_tests/mangling.hy
@@ -1,8 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
-
 (defn test-hyphen []
   (setv a-b 1)
   (assert (= a-b 1))

--- a/tests/native_tests/model_patterns.hy
+++ b/tests/native_tests/model_patterns.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (defmacro do-until [#* args]
   (import
     hy.model-patterns [whole FORM notpexpr dolike]

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import os sys
         importlib
         pytest

--- a/tests/native_tests/operators.hy
+++ b/tests/native_tests/operators.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import pytest)
 (import hy.pyops *)
 

--- a/tests/native_tests/py3_8_only_tests.hy
+++ b/tests/native_tests/py3_8_only_tests.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 ;; Tests where the emitted code relies on Python ≥3.8.
 ;; conftest.py skips this file when running on Python <3.8.
 

--- a/tests/native_tests/quote.hy
+++ b/tests/native_tests/quote.hy
@@ -1,8 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
-
 (defn test-quote []
   (setv q (quote (a b c)))
   (assert (= (len q) 3))

--- a/tests/native_tests/sub_py3_7_only.hy
+++ b/tests/native_tests/sub_py3_7_only.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 ;; Tests where the emitted code relies on Python ≥3.8.
 ;; conftest.py skips this file when running on Python <3.8.
 

--- a/tests/native_tests/tag_macros.hy
+++ b/tests/native_tests/tag_macros.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import pytest
         functools [wraps])
 

--- a/tests/native_tests/with_decorator.hy
+++ b/tests/native_tests/with_decorator.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (defn test-decorated-1line-function []
   (defn foodec [func]
     (fn [] (+ (func) 1)))

--- a/tests/native_tests/with_test.hy
+++ b/tests/native_tests/with_test.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 (import pytest)
 
 (defclass WithTest [object]

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,8 +1,3 @@
-# Copyright 2020 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
-
 def kwtest(*args, **kwargs):
     return kwargs
 

--- a/tests/resources/argparse_ex.hy
+++ b/tests/resources/argparse_ex.hy
@@ -1,7 +1,4 @@
 #!/usr/bin/env hy
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
 
 (import sys)
 (import argparse)

--- a/tests/resources/pydemo.hy
+++ b/tests/resources/pydemo.hy
@@ -1,7 +1,3 @@
-;; Copyright 2021 the authors.
-;; This file is part of Hy, which is free software licensed under the Expat
-;; license. See the LICENSE.
-
 ;; This Hy module is intended to concisely demonstrate all of
 ;; Python's major syntactic features for the purpose of testing hy2py.
 "This is a module docstring."

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
 
 import os
 import re

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 # Copyright 2021 the authors.
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.

--- a/tests/test_hy2py.py
+++ b/tests/test_hy2py.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # Copyright 2021 the authors.
 # This file is part of Hy, which is free software licensed under the Expat
 # license. See the LICENSE.

--- a/tests/test_hy2py.py
+++ b/tests/test_hy2py.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import math, itertools, asyncio
 from hy import mangle
 import hy.importer

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -1,6 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
 import sys
 import traceback
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,3 @@
-# Copyright 2021 the authors.
-# This file is part of Hy, which is free software licensed under the Expat
-# license. See the LICENSE.
-
 import copy
 import pytest
 import hy


### PR DESCRIPTION
In the spirit of continuing to shake off status-quo bias, here's another attempt at #1260.

I can't imagine a situation in which a court would allow a license violation because the individual files didn't have license headers, even though the repository has a license file in the usual place and the license is tagged in `setup.py`, GitHub, and PyPI. License headers are just a holdover from the uncertain early days of GNU. They're noise at the top of every file and they create diff noise every year when they get updated. Now that I'm working on Hyrule, I'd like to get rid of these first so we don't have to deal with them in both repositories.