### PR TITLE
Fix: filter internal importlib frames from stacktrace

### DIFF
--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -1,9 +1,11 @@
 import sys
+import platform
 
 PY3_7 = sys.version_info >= (3, 7)
 PY3_8 = sys.version_info >= (3, 8)
 PY3_9 = sys.version_info >= (3, 9)
 PY3_10 = sys.version_info >= (3, 10)
+PYPY = platform.python_implementation() == "PyPy"
 
 
 if not PY3_9:

--- a/hy/errors.py
+++ b/hy/errors.py
@@ -8,6 +8,7 @@ from functools import reduce
 from colorama import Fore
 from contextlib import contextmanager
 from hy import _initialize_env_var
+from hy._compat import PYPY
 
 _hy_filter_internal_errors = _initialize_env_var('HY_FILTER_INTERNAL_ERRORS',
                                                  True)
@@ -237,6 +238,13 @@ _tb_hidden_modules = {m for m in map(_module_filter_name,
                                       'hy.core.result_macros',
                                       'rply'])
                       if m is not None}
+
+# We can't derive these easily from just their module names due
+# to missing magic attributes in internal importlib modules
+_tb_hidden_modules.update(
+    f"<builtin>/frozen {x}" if PYPY else f"<frozen {x}>"
+    for x in ("importlib._bootstrap", "importlib._bootstrap_external")
+)
 
 
 def hy_exc_filter(exc_type, exc_value, exc_traceback):

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -12,7 +12,7 @@ import pytest
 
 import hy
 from hy.lex import hy_parse
-from hy.errors import HyLanguageError
+from hy.errors import HyLanguageError, hy_exc_handler
 from hy.lex.exceptions import PrematureEndOfInput
 from hy.compiler import hy_eval, hy_compile
 from hy.importer import HyLoader
@@ -291,3 +291,18 @@ def test_hy_python_require():
     # https://github.com/hylang/hy/issues/1911
     test = "(do (require tests.resources.macros [test-macro]) (test-macro) blah)"
     assert hy.eval(hy.read_str(test)) == 1
+
+
+def test_filtered_importlib_frames(capsys):
+    path = os.getcwd() + "/tests/resources/importer/compiler_error.hy"
+    testLoader = HyLoader("tests.resources.importer.compiler_error", path)
+    spec = importlib.util.spec_from_loader(testLoader.name, testLoader)
+    mod = importlib.util.module_from_spec(spec)
+
+    with pytest.raises(PrematureEndOfInput) as execinfo:
+        testLoader.exec_module(mod)
+
+    hy_exc_handler(execinfo.type, execinfo.value, execinfo.tb)
+    captured_w_filtering = capsys.readouterr()[-1].strip()
+
+    assert "importlib._" not in captured_w_filtering

--- a/tests/resources/importer/compiler_error.hy
+++ b/tests/resources/importer/compiler_error.hy
@@ -1,0 +1,2 @@
+;; This should fail at compile time
+(print "hello)


### PR DESCRIPTION
closes #1693 

don't think this really merits a NEWS update. it doesn't affect users in any real way