### PR TITLE
Allow `(require ... :readers *)`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1104,6 +1104,7 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
    Reader macros are required using ``:readers [...]``.
    The ``:macros`` kwarg can be optionally added for readability::
 
+       => (require mymodule :readers *)
        => (require mymodule :readers [!])
        => (require mymodule [foo] :readers [!])
        => (require mymodule :readers [!] [foo])
@@ -1139,6 +1140,9 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
    conveniently with :hy:func:`export <hy.core.macros.export>`. The default
    behavior is to collect all macros other than those whose mangled names begin
    with an ASCII underscore (``_``).
+
+   When requiring reader macros, ``(require mymodule :readers *)`` will collect
+   all reader macros both defined and required within ``mymodule``.
 
    :strong:`Macros that call macros`
 

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -179,30 +179,15 @@ def require_reader(source_module, target_module, assignments=None):
         source_module = import_module_from_string(source_module, target_module)
 
     source_macros = source_module.__dict__.setdefault("__reader_macros__", {})
-
-    if not source_module.__reader_macros__:
-        if assignments:
-            for name in assignments:
-                try:
-                    require_reader(
-                        f"{source_module.__name__}.{mangle(name)}", target_module
-                    )
-                except HyRequireError as e:
-                    raise HyRequireError(
-                        f"Cannot import reader '{name}'"
-                        f" from '{source_module.__name__}'"
-                        f" ({source_module.__file__})"
-                    )
-            return True
-        else:
-            return False
-
     target_macros = target_namespace.setdefault("__reader_macros__", {})
 
-    for name in assignments or list(source_macros.keys()):
-        _name = mangle("#" + name)
-        if _name in source_module.__reader_macros__:
-            target_macros[_name] = source_macros[_name]
+    assignments = (
+        source_macros.keys() if assignments == "ALL" else map(mangle, assignments)
+    )
+
+    for name in assignments:
+        if name in source_module.__reader_macros__:
+            target_macros[name] = source_macros[name]
         else:
             raise HyRequireError(
                 "Could not require name {} from {}".format(_name, source_module)

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -167,7 +167,7 @@ def import_module_from_string(module_name, package_module):
         raise HyRequireError(e.args[0]).with_traceback(None)
 
 
-def require_reader(source_module, target_module, assignments=None):
+def require_reader(source_module, target_module, assignments):
     target_module, target_namespace = derive_target_module(
         target_module, inspect.stack()[1][0]
     )
@@ -198,11 +198,13 @@ def require_reader(source_module, target_module, assignments=None):
 
 def enable_readers(module, reader, names):
     _, namespace = derive_target_module(module, inspect.stack()[1][0])
+    names = (
+        namespace["__reader_macros__"].keys() if names == "ALL" else map(mangle, names)
+    )
     for name in names:
-        _name = mangle("#" + name)
-        if _name not in namespace["__reader_macros__"]:
+        if name not in namespace["__reader_macros__"]:
             raise NameError(f"reader {name} is not defined")
-        reader.reader_table[_name] = namespace["__reader_macros__"][_name]
+        reader.reader_table[name] = namespace["__reader_macros__"][name]
 
 
 def require(source_module, target_module, assignments, prefix=""):

--- a/tests/native_tests/reader_macros.hy
+++ b/tests/native_tests/reader_macros.hy
@@ -63,6 +63,13 @@
         [(qplah 1) #upper "hello"]]f])
       [[8 1] "HELLO"])))
 
+  ;; test require :readers *
+  (assert (=
+      (eval-module #[=[
+        (require tests.resources.tlib :readers *)
+        [#upper "eVeRy" #lower "ReAdEr"]]=])
+      ["EVERY" "reader"]))
+
   ;; test can't redefine :macros or :readers assignment brackets
   (with [(pytest.raises hy.errors.HySyntaxError)]
     (eval-module #[[(require tests.resources.tlib [taggart] [upper])]]))

--- a/tests/resources/tlib.hy
+++ b/tests/resources/tlib.hy
@@ -14,3 +14,9 @@
     (if (isinstance node #(hy.models.Symbol hy.models.String))
         (.__class__ node (.upper node))
         (raise (TypeError f"Cannot uppercase {(type node)}")))))
+
+(defreader lower
+  (setv node (&reader.parse-one-form))
+  (if (isinstance node #(hy.models.Symbol hy.models.String))
+    (.__class__ node (.lower node))
+    (raise (TypeError f"Cannot lowercase {(type node)}"))))


### PR DESCRIPTION
Closes #2265.

Breaks latest hyrule since the API for `hy.macros.require_reader` is slightly different, but it's a very easy fix.
I can submit a PR once this one goes through.
