### PR TITLE
Recognize `\N{…}` escape sequences in f-strings

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -15,6 +15,7 @@ Bug Fixes
 * `__file__` should now be set the same way as in Python.
 * Fixed a bug with `python -O` where assertions were still partly
   evaluated.
+* `\N{…}` escape sequences are now recognized in f-strings.
 
 Misc. Improvements
 ------------------------------

--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -448,7 +448,7 @@ class HyReader(Reader):
                 s = s[:-n_closing_chars]
                 break
             # check if c is start of component
-            if is_fstring and c == "{":
+            if is_fstring and c == "{" and s[-3:] != ["\\", "N", "{"]:
                 # check and handle "{{"
                 if self.peek_and_getc("{"):
                     s.append("{")

--- a/tests/native_tests/language.hy
+++ b/tests/native_tests/language.hy
@@ -1109,6 +1109,11 @@ cee"} dee" "ey bee\ncee dee"))
       (+ "C[" format-spec "]")))
   (assert (= f"{(C) :  {(str (+ 1 1)) !r :x<5}}" "C[  '2'xx]"))
 
+  ; \N sequences
+  ; https://github.com/hylang/hy/issues/2321
+  (setv ampersand "wich")
+  (assert (= f"sand{ampersand} \N{ampersand} chips" "sandwich & chips"))
+
   ; Format bracket strings
   (assert (= #[f[a{p !r :9}]f] "a'xyzzy'  "))
   (assert (= #[f-string[result: {value :{width}.{precision}}]f-string]


### PR DESCRIPTION
Fixes #2321.