### PR TITLE
Bypass validity checks when quoting Symbols and Keywords

### DIFF
--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -235,10 +235,10 @@ def render_quoted_form(compiler, form, level):
             body.extend([Keyword("conversion"), String(form.conversion)])
 
     elif isinstance(form, Symbol):
-        body = [String(form)]
+        body = [String(form), Keyword("from_parser"), Symbol("True")]
 
     elif isinstance(form, Keyword):
-        body = [String(form.name)]
+        body = [String(form.name), Keyword("from_parser"), Symbol("True")]
 
     elif isinstance(form, String):
         if form.brackets is not None:


### PR DESCRIPTION
Moves checked creation of Symbols and Keywords to new functions `hy.sym()` and `hy.kw()`.

Without speedsym (best of 5 runs):
```
$ time hy -c "(for [_ (range 100000)] 'a)"
real    0m0.699s
user    0m0.680s
sys     0m0.010s
```

With speedsym (best of 5 runs):
```
$ time hy -c "(for [_ (range 100000)] 'a)"
real    0m0.102s
user    0m0.086s
sys     0m0.018
```

I've been using Hy as part of an x86 instruction simulator, where we're hooking every instruction and running a bit of Hy code; the slowdown from creating Symbols (because of quoted forms) is enough to get our simulator to time out.