### PR TITLE
Generate .pyc files from .hy files on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 build/
 /.cache
 /.pytest_cache
+/.eggs

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -64,6 +64,7 @@ Bug Fixes
   in string and bytes literals.
 * ``defmacro`` no longer allows arguments after ``#* args``
 * Tracebacks from code parsed with `hy.read` now show source positions.
+* Hy now pre-compiles .hy files during setup/installation.
 
 New Features
 ------------------------------


### PR DESCRIPTION
Change setup.py to generate .pyc files from .hy files on install (which will cause setup.py to include them in wheel distributions as well).

Fixes #1747; a similar patch to hyrule's setup.py will fix https://github.com/hylang/hyrule/issues/42. I can't test rpm/deb/etc generation, but with the way this generates the source/wheel distributions it should fix the .pyc recompilation issue regardless of the end package manager.

Note that this now makes wheels specific to a python version (ie instead of `hy-0.21-py3-none-any.whl`, running `setup.py bdist_wheel` will now generate `hy-0.21-cp310-none-any.whl`)
So for Pypi we (really, @Kodiologist) will want to generate wheels for each version of python we support. The source distribution doesn't contain .pyc files so it's still version agnostic.