### PR TITLE
narrow defmacro lambda list parser

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -60,6 +60,7 @@ Bug Fixes
 * Module names supplied to `hy -m` are now mangled.
 * Literal newlines (of all three styles) are now recognized properly
   in string and bytes literals.
+* ``defmacro`` no longer allows arguments after ``#* args``
 
 New Features
 ------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -341,6 +341,20 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
         => (infix (1 + 1))
         2
 
+   .. note:: because all values are passed to macros unevaluated, ``defmacro``
+             cannot use keyword arguments, or kwargs. All arguments are passed
+             in positionally. Parameters can still be given default values
+             however::
+
+                => (defmacro a-macro [a [b 1]]
+                ...  `[~a ~b])
+                => (a-macro 2)
+                [2 1]
+                => (a-macro 2 3)
+                [2 3]
+                => (a-macro :b 3)
+                [:b 3]
+
 .. hy:function:: (if [test then else])
 
    ``if`` compiles to an :py:keyword:`if` expression (or compound ``if`` statement). The form ``test`` is evaluated and categorized as true or false according to :py:class:`bool`. If the result is true, ``then`` is evaluated and returned. Othewise, ``else`` is evaluated and returned.

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1442,16 +1442,21 @@ def compile_function_node(compiler, expr, node, decorators, name, args, returns,
     return ret + Result(temp_variables=[ast_name, ret.stmts[-1]])
 
 
-@pattern_macro("defmacro", [SYM, lambda_list, many(FORM)])
+@pattern_macro(
+    "defmacro",
+    [
+        SYM,
+        brackets(
+            maybe(many(argument) + sym("/")),
+            many(argument),
+            maybe(varargs("unpack-iterable", NASYM)),
+        ),
+        many(FORM),
+    ],
+)
 def compile_macro_def(compiler, expr, root, name, params, body):
-    _, _, rest, _, kwargs = params
-
     if "." in name:
         raise compiler._syntax_error(name, "periods are not allowed in macro names")
-    if rest == Symbol("*"):
-        raise compiler._syntax_error(rest, "macros cannot use '*'")
-    if kwargs is not None:
-        raise compiler._syntax_error(kwargs, "macros cannot use '#**'")
 
     ret = Result() + compiler.compile(
         Expression(

--- a/tests/native_tests/native_macros.hy
+++ b/tests/native_tests/native_macros.hy
@@ -61,13 +61,14 @@
 (defn test-macro-kw []
   "An error is raised when * or #** is used in a macro"
 
-  (with [excifno (pytest.raises HySyntaxError)]
-    (hy.eval '(defmacro f [* a b]))
-    (assert (= (. excinfo value msg) "macros cannot use '*'")))
+  (with [(pytest.raises HySyntaxError)]
+    (hy.eval '(defmacro f [* a b])))
 
-  (with [excifno (pytest.raises HySyntaxError)]
-    (hy.eval '(defmacro f [#** kw]))
-    (assert (= (. excinfo value msg) "macros cannot use '#**'"))))
+  (with [(pytest.raises HySyntaxError)]
+    (hy.eval '(defmacro f [#** kw])))
+
+  (with [(pytest.raises HySyntaxError)]
+    (hy.eval '(defmacro f [a b #* body c]))))
 
 (defn test-macro-bad-name []
   (with [e (pytest.raises HySyntaxError)]


### PR DESCRIPTION
closes #1730 

`defmacro` no longer allows the position only delimiter `/` (values are always passed positionally), the keyword only delimiter `*`, kwargs  `#** kwargs`, or arguments after an `#*` args as part of it's parser.
  