### PR TITLE
Documentation tweaks

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,8 +53,6 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
    - The annotation always comes (and is evaluated) *before* the value being annotated. This is
      unlike Python, where it comes and is evaluated *after* the value being annotated.
 
-   Note that variable annotations are only supported on Python 3.6+.
-
    For annotating items with generic types, the :hy:func:`of <hyrule.misc.of>`
    macro will likely be of use.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -390,19 +390,20 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
 .. hy:function:: break
 
-   ``break`` is used to break out from a loop. It terminates the loop immediately.
-   The following example has an infinite ``while`` loop that is terminated as soon
-   as the user enters *k*.
+   ``break`` compiles to a :py:keyword:`break` statement, which terminates the
+   enclosing loop. The following example has an infinite ``while`` loop that
+   ends when the user enters "k"::
 
-   :strong:`Examples`
+       (while True
+         (if (= (input "> ") "k")
+           (break)
+           (print "Try again")))
 
-   ::
-
-     => (while True
-     ...   (if (= "k" (input "? "))
-     ...       (break)
-     ...       (print "Try again")))
-
+   In a loop with multiple iteration clauses, such as ``(for [x xs y ys] …)``,
+   ``break`` only breaks out of the innermost iteration, not the whole form. To
+   jump out of the whole form, enclose it in a :hy:func:`block
+   <hyrule.control.block>` and use ``block-ret`` instead of ``break``, or
+   enclose it in a function and use :hy:func:`return`.
 
 .. hy:function:: (chainc [#* args])
 
@@ -436,21 +437,26 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
 .. hy:function:: continue
 
-   ``continue`` returns execution to the start of a loop. In the following example,
-   ``(side-effect1)`` is called for each iteration. ``(side-effect2)``, however,
-   is only called on every other value in the list.
-
-   :strong:`Examples`
+   ``continue`` compiles to a :py:keyword:`continue` statement, which returns
+   execution to the start of a loop. In the following example, ``(.append
+   output x)`` is executed on each iteration, whereas ``(.append evens x)`` is
+   only executed for even numbers.
 
    ::
 
-       => ;; assuming that (side-effect1) and (side-effect2) are functions and
-       => ;; collection is a list of numerical values
-       => (for [x collection]
-       ...   (side-effect1 x)
-       ...   (if (% x 2)
-       ...     (continue))
-       ...   (side-effect2))
+       (setv  output []  evens [])
+       (for [x (range 10)]
+         (.append output x)
+         (when (% x 2)
+           (continue))
+         (.append evens x))
+
+   In a loop with multiple iteration clauses, such as ``(for [x xs y ys] …)``,
+   ``continue`` applies to the innermost iteration, not the whole form. To jump
+   to the next step of an outer iteration, try rewriting your loop as multiple
+   nested loops and interposing a :hy:func:`block <hyrule.control.block>`, as
+   in ``(for [x xs] (block (for [y ys] …)))``. You can then use ``block-ret``
+   in place of ``continue``.
 
 .. hy:function:: (do [#* body])
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -55,7 +55,8 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
    Note that variable annotations are only supported on Python 3.6+.
 
-   For annotating items with generic types, the :hy:func:`of <hy.core.macros.of>` macro will likely be of use.
+   For annotating items with generic types, the :hy:func:`of <hyrule.misc.of>`
+   macro will likely be of use.
 
    .. note::
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -490,7 +490,7 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
        3
 
    In its square-bracketed first argument, ``for`` allows the same types of
-   clauses as :hy:function:`lfor`.
+   clauses as :hy:func:`lfor`.
 
    ::
 
@@ -579,7 +579,7 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
    multiple *index* or *key* values are provided, they are used to access
    successive elements in a nested structure. Example usage:
 
-   :string:`Examples`
+   :strong:`Examples`
 
    ::
 
@@ -682,7 +682,7 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
 .. hy:function:: (lfor [binding iterable #* body])
 
-   The comprehension forms ``lfor``, :hy:function:`sfor`, :hy:func:`dfor`, :hy:func:`gfor`, and :hy:func:`for`
+   The comprehension forms ``lfor``, :hy:func:`sfor`, :hy:func:`dfor`, :hy:func:`gfor`, and :hy:func:`for`
    are used to produce various kinds of loops, including Python-style
    :ref:`comprehensions <py:comprehensions>`. ``lfor`` in particular
    creates a list comprehension. A simple use of ``lfor`` is::

--- a/docs/cheatsheet.json
+++ b/docs/cheatsheet.json
@@ -104,49 +104,49 @@
       {
         "name": "Arithmetic",
         "methods": [
-          "hy.core.shadow.@",
-          "hy.core.shadow.%",
-          "hy.core.shadow.+",
-          "hy.core.shadow.-",
-          "hy.core.shadow.*",
-          "hy.core.shadow.**",
-          "hy.core.shadow./",
-          "hy.core.shadow.//"
+          "hy.pyops.@",
+          "hy.pyops.%",
+          "hy.pyops.+",
+          "hy.pyops.-",
+          "hy.pyops.*",
+          "hy.pyops.**",
+          "hy.pyops./",
+          "hy.pyops.//"
         ]
       },
       {
         "name": "Comparison",
         "methods": [
           "hy.core.macros.cond",
-          "hy.core.shadow.<",
-          "hy.core.shadow.>",
-          "hy.core.shadow.<=",
-          "hy.core.shadow.>=",
-          "hy.core.shadow.=",
-          "hy.core.shadow.\\!=",
-          "hy.core.shadow.is",
-          "hy.core.shadow.not?",
-          "hy.core.shadow.in",
-          "hy.core.shadow.not-in"
+          "hy.pyops.<",
+          "hy.pyops.>",
+          "hy.pyops.<=",
+          "hy.pyops.>=",
+          "hy.pyops.=",
+          "hy.pyops.\\!=",
+          "hy.pyops.is",
+          "hy.pyops.not?",
+          "hy.pyops.in",
+          "hy.pyops.not-in"
         ]
       },
       {
         "name": "Bitwise",
         "methods": [
-          "hy.core.shadow.\\<\\<",
-          "hy.core.shadow.>>",
-          "hy.core.shadow.&",
-          "hy.core.shadow.|",
-          "hy.core.shadow.^",
-          "hy.core.shadow.~"
+          "hy.pyops.\\<\\<",
+          "hy.pyops.>>",
+          "hy.pyops.&",
+          "hy.pyops.|",
+          "hy.pyops.^",
+          "hy.pyops.~"
         ]
       },
       {
         "name": "Logic",
         "methods": [
-          "hy.core.shadow.not",
-          "hy.core.shadow.and",
-          "hy.core.shadow.or"
+          "hy.pyops.not",
+          "hy.pyops.and",
+          "hy.pyops.or"
         ]
       }
     ]

--- a/docs/language/internals.rst
+++ b/docs/language/internals.rst
@@ -225,7 +225,7 @@ such an occasion. A much better version of ``nif`` would be::
               [(< ~g 0) ~neg-form])))
 
 This is an easy case, since there is only one symbol. But if there is
-a need for several gensym's there is a second macro :hy:func:`with-gensyms <hyrule.with-gensyms>` that
+a need for several gensym's there is a second macro :hy:func:`with-gensyms <hyrule.macrotools.with-gensyms>` that
 basically expands to a ``setv`` form::
 
    (with-gensyms [a b c]
@@ -249,7 +249,7 @@ so our re-written ``nif`` would look like::
                 [(= ~g 0) ~zero-form]
                 [(< ~g 0) ~neg-form]))))
 
-Finally, though we can make a new macro that does all this for us. :hy:func:`defmacro/g! <hyrule.defmacro/g!>`
+Finally, though we can make a new macro that does all this for us. :hy:func:`defmacro/g! <hyrule.macrotools.defmacro/g!>`
 will take all symbols that begin with ``g!`` and automatically call ``gensym`` with the
 remainder of the symbol. So ``g!a`` would become ``(hy.gensym "a")``.
 

--- a/docs/language/repl.rst
+++ b/docs/language/repl.rst
@@ -104,10 +104,11 @@ prompts. The following shows a number of possibilities::
     re
     json
     pathlib [Path]
+    hy.pypos *
     hyrule [pp pformat])
 
   (require
-    hyrule [%])
+    hyrule [unless])
 
   (setv
     ;; Spy and output-fn will be set automatically for all hy repls

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -333,7 +333,7 @@ which imports the module and makes macros available at compile-time.
 Hyrule
 ======
 
-`Hyrule <https://github.com/hylang/hyrule>`_ is Hy's standard utility library.
+`Hyrule <https://pypi.org/project/hyrule>`_ is Hy's standard utility library.
 It provides a variety of functions and macros that are useful for writing Hy
 programs. ::
 

--- a/hy/core/util.hy
+++ b/hy/core/util.hy
@@ -42,7 +42,9 @@
 (setv _gensym_lock (Lock))
 
 (defn gensym [[g "G"]]
-  "Generate a unique symbol for use in macros without accidental name clashes.
+  #[[Generate a symbol with a unique name. The argument will be included in the
+  generated symbol, as an aid to debugging. Typically one calls ``hy.gensym``
+  without an argument.
 
   .. versionadded:: 0.9.12
 
@@ -50,18 +52,23 @@
 
      Section :ref:`using-gensym`
 
-  Examples:
-    ::
+  The below example uses the return value of ``f`` twice but calls it only
+  once, and uses ``hy.gensym`` for the temporary variable to avoid collisions
+  with any other variable names.
 
-      => (hy.gensym)
-      '_G￿1
+  ::
 
-    ::
+      (defmacro selfadd [x]
+        (setv g (hy.gensym))
+        `(do
+           (setv ~g ~x)
+           (+ ~g ~g)))
 
-      => (hy.gensym \"x\")
-      '_x￿2
+      (defn f []
+        (print "This is only executed once.")
+        4)
 
-   "
+      (print (selfadd (f)))]]
   (setv new_symbol None)
   (global _gensym_counter)
   (global _gensym_lock)

--- a/tests/native_tests/comprehensions.hy
+++ b/tests/native_tests/comprehensions.hy
@@ -221,6 +221,25 @@
   (assert (= l ["a" "a" "a" "z"])))
 
 
+(defn test-multidimensional-for-break-continue []
+  "`break` and `continue` only affect the innermost generated loop."
+
+  (setv out "")
+  (for [x "abc"  y "123"]
+    (+= out x y)
+    (when (= (+ x y) "b2")
+      (break)))
+  (assert (= out "a1a2a3b1b2c1c2c3"))
+
+  (setv out "")
+  (for [c "xyz"  d "12"]
+    (+= out c d)
+    (when (= (+ c d) "y1")
+      (continue))
+    (+= out "-"))
+  (assert (= out "x1-x2-y1y2-z1-z2-")))
+
+
 (defmacro eval-isolated [#*body]
   `(hy.eval '(do ~@body) :module "<test>" :locals {}))
 


### PR DESCRIPTION
Closes #2194.

All of this is documentation edits, except for one commit that adds new tests to match new statements about `break` and `continue` in the documentation.