### PR TITLE
In the REPL, print a delimiter after `spy` output

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -23,6 +23,8 @@ New Features
 * The `py` macro now implicitly parenthesizes the input code, so Python's
   indentation restrictions don't apply.
 * New built-in object `hy.M` for easy imports in macros.
+* `hy --spy` now prints a delimiter between the Python equivalent of
+  your code and the result of evaluating the code for easier reading.
 
 0.26.0 (released 2023-02-08)
 =============================

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -28,6 +28,7 @@ for a complete list of options and :py:ref:`Python's documentation
 
        => (+ 1 2)
        1 + 2
+       ------------------------------
        3
 
 .. cmdoption:: --repl-output-fn

--- a/hy/repl.py
+++ b/hy/repl.py
@@ -240,7 +240,7 @@ class REPL(code.InteractiveConsole):
     Note that as with :func:`code.interact`, changes to ``(locals)`` inside the REPL are
     not propagated back to the original scope."""
 
-    def __init__(self, spy=False, output_fn=None, locals=None, filename="<stdin>", allow_incomplete=True):
+    def __init__(self, spy=False, spy_delimiter=('-' * 30), output_fn=None, locals=None, filename="<stdin>", allow_incomplete=True):
 
         # Create a proper module for this REPL so that we can obtain it easily
         # (e.g. using `importlib.import_module`).
@@ -293,6 +293,7 @@ class REPL(code.InteractiveConsole):
         )
 
         self.spy = spy
+        self.spy_delimiter = spy_delimiter
         self.last_value = None
         self.print_last_value = True
 
@@ -332,6 +333,7 @@ class REPL(code.InteractiveConsole):
                     type_ignores=[],
                 )
                 print(ast.unparse(new_ast))
+                print(self.spy_delimiter)
             except Exception:
                 msg = "Exception in AST callback:\n{}\n".format(traceback.format_exc())
                 self.write(msg)


### PR DESCRIPTION
- Closes #1435

I arbitrarily chose `'-' * 30` as the (default) delimiter. I don't have a strong preference, so if you'd like to bikeshed about it, now's the time.