### PR TITLE
Forbid `Symbol("#foo")`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -29,6 +29,8 @@ Bug Fixes
 * The parser no longer looks for shebangs in the REPL or `hy -c`.
 * `require` with relative module names should now work correctly with
   `hy -m`, as well as `hy2py`'s recursive mode.
+* `hy.models.Symbol` no longer allows constructing a symbol beginning
+  with `#`.
 
 New Features
 ------------------------------

--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -98,7 +98,7 @@ def as_identifier(ident, reader=None):
     if reader is None:
         if (
             not ident
-            or ident[:1] == ":"
+            or ident[0] in ":#"
             or any(isnormalizedspace(c) for c in ident)
             or HyReader.NON_IDENT.intersection(ident)
         ):

--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -55,7 +55,7 @@ def test_macroexpand_nan():
 
 def test_macroexpand_source_data():
     # https://github.com/hylang/hy/issues/1944
-    ast = Expression([Symbol("#@"), String("a")])
+    ast = Expression([Symbol("when"), String("a")])
     ast.start_line = 3
     ast.start_column = 5
     bad = macroexpand_1(ast, "hy.core.macros")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,8 @@ def test_symbol_or_keyword():
     for x in ("foo", "foo-bar", "foo_bar", "✈é😂⁂"):
         assert str(Symbol(x)) == x
         assert Keyword(x).name == x
-    for x in ("", ":foo", "5"):
+    for x in ("", ":foo", "5", "#foo"):
+        # https://github.com/hylang/hy/issues/2383
         with pytest.raises(ValueError):
             Symbol(x)
         assert Keyword(x).name == x


### PR DESCRIPTION
- Fixes #2383