### PR TITLE
Fix: subscript type annotations

### DIFF
--- a/hy/lex/hy_reader.py
+++ b/hy/lex/hy_reader.py
@@ -315,13 +315,14 @@ class HyReader(Reader):
 
     @reader_for("^")
     def annotate_or_xor(self, _):
-        suffix = self.read_ident(just_peeking=True)
-        if suffix == "":
+        next_char = self.peekc()
+        if not next_char or isnormalizedspace(next_char):
             return sym("^")
-        if suffix == "=":
+        elif next_char == "=":
             self.getc()
             return sym("^=")
-        return mkexpr("annotate", self.parse_one_form())
+        else:
+            return mkexpr("annotate", self.parse_one_form())
 
     ###
     # Sequences

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -759,14 +759,14 @@
 
 (defn test-defn-annotations []
 
-  (defn ^int f [^int p1 p2 ^str p3 ^str [o1 None] ^int [o2 0]
+  (defn ^int f [^(get List int) p1 p2 ^str p3 ^str [o1 None] ^int [o2 0]
            ^str #* rest ^str k1 ^int [k2 0] ^bool #** kwargs])
 
   (assert (is (. f __annotations__ ["return"]) int))
   (for [[k v] (.items (dict
-      :p1 int  :p3 str  :o1 str  :o2 int
-      :k1 str  :k2 int  :kwargs bool))]
-    (assert (is (. f __annotations__ [k]) v))))
+                        :p1 (get List int)  :p3 str  :o1 str  :o2 int
+                        :k1 str  :k2 int  :kwargs bool))]
+    (assert (= (. f __annotations__ [k]) v))))
 
 
 (defn test-return []


### PR DESCRIPTION
hy reader wasn't properly parsing expressions after `^` 