### PR TITLE
Add `_hy_export_macros` and `export`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -36,6 +36,9 @@ New Features
   keyword arguments. Hy includes a workaround for a CPython bug that
   prevents the generation of legal Python code for these cases
   (`bpo-46520`_).
+* You can now set the variable `_hy_export_macros` to control what macros are
+  collected by `(require module *)`
+* New macro `export`
 * new function `hy.model_patterns.parse_if`
 
 .. _bpo-2675: https://bugs.python.org/issue2675#msg265564

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ import os
 import sys
 from functools import reduce
 from operator import or_
+from pathlib import Path
 
 import pytest
 
@@ -37,9 +38,4 @@ def pytest_collect_file(parent, path):
         and NATIVE_TESTS in path.dirname + os.sep
         and path.basename != "__init__.hy"
     ):
-
-        if hasattr(pytest.Module, "from_parent"):
-            pytest_mod = pytest.Module.from_parent(parent, fspath=path)
-        else:
-            pytest_mod = pytest.Module(path, parent)
-        return pytest_mod
+        return pytest.Module.from_parent(parent, path=Path(path))

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -597,36 +597,27 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
 .. hy:function:: (import [#* forms])
 
-   ``import`` is used to import modules, like in Python. There are several ways
-   that ``import`` can be used.
+   ``import`` compiles to an :py:keyword:`import` statement, which makes objects
+   in a different module available in the current module. Hy's syntax for the
+   various kinds of import looks like this::
 
-   :strong:`Examples`
-
-   ::
-
-       ;; Imports each of these modules
-       ;;
-       ;; Python:
-       ;; import sys
-       ;; import os.path
+       ;; Import each of these modules
+       ;; Python: import sys, os.path
        (import sys os.path)
 
-       ;; Import from a module
-       ;;
-       ;; Python: from os.path import exists, isdir, isfile
-       (import os.path [exists isdir isfile])
+       ;; Import several names from a single module
+       ;; Python: from os.path import exists, isdir as is_dir, isfile
+       (import os.path [exists  isdir :as dir?  isfile])
 
        ;; Import with an alias
-       ;;
        ;; Python: import sys as systest
        (import sys :as systest)
 
        ;; You can list as many imports as you like of different types.
-       ;;
        ;; Python:
-       ;; from tests.resources import kwtest, function_with_a_dash
-       ;; from os.path import exists, isdir as is_dir, isfile as is_file
-       ;; import sys as systest
+       ;;     from tests.resources import kwtest, function_with_a_dash
+       ;;     from os.path import exists, isdir as is_dir, isfile as is_file
+       ;;     import sys as systest
        (import tests.resources [kwtest function-with-a-dash]
                os.path [exists
                         isdir :as dir?
@@ -634,9 +625,13 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
                sys :as systest)
 
        ;; Import all module functions into current namespace
-       ;;
        ;; Python: from sys import *
        (import sys *)
+
+   ``__all__`` can be set to control what's imported by ``import *``, as in
+   Python, but beware that all names in ``__all__`` must be :ref:`mangled
+   <mangling>`. The macro :hy:func:`export <hy.core.macros.export>` is a handy
+   way to set ``__all__`` in a Hy program.
 
 .. hy:function:: (eval-and-compile [#* body])
 
@@ -1093,17 +1088,13 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
 .. hy:function:: (require [#* args])
 
-   ``require`` is used to import macros from one or more given modules. It allows
-   parameters in all the same formats as ``import``. The ``require`` form itself
-   produces no code in the final program: its effect is purely at compile-time, for
-   the benefit of macro expansion. Specifically, ``require`` imports each named
-   module and then makes each requested macro available in the current module.
+   ``require`` is used to get macros from one or more given modules. It allows
+   parameters in all the same formats as ``import``. ``require`` imports each
+   named module and then makes each requested macro available in the current
+   module.
 
-   The following are all equivalent ways to call a macro named ``foo`` in the module ``mymodule``:
-
-   :strong:`Examples`
-
-   ::
+   The following are all equivalent ways to call a macro named ``foo`` in the
+   module ``mymodule``::
 
        (require mymodule)
        (mymodule.foo 1)
@@ -1119,6 +1110,13 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
        (require mymodule [foo :as bar])
        (bar 1)
+
+   To define which macros are collected by ``(require mymodule *)``, set the
+   variable ``_hy_export_macros`` (analogous to Python's ``__all__``) to a list
+   of :ref:`mangled <mangling>` macro names, which is accomplished most
+   conveniently with :hy:func:`export <hy.core.macros.export>`. The default
+   behavior is to collect all macros other than those whose mangled names begin
+   with an ASCII underscore (``_``).
 
    :strong:`Macros that call macros`
 

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1680,7 +1680,7 @@ def compile_import_or_require(compiler, expr, root, entries):
     ret = Result()
 
     for entry in entries:
-        assignments = "ALL"
+        assignments = "EXPORTS"
         prefix = ""
 
         module, rest = entry
@@ -1702,10 +1702,10 @@ def compile_import_or_require(compiler, expr, root, entries):
         if root == "import":
             module_name = ast_module.lstrip(".")
             level = len(ast_module) - len(module_name)
-            if assignments == "ALL" and prefix == "":
+            if assignments == "EXPORTS" and prefix == "":
                 node = asty.ImportFrom
                 names = [asty.alias(module, name="*", asname=None)]
-            elif assignments == "ALL":
+            elif assignments == "EXPORTS":
                 compiler.scope.define(mangle(prefix))
                 node = asty.Import
                 names = [
@@ -1742,8 +1742,8 @@ def compile_import_or_require(compiler, expr, root, entries):
                         Symbol("None"),
                         Keyword("assignments"),
                         (
-                            String("ALL")
-                            if assignments == "ALL"
+                            String("EXPORTS")
+                            if assignments == "EXPORTS"
                             else [[String(k), String(v)] for k, v in assignments]
                         ),
                         Keyword("prefix"),

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -164,8 +164,7 @@ def require(source_module, target_module, assignments, prefix=""):
         package = None
         if source_module.startswith("."):
             source_dirs = source_module.split(".")
-            target_dirs = (getattr(target_module, "__name__", target_module)
-                .split("."))
+            target_dirs = getattr(target_module, "__name__", target_module).split(".")
             while len(source_dirs) > 1 and source_dirs[0] == "" and target_dirs:
                 source_dirs.pop(0)
                 target_dirs.pop()
@@ -176,8 +175,11 @@ def require(source_module, target_module, assignments, prefix=""):
             raise HyRequireError(e.args[0]).with_traceback(None)
 
     source_macros = source_module.__dict__.setdefault("__macros__", {})
-    source_exports = getattr(source_module, "_hy_export_macros",
-        [k for k in source_macros.keys() if not k.startswith('_')])
+    source_exports = getattr(
+        source_module,
+        "_hy_export_macros",
+        [k for k in source_macros.keys() if not k.startswith("_")],
+    )
 
     if not source_module.__macros__:
         if assignments in ("ALL", "EXPORTS"):
@@ -203,10 +205,15 @@ def require(source_module, target_module, assignments, prefix=""):
     if prefix:
         prefix += "."
 
-    for name, alias in (assignments if assignments not in ("ALL", "EXPORTS") else (
+    for name, alias in (
+        assignments
+        if assignments not in ("ALL", "EXPORTS")
+        else (
             (k, k)
             for k in source_macros.keys()
-            if assignments == "ALL" or k in source_exports)):
+            if assignments == "ALL" or k in source_exports
+        )
+    ):
         _name = mangle(name)
         alias = mangle(
             "#" + prefix + unmangle(alias)[1:]

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -163,9 +163,8 @@ def require(source_module, target_module, assignments, prefix=""):
         try:
             if source_module.startswith("."):
                 source_dirs = source_module.split(".")
-                target_dirs = getattr(target_module, "__name__", target_module).split(
-                    "."
-                )
+                target_dirs = (getattr(target_module, "__name__", target_module)
+                    .split("."))
                 while len(source_dirs) > 1 and source_dirs[0] == "" and target_dirs:
                     source_dirs.pop(0)
                     target_dirs.pop()

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1272,6 +1272,7 @@ cee\"} dee" "ey bee\ncee dee"))
   (assert (= x "KL"))
   (assert (= y 1)))
 
+
 (defn test-require []
   (with [(pytest.raises NameError)]
     (qplah 1 2 3 4))

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1354,6 +1354,19 @@ cee\"} dee" "ey bee\ncee dee"))
   (assert (in "lb.xyzzy" __macros__)))
 
 
+(defn test-export-objects []
+  ; We use `hy.eval` here because of a Python limitation that
+  ; importing `*` is only allowed at the module level.
+  (hy.eval '(do
+    (import tests.resources.exports *)
+    (assert (= (jan) 21))
+    (assert (= (♥) 23))
+    (with [(pytest.raises NameError)]
+      (wayne))
+    (import tests.resources.exports [wayne])
+    (assert (= (wayne) 22)))))
+
+
 (defn test-encoding-nightmares []
   (assert (= (len "ℵℵℵ♥♥♥\t♥♥\r\n") 11)))
 

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1317,12 +1317,19 @@ cee\"} dee" "ey bee\ncee dee"))
   (assert (= (✈ "silly") "plane silly"))
   (assert (= (hyx_XairplaneX "foolish") "plane foolish"))
 
-  (require tests.resources [tlib macros :as m])
+  (require tests.resources [tlib  macros :as m  exports-none])
   (assert (in "tlib.qplah" __macros__))
   (assert (in (hy.mangle "m.test-macro") __macros__))
+  (assert (in (hy.mangle "exports-none.cinco") __macros__))
   (require os [path])
   (with [(pytest.raises hy.errors.HyRequireError)]
-    (hy.eval '(require tests.resources [does-not-exist]))))
+    (hy.eval '(require tests.resources [does-not-exist])))
+
+  (require tests.resources.exports *)
+  (assert (= (casey 1 2 3) [11 1 2 3]))
+  (assert (= (☘ 1 2 3) [13 1 2 3]))
+  (with [(pytest.raises NameError)]
+    (brother 1 2 3 4)))
 
 
 (defn test-require-native []

--- a/tests/resources/exports.hy
+++ b/tests/resources/exports.hy
@@ -1,3 +1,12 @@
+(defn jan []
+  21)
+
+(defn wayne []
+  22)
+
+(defn ♥ []
+  23)
+
 (defmacro casey [#* tree]
   `[11 ~@tree])
 
@@ -7,4 +16,6 @@
 (defmacro ☘ [#* tree]
   `[13 ~@tree])
 
-(setv _hy_export_macros (tuple (map hy.mangle ["casey" "☘"])))
+(export
+  :objects [jan ♥]
+  :macros [casey ☘])

--- a/tests/resources/exports.hy
+++ b/tests/resources/exports.hy
@@ -1,0 +1,10 @@
+(defmacro casey [#* tree]
+  `[11 ~@tree])
+
+(defmacro brother [#* tree]
+  `[12 ~@tree])
+
+(defmacro ☘ [#* tree]
+  `[13 ~@tree])
+
+(setv _hy_export_macros (tuple (map hy.mangle ["casey" "☘"])))

--- a/tests/resources/exports_none.hy
+++ b/tests/resources/exports_none.hy
@@ -1,0 +1,5 @@
+(defmacro cinco [#* tree]
+  `[5 ~@tree])
+
+(setv _hy_export_macros [])
+  ; This should have no effect, because we never require `*` from this module.


### PR DESCRIPTION
- Closes #1934 
- Closes #2142

I thought `eval-and-compile` would be necessary for setting `_hy_export_macros`, but of course, by the time you're requiring a module, the whole thing has been executed.