### PR TITLE
Feature/calls in dot forms

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,6 +18,10 @@ Bug Fixes
 * `let` should no longer re-evaluate default arguments.
 * Improved error messages for illegal uses of `finally` and `else`.
 
+New Features
+------------------------------
+* the attribute access macro `.` now accepts method calls.
+
 1.0a3 (released 2021-07-09)
 ==============================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,19 +88,19 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
    ::
 
-       (. foo bar baz [(+ 1 2)] frob)
+       (. foo (bar "qux")  baz [(+ 1 2)] frob)
 
    Compiles down to:
 
    .. code-block:: python
 
-       foo.bar.baz[1 + 2].frob
+       foo.bar("qux").baz[1 + 2].frob
 
    ``.`` compiles its first argument (in the example, *foo*) as the object on
    which to do the attribute dereference. It uses bare symbols as attributes
-   to access (in the example, *bar*, *baz*, *frob*), and compiles the contents
-   of lists (in the example, ``[(+ 1 2)]``) for indexation. Other arguments
-   raise a compilation error.
+   to access (in the example, *baz*, *frob*), Expressions as method calls (as in *bar*),
+   and compiles the contents of lists (in the example, ``[(+ 1 2)]``) for indexation.
+   Other arguments raise a compilation error.
 
    Access to unknown attributes raises an :exc:`AttributeError`. Access to
    unknown keys raises an :exc:`IndexError` (on lists and tuples) or a

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -4,6 +4,7 @@
 
 (import tests.resources [kwtest function-with-a-dash AsyncWithTest]
         os.path [exists isdir isfile]
+        os
         sys :as systest
         re
         operator [or_]
@@ -1528,6 +1529,9 @@ cee\"} dee" "ey bee\ncee dee"))
   (assert (is (. foo [(+ 1 1)] __class__) mycls))
   (assert (= (. foo [(+ 1 1)] __class__ __name__ [0]) "m"))
   (assert (= (. foo [(+ 1 1)] __class__ __name__ [1]) "y"))
+  (assert (= (. os (getcwd) (isalpha) __class__ __name__ [0]) "b"))
+  (assert (= (. "ab hello" (strip "ab ") (upper)) "HELLO"))
+  (assert (= (. "hElLO\twoRld" (expandtabs :tabsize 4) (lower)) "hello   world"))
 
   (setv bar (mycls))
   (setv (. foo [1]) bar)


### PR DESCRIPTION
closes #1108 

This allows expressions in the attribute access macro `.` that compile to method calls, such that the following is now possible

```clojure
=> (. os (getcwd) (isalpha) __class__ __name__ [0])
os.getcwd().isalpha().__class__.__name__[0]
'b'
=> (. "ab hello" (strip "ab ") (upper))
"ab hello".strip("ab ").upper()
"HELLO"
```