### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         name-prefix: ['']
         os: [ubuntu-latest]
-        python: [3.6, 3.7, 3.8, 3.9, '3.10', pypy-3.7]
+        python: [3.7, 3.8, 3.9, '3.10', pypy-3.7]
         include:
           # To keep the overall number of runs low, we test Windows
           # only on the latest CPython.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,6 +3,10 @@
 Unreleased
 ==============================
 
+Removals
+------------------------------
+* Python 3.6 is no longer supported.
+
 Other Breaking Changes
 ------------------------------
 * `import` and `require` no longer need outer brackets.

--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -47,10 +47,3 @@ def __getattr__(k):
     globals()[k] = getattr(
         importlib.import_module(module), original_name)
     return globals()[k]
-
-import hy._compat
-if not hy._compat.PY3_7:
-    # `__getattr__` isn't supported, so we'll just import everything
-    # now.
-    for k in _jit_imports:
-        __getattr__(k)

--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -1,7 +1,6 @@
 import sys
 import platform
 
-PY3_7 = sys.version_info >= (3, 7)
 PY3_8 = sys.version_info >= (3, 8)
 PY3_9 = sys.version_info >= (3, 9)
 PY3_10 = sys.version_info >= (3, 10)
@@ -33,11 +32,3 @@ else:
         return type(code_obj)(*(
             kwargs.get(k, getattr(code_obj, k))
             for k in _code_args))
-
-
-if not PY3_7:
-    # Shim `asyncio.run`.
-    import asyncio
-    def f(coro):
-        return asyncio.get_event_loop().run_until_complete(coro)
-    asyncio.run = f

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'colorama',
         'astor>=0.8 ; python_version < "3.9"',
     ],
+    python_requires = '>= 3.7, <= 3.10',
     entry_points={
         'console_scripts': [
             'hy = hy.cmdline:hy_main',

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         "Programming Language :: Lisp",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tests/native_tests/hy_repr.hy
+++ b/tests/native_tests/hy_repr.hy
@@ -1,5 +1,4 @@
 (import
-  hy._compat [PY3_7]
   math [isnan])
 
 (defn test-hy-repr-roundtrip-from-str []
@@ -112,9 +111,7 @@
   (import re)
   (setv mo (re.search "b+" "aaaabbbccc"))
   (assert (= (hy.repr mo)
-    (.format
-      #[[<{} object; :span (, 4 7) :match "bbb">]]
-      (if PY3_7 "re.Match" (+ (. (type mo) __module__) ".SRE_Match"))))))
+    #[[<re.Match object; :span (, 4 7) :match "bbb">]])))
 
 (defn test-hy-repr-custom []
 

--- a/tests/native_tests/sub_py3_7_only.hy
+++ b/tests/native_tests/sub_py3_7_only.hy
@@ -1,5 +1,5 @@
-;; Tests where the emitted code relies on Python ≥3.8.
-;; conftest.py skips this file when running on Python <3.8.
+;; Tests where the emitted code relies on Python ≤3.7.
+;; conftest.py skips this file when running on Python ≥3.8.
 
 (import pytest)
 


### PR DESCRIPTION
[Python 3.6 reaches its end-of-life on December 23rd.](https://devguide.python.org/#status-of-python-branches) So, removing support is appropriate for a release in January or the last few days of the year.