### PR TITLE
hy2py now uses `-m` for modules

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,14 @@
 .. default-role:: code
 
+Unreleased
+=============================
+
+Breaking Changes
+------------------------------
+* `hy2py` now requires `-m` to specify modules, and uses
+  the same `sys.path` rules as Python when parsing a module
+  vs a standalone script.
+
 0.27.0 (released 2023-07-06)
 =============================
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -821,15 +821,6 @@ def hy_compile(
     """
     module = get_compiler_module(module, compiler, False)
 
-    if isinstance(module, str):
-        if module.startswith("<") and module.endswith(">"):
-            module = types.ModuleType(module)
-        else:
-            module = importlib.import_module(mangle(module))
-
-    if not inspect.ismodule(module):
-        raise TypeError("Invalid module type: {}".format(type(module)))
-
     filename = getattr(tree, "filename", filename)
     source = getattr(tree, "source", source)
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -740,6 +740,20 @@ def test_assert(tmp_path, monkeypatch):
             assert ("bye" in err) == show_msg
 
 
+def test_hy2py_compile_only(monkeypatch):
+    def check(args):
+        output, _ = run_cmd(f"hy2py {args}")
+        assert not re.search(r"^hello world$", output, re.M)
+
+    monkeypatch.chdir('tests/resources')
+    check("hello_world.hy")
+    check("-m hello_world")
+
+    monkeypatch.chdir('..')
+    check("resources/hello_world.hy")
+    check("-m resources.hello_world")
+
+
 def test_hy2py_recursive(monkeypatch, tmp_path):
     (tmp_path / 'foo').mkdir()
     (tmp_path / 'foo/__init__.py').touch()
@@ -755,10 +769,10 @@ def test_hy2py_recursive(monkeypatch, tmp_path):
 
     monkeypatch.chdir(tmp_path)
 
-    _, err = run_cmd("hy2py foo", expect=1)
+    _, err = run_cmd("hy2py -m foo", expect=1)
     assert "ValueError" in err
 
-    run_cmd("hy2py foo --output bar")
+    run_cmd("hy2py -m foo --output bar")
     assert set((tmp_path / 'bar').rglob('*')) == {
         tmp_path / 'bar' / p
         for p in ('first.py', 'folder', 'folder/second.py')}
@@ -767,7 +781,7 @@ def test_hy2py_recursive(monkeypatch, tmp_path):
     assert output == "1\nhello world\n"
 
 
-@pytest.mark.parametrize('case', ['hy -m', 'hy2py'])
+@pytest.mark.parametrize('case', ['hy -m', 'hy2py -m'])
 def test_relative_require(case, monkeypatch, tmp_path):
     # https://github.com/hylang/hy/issues/2204
 
@@ -784,8 +798,8 @@ def test_relative_require(case, monkeypatch, tmp_path):
 
     if case == 'hy -m':
         output, _ = run_cmd('hy -m pkg.b')
-    elif case == 'hy2py':
-        run_cmd('hy2py pkg -o out')
+    elif case == 'hy2py -m':
+        run_cmd('hy2py -m pkg -o out')
         (tmp_path / 'out' / '__init__.py').touch()
         output, _ = run_cmd('python3 -m out.b')
 


### PR DESCRIPTION
Fixes a bug where `hy2py` was accidentally importing (and thus executing) the module/script being parsed.

As part of the bugfix, I also changed `hy2py` to explicitly use the `-m` flag for parsing modules, bringing it more in line with `hy`/`python` commandline flags.
It also now follows the same `sys.path` rules too, where using `-m` adds the current directory to `sys.path`, but passing a file directly adds the parent directory of the file instead.

