### PR TITLE
`hy2py` recursive

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -823,9 +823,9 @@ def hy2py_module(options):
         with out_file.open('w') as f:
             f.write(compiled)
 
-    if options.copy_py:
-        for file in options.MODULE.rglob('*.py'):
-            if not file.is_file():
+    if options.copy:
+        for file in options.MODULE.rglob('*'):
+            if not file.is_file() or file.suffix == '.hy':
                 continue
 
             relative = file.relative_to(options.MODULE)
@@ -833,8 +833,8 @@ def hy2py_module(options):
             out_file.parent.mkdir(parents=True, exist_ok=True)
 
             print(f'copying {relative}')
-            with file.open('r', encoding='utf-8') as in_f:
-                with out_file.open('w') as out_f:
+            with file.open('rb') as in_f:
+                with out_file.open('wb') as out_f:
                     out_f.write(in_f.read())
 
 
@@ -870,8 +870,8 @@ def hy2py_main():
                                help="Path to module directory")
     module_parser.add_argument("OUT_DIR", type=Path,
                                help="Output directory for compiled files")
-    module_parser.add_argument("--copy-py", "-c", action="store_true",
-                               help="copy python files to OUT_DIR")
+    module_parser.add_argument("--copy", "-c", action="store_true",
+                               help="copy non hy files to OUT_DIR")
     module_parser.set_defaults(func=hy2py_module)
 
     options = parser.parse_args(sys.argv[1:])

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -742,6 +742,7 @@ def hy2py_file(options):
             return 1
 
         else:
+            filename = str(options.FILE)
             if options.as_module:
                 module_parts = len(options.as_module.split('.'))
                 module_dir = str(reduce(truediv,
@@ -758,7 +759,6 @@ def hy2py_file(options):
             else:
                 set_path(filename)
 
-            filename = str(options.FILE)
             with options.FILE.open('r', encoding='utf-8') as source_file:
                 source = source_file.read()
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -430,7 +430,7 @@ def test_bin_hyc_file_sys_path():
     test_file = 'tests/resources/relative_import_compile_time.hy'
     file_relative_path = os.path.realpath(os.path.dirname(test_file))
 
-    for binary in ("hy", "hyc", "hy2py"):
+    for binary in ("hy", "hyc", "hy2py file"):
         # Ensure we hit the compiler
         rm(cache_from_source(test_file))
         assert not os.path.exists(cache_from_source(file_relative_path))

--- a/tests/test_hy2py.py
+++ b/tests/test_hy2py.py
@@ -13,7 +13,7 @@ def test_hy2py_import(tmpdir):
     path = tmpdir.join("pydemo.py")
     with open(path, "wb") as o:
         subprocess.check_call(
-            ["hy2py", "tests/resources/pydemo.hy"],
+            ["hy2py", "file", "tests/resources/pydemo.hy"],
             stdout = o,
             env = {**os.environ, 'PYTHONIOENCODING': 'UTF-8'})
     assert_stuff(hy.importer._import_from_path("pydemo", path))


### PR DESCRIPTION
add sub commands:
* `file` - to compile single file
* `module` - to compile module directory

---
compiling module
```sh
hy2py module my_module compiled/my_module
```

---
add `--as-module` flag to `file` sub command to compile file as part of module (related to  #2204)

for example:
```sh
mkdir my_module
touch 'my_module/__init__.py'
echo '(setv foo 1)' > my_module/macros.hy
echo '(require .macros *)' > my_module/args.hy
hy2py file --as-module my_module.args my_module/args.hy
```

---
fixes: #2079