### PR TITLE
Remove exception to the merge policy for releases

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -120,9 +120,7 @@ There are two situations in which a PR is allowed to be merged:
    author. Changes to the documentation, or trivial changes to code, need only
    **one** approving member.
 2. When the PR is at least **three days** old and **no** member of the Hy core
-   team has expressed disapproval of the PR in its current state. (Exception: a
-   PR to create a new release is not eligible to be merged under this criterion,
-   only the first one.)
+   team has expressed disapproval of the PR in its current state.
 
 Anybody on the Hy core team may perform the merge. Merging should create a merge
 commit (don't squash unnecessarily, because that would remove separation between


### PR DESCRIPTION
Back in ye olde days of 2018 when the gist of our merge policy was implemented (#1508), there was a concern that releases deserved extra scrutiny. The way I ended up trying to address this concern, which ultimately was accepted, was to make PRs for new releases exempt from the rule that a sufficiently old PR with no objections could be merged without review.

What I've found while doing the 10 major releases since this rule change is that the exception doesn't seem to be doing any good. It can take a long time for the release to be rubber-stamped, over a month in some cases, and in the one case I can recall a new-release PR being objected to (when we were arguing about alpha releases versus 0.x releases), the whole discussion took place before the three-day deadline. So it appears that by removing the exception, we can much more quickly release new versions of Hy, without accidentally releasing something that a core developer would have objected to given more time.

Being able to make a new release in the immediate future would be nice, since Python 3.11 is out and Hy `master` adds support for it.

@hylang/core Any objections?