### PR TITLE
Fix `hy2py` on standard input

### DIFF
--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -384,7 +384,7 @@ def hy2py_worker(source, options, filename=None, parent_module=None, output_file
         hst.filename = filename
 
         with filtered_hy_exceptions():
-            module_name = source_path.stem
+            module_name = source_path.stem if source_path else Path(filename).name
             if parent_module:
                 module_name = f"{parent_module}.{module_name}"
             module = types.ModuleType(module_name)

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -592,6 +592,12 @@ def test_assert(tmp_path, monkeypatch):
             assert ("bye" in err) == show_msg
 
 
+def test_hy2py_stdin():
+    out, _ = run_cmd("hy2py", "(+ 482 223)")
+    assert "482 + 223" in out
+    assert "705" not in out
+
+
 def test_hy2py_compile_only(monkeypatch):
     def check(args):
         output, _ = run_cmd(f"hy2py {args}")


### PR DESCRIPTION
This was a regression from #2467. It looks like I foolishly didn't include a test when I originally wrote #1163.