### PR TITLE
Fix scoping in comprehensions in `let`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,6 +20,7 @@ Bug Fixes
 * Elements of `builtins` such as `help` are no longer overridden until
   the Hy REPL actually starts.
 * Crash when using Keywords as `match` value.
+* Fixed a scoping bug in comprehensions in `let` bodies.
 
 .. _bpo-2675: https://bugs.python.org/issue2675#msg265564
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -855,6 +855,12 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
    ``importlib.import_module``, ``fn``, or ``type`` (or whatever
    metaclass) instead.
 
+   If ``lfor``, ``sfor``, ``dfor``, or ``gfor`` (but not ``for``) is in
+   the body of a ``let``, assignments in iteration clauses and ``:setv``
+   clauses will create a new variable in the comprehenion form's own
+   scope, without touching any outer let-bound variable of the same
+   name.
+
    Like the ``let*`` of many other Lisps, ``let`` executes the variable
    assignments one-by-one, in the order written::
 

--- a/hy/scoping.py
+++ b/hy/scoping.py
@@ -357,6 +357,12 @@ class ScopeGen(ScopeFn):
             self.assignments.append(node)
         return node.node
 
+    @NodeRef.wrap
+    def access(self, node):
+        if not node.name in self.iterators:
+            self.seen.append(node)
+        return node.node
+
     def iterator(self, target):
         """
         Declare an iteration variable name for this scope; as in Python, the

--- a/tests/native_tests/comprehensions.hy
+++ b/tests/native_tests/comprehensions.hy
@@ -145,7 +145,26 @@
   ; An `sfor` that gets compiled to a real comprehension
   (setv x 0)
   (assert (= (sfor x [1 2 3] (+ x 1)) #{2 3 4}))
-  (assert (= x 0)))
+  (assert (= x 0))
+
+  (setv x 20)
+  (lfor n (range 10) (setv x n))
+  (assert (= x 9))
+
+  (lfor n (range 10) (setv y n))
+  (assert (= y 9))
+
+  (lfor n (range 0) (setv z n))
+  (with [(pytest.raises UnboundLocalError)]
+    z)
+
+  (defn foo []
+    (defclass Foo []
+      (lfor x (, 2) (setv z 3))
+      (with [(pytest.raises NameError)]
+        z))
+    (assert (not-in "z" (locals))))
+  (foo))
 
 
 (defn test-for-loop []

--- a/tests/native_tests/let.hy
+++ b/tests/native_tests/let.hy
@@ -93,27 +93,6 @@
     (assert (= x 99))))
 
 
-(defn test-generator-scope []
-  (setv x 20)
-  (lfor n (range 10) (setv x n))
-  (assert (= x 9))
-
-  (lfor n (range 10) (setv y n))
-  (assert (= y 9))
-
-  (lfor n (range 0) (setv z n))
-  (with [(pytest.raises UnboundLocalError)]
-    z)
-
-  (defn foo []
-    (defclass Foo []
-      (lfor x (, 2) (setv z 3))
-      (with [(pytest.raises NameError)]
-        z))
-    (assert (not-in "z" (locals))))
-  (foo))
-
-
 (defn test-let-quasiquote []
   (setv a-symbol 'a)
   (let [a "x"]

--- a/tests/native_tests/let.hy
+++ b/tests/native_tests/let.hy
@@ -93,6 +93,39 @@
     (assert (= x 99))))
 
 
+(defn test-let-comprehension-scope []
+  ; https://github.com/hylang/hy/issues/2224
+
+  (setv x 100)
+
+  (let [x 10]
+    (assert (=
+      (lfor  x (range 5)  :if (> x 1)  x)
+      [2 3 4]))
+    (assert (= x 10)))
+
+  (let [x 15]
+    (assert (=
+      (lfor  y (range 3)  :setv x (* y 2)  (+ y x))
+      [0 3 6]))
+    (assert (= x 15)))
+
+  (let [x 20]
+    (assert (=
+      (lfor  z "abc"  :do (setv x (.upper z))  (+ z x))
+      ["aA" "bB" "cC"]))
+    (assert (= x "C")))
+
+  (let [x 25
+        l []]
+    (for [x (range 5)  :if (> x 1)]
+      (.append l x))
+    (assert (= l [2 3 4]))
+    (assert (= x 4)))
+
+  (assert (= x 100)))
+
+
 (defn test-let-quasiquote []
   (setv a-symbol 'a)
   (let [a "x"]


### PR DESCRIPTION
- Fixes #2224.
- Replaces #2228.