### PR TITLE
Add `#/` import reader macro

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -16,6 +16,7 @@ New Features
   case they're no-ops.
 * The `py` macro now implicitly parenthesizes the input code, so Python's
   indentation restrictions don't apply.
+* New built-in object `hy.M` for easy imports in macros.
 
 0.26.0 (released 2023-02-08)
 =============================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1312,6 +1312,8 @@ the following methods
 
 .. hy:autofunction:: hy.as-model
 
+.. hy:autoclass:: hy.M
+
 .. _reader-macros:
 
 Reader Macros

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,10 @@ intersphinx_mapping = dict(
     py3_10=("https://docs.python.org/3.10/", None),
     hyrule=("https://hyrule.readthedocs.io/en/master/", None),
 )
+
+import hy
+hy.M = type(hy.M)  # A trick to enable `hy:autoclass:: hy.M`
+
 # ** Generate Cheatsheet
 import json
 from itertools import zip_longest

--- a/hy/__init__.py
+++ b/hy/__init__.py
@@ -15,6 +15,19 @@ import hy.importer  # NOQA
 hy.importer._inject_builtins()
 # we import for side-effects.
 
+
+class M:
+    """``hy.M`` is an object that provides syntactic sugar for imports. It allows syntax like ``(hy.M.math.sqrt 2)``  to mean ``(import math) (math.sqrt 2)``, except without bringing ``math`` or ``math.sqrt`` into scope. This is useful in macros to avoid namespace pollution. To refer to a module with dots in its name, use slashes instead: ``hy.M.os/path.basename`` gets the function ``basename`` from the module ``os.path``.
+
+    You can also call ``hy.M`` like a function, as in ``(hy.M "math")``, which is useful when the module name isn't known until run-time. This interface just calls :py:func:`importlib.import_module`, avoiding (1) mangling due to attribute lookup, and (2) the translation of ``/`` to ``.`` in the module name. The advantage of ``(hy.M modname)`` over ``importlib.import_module(modname)`` is merely that it avoids bringing ``importlib`` itself into scope."""
+    def __call__(self, module_name):
+        import importlib
+        return importlib.import_module(module_name)
+    def __getattr__(self, s):
+        return self(hy.mangle('.'.join(hy.unmangle(s).split('/'))))
+M = M()
+
+
 # Import some names on demand so that the dependent modules don't have
 # to be loaded if they're not needed.
 

--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -393,6 +393,17 @@ class HyReader(Reader):
             self.parse_one_form(),
         )
 
+    @reader_for("#/")
+    def hash_import_slash(self, _):
+        """Sugar for hy.M, to access modules without needing to explicitly import them first."""
+        modstring = self.read_ident()
+        mod, *ident = modstring.split(".")
+        mod = mangle(mod.replace("/", "."))
+        imp = mkexpr(as_identifier("hy.M"), mod)
+        if ident:
+            return mkexpr(as_identifier("."), imp, *map(as_identifier, ident))
+        return imp
+
     ###
     # Strings
     # (these are more complicated because f-strings

--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -128,9 +128,9 @@ class HyReader(Reader):
         """
         model.start_line, model.start_column = start
         model.end_line, model.end_column = self.pos
+        # `replace` will recurse into submodels and set any model
+        # positions that are still unset the same way.
         return model.replace(model)
-          # `replace` will recurse into submodels and set any model
-          # positions that are still unset the same way.
 
     def read_default(self, key):
         """Default reader handler when nothing in the table matches.
@@ -450,7 +450,9 @@ class HyReader(Reader):
                     index = -1
             return 0
 
-        return self.read_string_until(delim_closing, "fr" if is_fstring else None, is_fstring, brackets=delim)
+        return self.read_string_until(
+            delim_closing, "fr" if is_fstring else None, is_fstring, brackets=delim
+        )
 
     def read_string_until(self, closing, prefix, is_fstring, **kwargs):
         if is_fstring:


### PR DESCRIPTION
Reader macro `#/` for accessing `hy.M` import helper.
Examples:
```hy
(#/re.match r"re(gex)?" line)
(= (type #/collections/abc #/types.ModuleType))
(print #/os/path.curdir)
```