### PR TITLE
Fix some shebang issues

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -13,6 +13,7 @@ Bug Fixes
   fails.
 * Fixed some bugs with traceback pointing.
 * Fixed some bugs with escaping in bracket f-strings
+* The parser no longer looks for shebangs in the REPL or `hy -c`.
 
 New Features
 ------------------------------

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -35,7 +35,7 @@ def run_command(source, filename=None):
     with filtered_hy_exceptions():
         try:
             hy_eval(
-                read_many(source, filename=filename, skip_shebang=True),
+                read_many(source, filename=filename),
                 __main__.__dict__,
                 __main__,
                 filename=filename,

--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -160,7 +160,8 @@ class HyReader(Reader):
         """
         self._set_source(stream, filename)
 
-        if skip_shebang and "".join(islice(self.peeking(), len("#!"))) == "#!":
+        if skip_shebang and "".join(
+                islice(self.peeking(eof_ok = True), len("#!"))) == "#!":
             for c in self.chars():
                 if c == "\n":
                     break

--- a/hy/repl.py
+++ b/hy/repl.py
@@ -167,7 +167,7 @@ class HyCompile(codeop.Compile):
             self.hy_compiler.filename = name
             self.hy_compiler.source = source
             hy_ast = read_many(
-                source, filename=name, reader=self.reader, skip_shebang=True
+                source, filename=name, reader=self.reader
             )
             exec_ast, eval_ast = hy_compile(
                 hy_ast,

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,4 @@ filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
     ignore::SyntaxWarning
+    ignore::pytest.PytestReturnNotNoneWarning

--- a/tests/native_tests/repl.hy
+++ b/tests/native_tests/repl.hy
@@ -11,3 +11,9 @@
   (assert (= sys.ps1 "chippy"))
   (.run (hy.REPL))
   (assert (= sys.ps1 "chippy")))
+
+(defn test-repl-input-1char [monkeypatch capsys]
+  ; https://github.com/hylang/hy/issues/2430
+  (monkeypatch.setattr "sys.stdin" (io.StringIO "1\n"))
+  (.run (hy.REPL))
+  (assert (= (. capsys (readouterr) out) "=> 1\n=> " )))

--- a/tests/native_tests/repl.hy
+++ b/tests/native_tests/repl.hy
@@ -2,7 +2,8 @@
 
 (import
   io
-  sys)
+  sys
+  pytest)
 
 (defn test-preserve-ps1 [monkeypatch]
   ; https://github.com/hylang/hy/issues/1323#issuecomment-1310837340
@@ -17,3 +18,10 @@
   (monkeypatch.setattr "sys.stdin" (io.StringIO "1\n"))
   (.run (hy.REPL))
   (assert (= (. capsys (readouterr) out) "=> 1\n=> " )))
+
+(defn test-repl-no-shebangs [monkeypatch capsys]
+  (monkeypatch.setattr "sys.stdin" (io.StringIO "#!/usr/bin/env hy\n"))
+  (.run (hy.REPL))
+  (assert (in
+    "hy.reader.exceptions.LexException"
+    (. capsys (readouterr) err))))

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -332,6 +332,13 @@ def test_icmd_and_spy():
     assert "[] + []" in output
 
 
+def test_empty_file(tmp_path):
+    # https://github.com/hylang/hy/issues/2427
+    (tmp_path / 'foo.hy').write_text('')
+    run_cmd(['hy', (tmp_path / 'foo.hy')])
+      # This asserts that the return code is 0.
+
+
 def test_missing_file():
     _, err = run_cmd("hy foobarbaz", expect=2)
     assert "No such file" in err

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -303,6 +303,10 @@ def test_cmd():
     _, err = run_cmd("""hy -c '(print (.upper "hello")'""", expect=1)
     assert "Premature end of input" in err
 
+    # No shebang is allowed.
+    _, err = run_cmd("""hy -c '#!/usr/bin/env hy'""", expect = 1)
+    assert "LexException" in err
+
     # https://github.com/hylang/hy/issues/1879
     output, _ = run_cmd(
         """hy -c '(setv x "bing") (defn f [] (+ "fiz" x)) (print (f))'"""


### PR DESCRIPTION
- Fixes #2427
- Fixes #2430

Both bugs were caused by the same underlying issue, which is a regression I introduced in #2412, specifically 5fb663ee5beafe0188927cf4bb23deee204bfeb4.

I've also gone further and forbid shebangs in the REPL and `hy -c` entirely, since they have no legitimate use there.