### PR TITLE
Load reader macros from $HYSTARTUP

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -263,8 +263,6 @@ class HyREPL(code.InteractiveConsole):
                 require(mod, self.module, assignments="ALL")
             except Exception as e:
                 print(e)
-        # Load cmdline-specific macros.
-        require("hy.cmdline", self.module, assignments="ALL")
 
         self.hy_compiler = HyASTCompiler(self.module, module_name)
 

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -31,7 +31,7 @@ from hy.importer import HyLoader, runhy
 from hy.lex import mangle, read_module
 from hy.lex.exceptions import PrematureEndOfInput
 from hy.lex.hy_reader import HyReader
-from hy.macros import require
+from hy.macros import enable_readers, require, require_reader
 
 sys.last_type = None
 sys.last_value = None
@@ -124,6 +124,11 @@ class HyCompile(codeop.Compile):
         self.reader = HyReader()
 
         super().__init__()
+
+        if hasattr(self.module, "__reader_macros__"):
+            enable_readers(
+                self.module, self.reader, self.module.__reader_macros__.keys()
+            )
 
         self.flags |= hy_ast_compile_flags
 
@@ -261,6 +266,7 @@ class HyREPL(code.InteractiveConsole):
 
                 # load module macros
                 require(mod, self.module, assignments="ALL")
+                require_reader(mod, self.module, assignments="ALL")
             except Exception as e:
                 print(e)
 

--- a/tests/resources/hystartup.hy
+++ b/tests/resources/hystartup.hy
@@ -6,3 +6,6 @@
 
 (defmacro hello-world []
   `(+ 1 1))
+
+(defreader rad
+  '(+ "totally" "rad"))

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -619,6 +619,11 @@ def test_hystartup():
     assert "1 + 1" in output
     assert "2" in output
 
+    output, _ = run_cmd("hy", "#rad")
+    assert "#rad" not in output
+    assert "'totally' + 'rad'" in output
+    assert "'totallyrad'" in output
+
     output, _ = run_cmd("hy --repl-output-fn repr", "[1 2 3 4]")
     assert "[1, 2, 3, 4]" in output
     assert "[1 2 3 4]" not in output


### PR DESCRIPTION
Allows reader macros to be defined/required in the $HYSTARTUP file and be available in the REPL.
