### PR TITLE
Add reader macro to escape reserved macros

### DIFF
--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -366,6 +366,15 @@ class HyReader(Reader):
             self.parse_one_form(),
         )
 
+    @reader_for("#'")
+    def escaped_identifier(self, _):
+        """Parses an escaped identifier"""
+        form = self.parse_one_form()
+        if isinstance(form, Symbol):
+            return mkexpr("py", str(form))
+        else:
+            raise LexException.from_reader("expected a symbol", self)
+
     ###
     # Strings
     # (these are more complicated because f-strings


### PR DESCRIPTION
Some names like `export`, `quasiquote`, `quote`, etc are reserved in Hy, but useable in Python.

This allows accessing these names via a `#'export` syntax.

Not exactly sure what an approriate syntax is. I just used `#'foo` as a temporary placeholder.
