### PR TITLE
Fix: crash when using keywords as match value

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,8 +9,13 @@ Bug Fixes
   CPython bug regarding the standard module `curses` (`bpo-2675`_).
 * Elements of `builtins` such as `help` are no longer overridden until
   the Hy REPL actually starts.
+* Crash when using Keywords as `match` value.
 
 .. _bpo-2675: https://bugs.python.org/issue2675#msg265564
+
+New Features
+------------------------------
+* new function `hy.model_patterns.parse_if`
 
 1.0a4 (released 2022-01-09)
 ==============================

--- a/hy/model_patterns.py
+++ b/hy/model_patterns.py
@@ -137,3 +137,17 @@ def tag(tag_name, parser):
     with `tag` set to the given tag name and `value` set to the parser's
     value."""
     return parser >> (lambda x: Tag(tag_name, x))
+
+
+def parse_if(pred, parser):
+    """
+    Return a parser that parses a token with `parser` if it satisfies the
+    predicate `pred`.
+    """
+
+    @Parser
+    def _parse_if(tokens, s):
+        some(pred).run(tokens, s)
+        return parser.run(tokens, s)
+
+    return _parse_if

--- a/hy/models.py
+++ b/hy/models.py
@@ -235,6 +235,7 @@ class Keyword(Object):
     """Generic Hy Keyword object."""
 
     __slots__ = ["name"]
+    __match_args__ = ("name",)
 
     def __init__(self, value, from_parser=False):
         value = str(value)

--- a/tests/native_tests/py3_10_only_tests.hy
+++ b/tests/native_tests/py3_10_only_tests.hy
@@ -37,6 +37,9 @@
   (assert (= [0 1] (match [0 1 2] [#* x 2] x)))
   (assert (= 5 (match {"hello" 5} {"hello" x} x)))
   (assert (= :as (match 1 1 :if True ':as)))
+  (assert (= :as (match :hello
+                        :hello ':as
+                        any-binding :not-found)))
   (assert (is (match {}
                      {0 [1 2 {}]} 0
                      {0 [1 2 {}] 1 [[]]} 1


### PR DESCRIPTION
Something i noticed fiddling around today. 

Hy would crash when trying to pattern match against keywords

```clojure
(match :hello
       :hello 1
       :world 2)
=> hy.errors.HySyntaxError: parse error for pattern macro 'match': got unexpected token: :hello, expected: end of file
```

Turns out I forgot that Keywords are compiled into a class instantiation calls not values and need to be handled as such.