### PR TITLE
Detecting cycles in `as_model` from `hy/models.py`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -106,3 +106,4 @@
 * Peter Andreev <appa@gmx.co.uk>
 * Sunjay Cauligi <scauligi@eng.ucsd.edu>
 * David Tscheppen <david.tscheppen@gmail.com>
+* Dmitry Ivanov <dmitry.ivanov@divanov.eu>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -41,6 +41,7 @@ New Features
 ------------------------------
 * `hy.repr` now supports several more standard types.
 * the attribute access macro `.` now accepts method calls.
+* `as_model` checks for self-references in its argument.
 
 .. _Hyrule: https://github.com/hylang/hyrule
 


### PR DESCRIPTION
Closes #2153.

In relation to `List`s and `Dictionaries`, this edit tracks parents of the elements to raise a `HyWrapperError` instead of relying Python being incapable of infinite recursion for recursive models.

This is done by passing an array of already seen parents for each recursive transformation in a List or a Dict.

Mysteriously, this breaks `tests/importer/test_importer.py::test_import_error_cleanup` as the imported module raises a `NameError` and not a `HyMacroExpansionError`.