### PR TITLE
Add "import os" in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+
 from setuptools import find_packages, setup
 import fastentrypoints   # Monkey-patches setuptools.
 


### PR DESCRIPTION
When adding `hy` as a `git` depedency with Poetry, it tries to read `setup.py` and crashes because `os` is not imported