### PR TITLE
Upgrade to funcparserlib 1.0.0a0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,3 +107,4 @@
 * Sunjay Cauligi <scauligi@eng.ucsd.edu>
 * David Tscheppen <david.tscheppen@gmail.com>
 * Dmitry Ivanov <dmitry.ivanov@divanov.eu>
+* Andrey Vlasovskikh <andrey.vlasovskikh@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     version=__version__,
     install_requires=[
         'rply>=0.7.7',
-        'funcparserlib>=0.3.6',
+        'funcparserlib>=1.0.0a0',
         'colorama',
         'astor>=0.8 ; python_version < "3.9"',
     ],


### PR DESCRIPTION
**Update:** I've created a new PR from a separate branch, as requested in #2163, and added an entry into AUTHORS. In the first PR I occasionally skipped these steps after my first quick look at CONTRIBUTING.rst.

Although I intended to make funcparserlib 1.0.0a0 backwards-compatible with 0.3.6, there is one incompatibility detected by the Hy tests, so I had to update `importlike(...)` to account for these changes.

`p1 + maybe(skip(p2))` no longer returns the result of `p1` if `p2` matches its tokens, so `skip(...)` it not distributive. The funcparserlib docs for 0.3.6 mentioned that you can use skip() **only** in `+`-expressions, but there is no enforcement for that. The current behaviour of `p1 + maybe(skip(p2))` is `(<the parse result of p1>, _Ignored(<the parse result of p2>))`.