### PR TITLE
delmacro and macro redefinition warning

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -72,6 +72,7 @@ New Features
 * new function `hy.model_patterns.parse_if`
 * Added a command-line option `-u` (or `--unbuffered`) per CPython.
 * new function `hy.model_patterns.in_tuple`
+* new core macro `delmacro` to delete user defined or require'd macros.
 
 .. _bpo-2675: https://bugs.python.org/issue2675#msg265564
 .. _bpo-46520: https://bugs.python.org/issue46520

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -161,6 +161,33 @@
         (lfor  x a  (hy.models.String x))
         (raise (TypeError "arguments must be keywords or lists of symbols"))))))))
 
+(defmacro delmacro
+  [#* names]
+  #[[Delete a macro(s) from the current module
+  ::
+
+     => (require a-module [some-macro])
+     => (some-macro)
+     1
+
+     => (delmacro some-macro)
+     => (some-macro)
+     Traceback (most recent call last):
+       File "<string>", line 1, in <module>
+         (some-macro)
+     NameError: name 'some_macro' is not defined
+
+     => (delmacro some-macro)
+     Traceback (most recent call last):
+       File "<string>", line 1, in <module>
+         (delmacro some-macro)
+     NameError: macro 'some-macro' is not defined
+  ]]
+  (let [sym (hy.gensym)]
+    `(eval-and-compile
+       (for [~sym ~(lfor name names (hy.mangle name))]
+         (when (in ~sym __macros__) (del (get __macros__ ~sym)))))))
+
 
 ;; Placeholder macros
 (for [s '[unquote unquote-splice unpack-mapping except finally else]]

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -357,3 +357,25 @@ in expansions."
                  (fn []))
                (wrap-error-test))))
   (assert (in "HyWrapperError" (str excinfo.value))))
+
+(defn test-delmacro
+  []
+  ;; test deletion of user defined macro
+  (defmacro delete-me [] "world")
+  (delmacro delete-me)
+  (with [exc (pytest.raises NameError)]
+    (delete-me))
+  ;; test deletion of required macros
+  (require tests.resources.tlib [qplah parald])
+  (assert (and (qplah 1) (parald 1)))
+
+  (delmacro qplah parald)
+  (with [exc (pytest.raises NameError)]
+    (hy.eval '(qplah)))
+  (with [exc (pytest.raises NameError)]
+    (hy.eval '(parald))))
+
+(defn test-macro-redefinition-warning
+  []
+  (with [(pytest.warns RuntimeWarning :match "require already refers to")]
+    (hy.eval '(defmacro require [] 1))))


### PR DESCRIPTION
closes #1689 

adds a `RuntimeWarning` when a user attempts to redefine a core macro and a new core macro `delmacro` a macro equivalent of `del` that deletes macros in the calling namespace. 

So the case of redefining `require` would look like:
```clojure
=> (require tests.resources.tlib [qplah])
hy.macros.require('tests.resources.tlib', None, assignments=[['qplah', 'qplah']], prefix='')
None
=> (defmacro require [] 1)
<string>:1: RuntimeWarning: require already refers to: `require` in module: `builtins`, being replaced by: `__console__.require`
  (defmacro require [] 1)
hy.macros.macro('require')(lambda hyx_XampersandXcompiler: 1)
None
=> (require)
1
1
=> (delmacro require)
None
=> (require tests.resources.tlib [parald])
hy.macros.require('tests.resources.tlib', None, assignments=[['parald', 'parald']], prefix='')
None
```