### PR TITLE
remove just-in-time imports in top-level module

### DIFF
--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -15,42 +15,9 @@ hy.importer._inject_builtins()
 
 from fractions import Fraction as _Fraction  # For fraction literals
 
-# Import some names on demand so that the dependent modules don't have
-# to be loaded if they're not needed.
+from hy.compiler import hy_eval as eval
+from hy.lex import read, read_str, mangle, unmangle
+from hy.models import as_model
 
-_jit_imports = dict(
-    read = "hy.lex",
-    read_str = "hy.lex",
-    mangle = "hy.lex",
-    unmangle = "hy.lex",
-    eval = ["hy.compiler", "hy_eval"],
-    repr = ["hy.core.hy_repr", "hy_repr"],
-    repr_register = ["hy.core.hy_repr", "hy_repr_register"],
-    gensym = "hy.core.language",
-    macroexpand = "hy.core.language",
-    macroexpand_1 = "hy.core.language",
-    disassemble = "hy.core.language",
-    as_model = "hy.models")
-
-def __getattr__(k):
-    if k == 'pyops':
-        global pyops
-        import hy.pyops
-        pyops = hy.pyops
-        return pyops
-
-    if k not in _jit_imports:
-        raise AttributeError(f'module {__name__!r} has no attribute {k!r}')
-    v = _jit_imports[k]
-    module, original_name = v if isinstance(v, list) else (v, k)
-    import importlib
-    globals()[k] = getattr(
-        importlib.import_module(module), original_name)
-    return globals()[k]
-
-import hy._compat
-if not hy._compat.PY3_7:
-    # `__getattr__` isn't supported, so we'll just import everything
-    # now.
-    for k in _jit_imports:
-        __getattr__(k)
+from hy.core.hy_repr import hy_repr as repr, hy_repr_register as repr_register
+from hy.core.language import gensym, macroexpand, macroexpand_1, disassemble


### PR DESCRIPTION
```python
import sys, hy

for module in sys.modules:
    if module.startswith('hy'):
        print(module)
```

```
hy.version
hy.lex.exceptions
hy.core
hy.errors
hy.models
hy.model_patterns
hy.lex
hy._compat
hy.macros
hy.compiler
hy.importer
hy.lex.lexer
hy.lex.parser
hy.core.result_macros
hy.core.macros
hy.core.language
hy
```

Everything except `hy.core.hy_repr` already gets imported (likely due to `hy.importer`), so the just-in-time machinery seems unnecessary.
