### PR TITLE
Fix: bump sphinx version to >=4.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ tox
 
 # documentation
 Pygments >= 1.6
-Sphinx==3.5.4
+Sphinx>=4.2.0
 sphinx_rtd_theme
 git+https://github.com/hylang/sphinxcontrib-hydomain.git


### PR DESCRIPTION
I think i fixed the hydomain dependency issues to allow us to merge #2174 , but i also had to update sphinx in hydomain to the latest version in the process which breaks `pip install -r requirements-dev.txt`. this bumps it and loosens the exact version requirements a bit. 