### PR TITLE
Make Kodi officially the maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Project
 * Community: Join us on [Github Discussions](https://github.com/hylang/hy/discussions)!
 * [Stack Overflow: The [hy] tag](https://stackoverflow.com/questions/tagged/hy)
 
+Hy's current maintainer is [Kodi Arfer](https://github.com/Kodiologist). He takes responsibility for answering user questions, which should primarily be asked on Stack Overflow or GitHub Discussions, but feel free to [poke him](http://arfer.net/elsewhere) if he's missed a question or you've found a serious security issue.
+
 ![Cuddles the Hacker](https://i.imgur.com/QbPMXTN.png)
 
 (fan art from the one and only [doctormo](http://doctormo.deviantart.com/art/Cuddles-the-Hacker-372184766))


### PR DESCRIPTION
I joined Hy's core team seven years ago. By various metrics (eligible pull requests reviewed, pull requests written, commits made, lines of code changed, issues closed, releases managed, user questions answered, and hours spent on Hy development), I've since become the biggest single contributor to Hy by a substantial margin (particularly in the period after Hy's busy first two years of life). In general, I've taken on a lot of responsibility. So, I'd say I'm the de-facto lead developer. Let's make it official.

I'm not proposing I should get any special privileges, which would be pretty meaningless anyway so long as @scauligi and I are the only active developers. This is really just for my resume. Perhaps if Hy development gets a lot busier (after the release of 1.0, one could imagine), then extra rules about how I could resolve disagreements or something could make sense. But for now, proposing such things seems premature.

@hylang/core Any objections?