### PR TITLE
Replace all uses of features that are deprecated in Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - name-prefix: 'win-'
             os: windows-latest
             python: 3.11
-          - name-prefix: 'macos-'
+          - name-prefix: 'mac-'
             os: macos-latest
             python: 3.11
 

--- a/hy/_compat.py
+++ b/hy/_compat.py
@@ -27,7 +27,7 @@ if "def" in ast.unparse(ast.parse("𝕕𝕖𝕗 = 1")):
     def rewriting_unparse(ast_obj):
         ast_obj = copy.deepcopy(ast_obj)
         for node in ast.walk(ast_obj):
-            if type(node) in (ast.Constant, ast.Str):
+            if type(node) is ast.Constant:
                 # Don't touch string literals.
                 continue
             for field in node._fields:

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -580,7 +580,7 @@ class HyASTCompiler:
     @builds_model(Integer, Float, Complex)
     def compile_numeric_literal(self, x):
         f = {Integer: int, Float: float, Complex: complex}[type(x)]
-        return asty.Num(x, n=f(x))
+        return asty.Constant(x, value=f(x))
 
     @builds_model(Symbol)
     def compile_symbol(self, symbol):
@@ -612,16 +612,15 @@ class HyASTCompiler:
                 attr="Keyword",
                 ctx=ast.Load(),
             ),
-            args=[asty.Str(obj, s=obj.name)],
+            args=[asty.Constant(obj, value=obj.name)],
             keywords=[],
         )
         return ret
 
     @builds_model(String, Bytes)
     def compile_string(self, string):
-        node = asty.Bytes if type(string) is Bytes else asty.Str
         f = bytes if type(string) is Bytes else str
-        return node(string, s=f(string))
+        return asty.Constant(string, value=f(string))
 
     @builds_model(FComponent)
     def compile_fcomponent(self, fcomponent):
@@ -856,7 +855,8 @@ def hy_compile(
         if (
             result.stmts
             and isinstance(result.stmts[0], ast.Expr)
-            and isinstance(result.stmts[0].value, ast.Str)
+            and isinstance(result.stmts[0].value, ast.Constant)
+            and isinstance(result.stmts[0].value.value, str)
         ):
 
             body += [result.stmts.pop(0)]

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -579,8 +579,8 @@ class HyASTCompiler:
 
     @builds_model(Integer, Float, Complex)
     def compile_numeric_literal(self, x):
-        f = {Integer: int, Float: float, Complex: complex}[type(x)]
-        return asty.Constant(x, value=f(x))
+        return asty.Constant(x, value =
+            {Integer: int, Float: float, Complex: complex}[type(x)](x))
 
     @builds_model(Symbol)
     def compile_symbol(self, symbol):
@@ -619,8 +619,8 @@ class HyASTCompiler:
 
     @builds_model(String, Bytes)
     def compile_string(self, string):
-        f = bytes if type(string) is Bytes else str
-        return asty.Constant(string, value=f(string))
+        return asty.Constant(string, value =
+            (bytes if type(string) is Bytes else str)(string))
 
     @builds_model(FComponent)
     def compile_fcomponent(self, fcomponent):

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -354,7 +354,7 @@ m_ops = {
 def compile_maths_expression(compiler, expr, root, args):
     if len(args) == 0:
         # Return the identity element for this operator.
-        return asty.Num(expr, n=({"+": 0, "|": 0, "*": 1}[root]))
+        return asty.Constant(expr, value=({"+": 0, "|": 0, "*": 1}[root]))
 
     if len(args) == 1:
         if root == "/":

--- a/hy/errors.py
+++ b/hy/errors.py
@@ -1,8 +1,8 @@
 import os
-import pkgutil
 import re
 import sys
 import traceback
+import importlib.util
 from contextlib import contextmanager
 from functools import reduce
 
@@ -197,7 +197,11 @@ class HyWrapperError(HyError, TypeError):
 
 def _module_filter_name(module_name):
     try:
-        compiler_loader = pkgutil.get_loader(module_name)
+        spec = importlib.util.find_spec(module_name)
+        if not spec:
+            return None
+
+        compiler_loader = spec.loader
         if not compiler_loader:
             return None
 

--- a/hy/errors.py
+++ b/hy/errors.py
@@ -4,7 +4,6 @@ import sys
 import traceback
 import importlib.util
 from contextlib import contextmanager
-from functools import reduce
 
 from hy import _initialize_env_var
 from hy._compat import PYPY

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -40,7 +40,7 @@ def cant_compile(expr):
 
 
 def s(x):
-    return can_compile('"module docstring" ' + x).body[-1].value.s
+    return can_compile('"module docstring" ' + x).body[-1].value.value
 
 
 def test_ast_bad_type():
@@ -374,7 +374,7 @@ def test_lambda_list_keywords_kwonly():
     for i, kwonlyarg_name in enumerate(("a", "b")):
         assert kwonlyarg_name == code.body[0].args.kwonlyargs[i].arg
     assert code.body[0].args.kw_defaults[0] is None
-    assert code.body[0].args.kw_defaults[1].n == 2
+    assert code.body[0].args.kw_defaults[1].value == 2
 
 
 def test_lambda_list_keywords_mixed():
@@ -399,8 +399,8 @@ def test_ast_unicode_strings():
         )
         # We put hy_s in a list so it isn't interpreted as a docstring.
 
-        # code == ast.Module(body=[ast.Expr(value=ast.List(elts=[ast.Str(s=xxx)]))])
-        return code.body[0].value.elts[0].s
+        # code == ast.Module(body=[ast.Expr(value=ast.List(elts=[ast.Constant(value=xxx)]))])
+        return code.body[0].value.elts[0].value
 
     assert _compile_string("test") == "test"
     assert _compile_string("\u03b1\u03b2") == "\u03b1\u03b2"


### PR DESCRIPTION
There are still some `DeprecationWarning`s produced by pytest itself, but these should be fixed by https://github.com/pytest-dev/pytest/pull/10894.