### PR TITLE
Docs: Add stable branch warning header for active alpha cycle

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,15 @@
+{% extends "!layout.html" %}
+
+{% block extrabody %}
+{% if has_active_alpha %}
+<div class="wy-nav-content-wrap">
+    <div id="dev-warning" class="wy-nav-content" style="overflow-wrap: breakword; padding: 1em 1em 0.1em 1em; background: #ffe761;">
+        <p>
+            Hy is currently in an active alpha cycle. Make sure you're looking
+            at the correct version of the documentation for your install by
+            using the version selector in the bottom-left corner of this page.
+        </p>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,9 @@ html_use_smartypants = False
 html_show_sphinx = False
 
 html_context = dict(
-    hy_descriptive_version = hy_descriptive_version)
+    hy_descriptive_version = hy_descriptive_version,
+    has_active_alpha = True,
+)
 
 highlight_language = 'clojure'
 


### PR DESCRIPTION
closes #2219 

Adds `has_active_alpha` bool we can toggle off when we're not in an alpha cycle and don't need the warning