### PR TITLE
Correct `root` in pattern macros with dotted head

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,6 +24,8 @@ Misc. Improvements
 Bug Fixes
 ------------------------------
 * Double quotes inside of bracketed f-strings are now properly handled.
+* Fixed incomplete recognition of macro calls with a unary dotted
+  head like `((. defn) f [])`.
 
 0.27.0 (released 2023-07-06)
 =============================

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -52,13 +52,12 @@ def pattern_macro(names, pattern, shadow=None):
                     ).replace(hy_compiler.this)
 
                 expr = hy_compiler.this
-                root = unmangle(expr[0])
 
                 if py_version_required and sys.version_info < py_version_required:
                     raise hy_compiler._syntax_error(
                         expr,
                         "`{}` requires Python {} or later".format(
-                            root, ".".join(map(str, py_version_required))
+                            name, ".".join(map(str, py_version_required))
                         ),
                     )
 
@@ -68,10 +67,10 @@ def pattern_macro(names, pattern, shadow=None):
                     raise hy_compiler._syntax_error(
                         expr[min(e.state.pos + 1, len(expr) - 1)],
                         "parse error for pattern macro '{}': {}".format(
-                            root, e.msg.replace("end of input", "end of macro call")
+                            name, e.msg.replace("end of input", "end of macro call")
                         ),
                     )
-                return fn(hy_compiler, expr, root, *parse_tree)
+                return fn(hy_compiler, expr, name, *parse_tree)
 
             return wrapper
 

--- a/tests/native_tests/functions.hy
+++ b/tests/native_tests/functions.hy
@@ -189,6 +189,15 @@
   (assert (= (asyncio.run (coro-test)) [1 2 3])))
 
 
+(defn test-root-set-correctly []
+  ; https://github.com/hylang/hy/issues/2475
+  ((. defn) not-async [] "ok")
+  (assert (= (not-async) "ok"))
+  (require builtins)
+  (builtins.defn also-not-async [] "ok")
+  (assert (= (also-not-async) "ok")))
+
+
 (defn test-return []
 
   ; `return` in main line


### PR DESCRIPTION
- Fixes #2475