### PR TITLE
Implement local `defmacro` and `require`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -5,6 +5,13 @@ Unreleased
 
 Breaking Changes
 ------------------------------
+
+* `defmacro` and `require` can now define macros locally instead of
+  only module-wide.
+
+  * `hy.eval`, `hy.macroexpand`, `doc`, and `delmacro` don't work with
+    local macros (yet).
+
 * When a macro is `require`\d from another module, that module is no
   longer implicitly included when checking for further macros in
   the expansion.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -198,6 +198,10 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
       => (infix (1 + 1))
       2
 
+   If ``defmacro`` appears in a function definition, a class definition, or a
+   comprehension other than :hy:func:`for` (such as :hy:func:`lfor`), the new
+   macro is defined locally rather than module-wide.
+
    .. note:: ``defmacro`` cannot use keyword arguments, because all values
              are passed to macros unevaluated. All arguments are passed
              positionally, but they can have default values::
@@ -895,7 +899,8 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
    ``require`` is used to import macros and reader macros from one or more given
    modules. It allows parameters in all the same formats as ``import``.
    ``require`` imports each named module and then makes each requested macro
-   available in the current module.
+   available in the current module, or in the current local scope if called
+   locally (using the same notion of locality as :hy:func:`defmacro`).
 
    The following are all equivalent ways to call a macro named ``foo`` in the
    module ``mymodule``.
@@ -939,8 +944,8 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
        NameError: name 'mymodule' is not defined
 
    Unlike requiring regular macros, reader macros cannot be renamed
-   with ``:as``, and are not made available under their absolute paths
-   to their source module::
+   with ``:as``, are not made available under their absolute paths
+   to their source module, and can't be required locally::
 
       => (require mymodule :readers [!])
       HySyntaxError: ...

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -751,7 +751,9 @@ def hy_eval_user(model, globals = None, locals = None, module = None):
         (hy.eval '(my-test-mac))                 ; => 3
         (import hyrule)
         (hy.eval '(my-test-mac) :module hyrule)  ; NameError
-        (hy.eval '(list-n 3 1) :module hyrule)   ; => [1 1 1]"""
+        (hy.eval '(list-n 3 1) :module hyrule)   ; => [1 1 1]
+
+    N.B. Local macros are invisible to ``hy.eval``."""
 
     if locals is None:
         locals = globals

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -4,6 +4,7 @@ import importlib
 import inspect
 import traceback
 import types
+from contextlib import contextmanager
 
 from funcparserlib.parser import NoParseError, many
 
@@ -335,6 +336,10 @@ class HyASTCompiler:
         """
         self.anon_var_count = 0
         self.temp_if = None
+        self.local_macro_stack = []
+          # A list of dictionaries that map mangled names to local
+          # macros. The last element is considered the top of the
+          # stack.
 
         if not inspect.ismodule(module):
             self.module = importlib.import_module(module)
@@ -506,6 +511,25 @@ class HyASTCompiler:
         if str(name) in ("None", "True", "False"):
             raise self._syntax_error(name, "Can't assign to constant")
         return name
+
+    def eval(self, model):
+        return hy_eval(
+            model,
+            locals = self.module.__dict__,
+            module = self.module,
+            filename = self.filename,
+            source = self.source,
+            import_stdlib = False)
+
+    @contextmanager
+    def local_macros(self):
+        """Make `defmacro` and `require` assign to a new element of
+        `self.local_macro_stack` instead of a module."""
+        self.local_macro_stack.append({})
+        try:
+            yield
+        finally:
+            self.local_macro_stack.pop()
 
     @builds_model(Expression)
     def compile_expression(self, expr):

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -117,7 +117,8 @@
 (defmacro doc [symbol]
   "macro documentation
 
-   Gets help for a macro function available in this module.
+   Gets help for a macro function available in this module (not a local
+   macro).
    Use ``require`` to make other macros available.
 
    Use ``(help foo)`` instead for help with runtime objects."
@@ -168,7 +169,8 @@
 
 (defmacro delmacro
   [#* names]
-  #[[Delete a macro(s) from the current module
+  #[[Delete a macro(s) from the current module. This doesn't work on a
+  local macro.
   ::
 
      => (require a-module [some-macro])

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -1784,7 +1784,9 @@ def compile_require(compiler, expr, root, entries):
         # we don't want to import all macros as prefixed if we're specifically
         # importing readers but not macros
         # (require a-module :readers ["!"])
-        if (rest or not readers) and require(
+        if (rest or not readers) and compiler.local_macro_stack:
+            require(module_name, compiler.local_macro_stack[-1], assignments=assignments, prefix=prefix)
+        elif (rest or not readers) and require(
             module_name, compiler.module, assignments=assignments, prefix=prefix
         ):
             # Actually calling `require` is necessary for macro expansions

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -388,14 +388,16 @@ def macroexpand(tree, module, compiler=None, once=False, result_ok=True):
             break
 
         # Choose the first namespace with the macro.
-        m = next(
-            (
-                mod._hy_macros[fn]
-                for mod in (module, builtins)
-                if fn in getattr(mod, "_hy_macros", ())
-            ),
-            None,
-        )
+        m = ((compiler and next(
+                (d[fn]
+                    for d in reversed(compiler.local_macro_stack)
+                    if fn in d),
+                None)) or
+            next(
+                (mod._hy_macros[fn]
+                    for mod in (module, builtins)
+                    if fn in getattr(mod, "_hy_macros", ())),
+                None))
         if not m:
             break
 

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -338,7 +338,7 @@ def macroexpand(tree, module, compiler=None, once=False, result_ok=True):
     """Expand the toplevel macros for the given Hy AST tree.
 
     Load the macros from the given `module`, then expand the (top-level) macros
-    in `tree` until we no longer can.
+    in `tree` until we no longer can. This doesn't work on local macros.
 
     `Expression` resulting from macro expansions are assigned the module in
     which the macro function is defined (determined using `inspect.getmodule`).

--- a/tests/native_tests/doc.hy
+++ b/tests/native_tests/doc.hy
@@ -6,6 +6,10 @@
   "Some tag macro"
   '1)
 
+(defmacro <-mangle-> []
+  "a fancy docstring"
+  '(+ 2 2))
+
 (defn test-doc [capsys]
   ;; https://github.com/hylang/hy/issues/1970
   ;; Let's first make sure we can doc the builtin macros
@@ -18,9 +22,6 @@
   (setv [out err] (.readouterr capsys))
   (assert (in "Some tag macro" out))
 
-  (defmacro <-mangle-> []
-    "a fancy docstring"
-    '(+ 2 2))
   (doc <-mangle->)
   (setv [out err] (.readouterr capsys))
   ;; https://github.com/hylang/hy/issues/1946

--- a/tests/native_tests/hy_misc.hy
+++ b/tests/native_tests/hy_misc.hy
@@ -28,11 +28,12 @@
              '(a b 5))))
 
 
+(defmacro m-with-named-import []
+  (import math [pow])
+  (pow 2 3))
+
 (defn test-macroexpand-with-named-import []
   ; https://github.com/hylang/hy/issues/1207
-  (defmacro m-with-named-import []
-    (import math [pow])
-    (pow 2 3))
   (assert (= (hy.macroexpand '(m-with-named-import)) (hy.models.Float (** 2 3)))))
 
 

--- a/tests/native_tests/import.hy
+++ b/tests/native_tests/import.hy
@@ -111,17 +111,6 @@
     (brother 1 2 3 4)))
 
 
-(defn test-require-native []
-  (with [(pytest.raises NameError)]
-    (test-macro-2))
-  (import tests.resources.macros)
-  (with [(pytest.raises NameError)]
-    (test-macro-2))
-  (require tests.resources.macros [test-macro-2])
-  (test-macro-2)
-  (assert (= qup 2)))
-
-
 (defn test-relative-require []
   (require ..resources.macros [test-macro])
   (assert (in "test_macro" _hy_macros))

--- a/tests/native_tests/import.hy
+++ b/tests/native_tests/import.hy
@@ -59,54 +59,52 @@
   (assert (in "_null_fn_for_import_test" (dir tests.resources.bin))))
 
 
-(defn test-require []
-  (with [(pytest.raises NameError)]
-    (qplah 1 2 3 4))
-  (with [(pytest.raises NameError)]
-    (parald 1 2 3 4))
-  (with [(pytest.raises NameError)]
-    (✈ 1 2 3 4))
-  (with [(pytest.raises NameError)]
-    (hyx_XairplaneX 1 2 3 4))
+(require
+  tests.resources.tlib
+  tests.resources.tlib :as TL
+  tests.resources.tlib [qplah]
+  tests.resources.tlib [parald :as parald-alias]
+  tests.resources [tlib  macros :as TM  exports-none]
+  os [path])
+    ; The last one is a no-op, since the module `os.path` exists but
+    ; contains no macros.
 
-  (require tests.resources.tlib [qplah])
-  (assert (= (qplah 1 2 3) [8 1 2 3]))
-  (with [(pytest.raises NameError)]
-    (parald 1 2 3 4))
-
-  (require tests.resources.tlib)
+(defn test-require-global []
   (assert (= (tests.resources.tlib.parald 1 2 3) [9 1 2 3]))
   (assert (= (tests.resources.tlib.✈ "silly") "plane silly"))
   (assert (= (tests.resources.tlib.hyx_XairplaneX "foolish") "plane foolish"))
-  (with [(pytest.raises NameError)]
-    (parald 1 2 3 4))
 
-  (require tests.resources.tlib :as T)
-  (assert (= (T.parald 1 2 3) [9 1 2 3]))
-  (assert (= (T.✈ "silly") "plane silly"))
-  (assert (= (T.hyx_XairplaneX "foolish") "plane foolish"))
-  (with [(pytest.raises NameError)]
-    (parald 1 2 3 4))
+  (assert (= (TL.parald 1 2 3) [9 1 2 3]))
+  (assert (= (TL.✈ "silly") "plane silly"))
+  (assert (= (TL.hyx_XairplaneX "foolish") "plane foolish"))
 
-  (require tests.resources.tlib [parald :as p])
-  (assert (= (p 1 2 3) [9 1 2 3]))
-  (with [(pytest.raises NameError)]
-    (parald 1 2 3 4))
+  (assert (= (qplah 1 2 3) [8 1 2 3]))
 
-  (require tests.resources.tlib *)
-  (assert (= (parald 1 2 3) [9 1 2 3]))
-  (assert (= (✈ "silly") "plane silly"))
-  (assert (= (hyx_XairplaneX "foolish") "plane foolish"))
+  (assert (= (parald-alias 1 2 3) [9 1 2 3]))
 
-  (require tests.resources [tlib  macros :as m  exports-none])
   (assert (in "tlib.qplah" _hy_macros))
-  (assert (in (hy.mangle "m.test-macro") _hy_macros))
+  (assert (in (hy.mangle "TM.test-macro") _hy_macros))
   (assert (in (hy.mangle "exports-none.cinco") _hy_macros))
-  (require os [path])
-  (with [(pytest.raises hy.errors.HyRequireError)]
-    (hy.eval '(require tests.resources [does-not-exist])))
 
-  (require tests.resources.exports *)
+  (with [(pytest.raises NameError)]
+    (parald 1 2 3 4))
+
+  (with [(pytest.raises hy.errors.HyRequireError)]
+    (hy.eval '(require tests.resources [does-not-exist]))))
+
+
+(require tests.resources.more-test-macros *)
+
+(defn test-require-global-star-without-exports []
+  (assert (= (bairn 1 2 3) [14 1 2 3]))
+  (assert (= (cairn 1 2 3) [15 1 2 3]))
+  (with [(pytest.raises NameError)]
+    (_dairn 1 2 3 4)))
+
+
+(require tests.resources.exports *)
+
+(defn test-require-global-star-with-exports []
   (assert (= (casey 1 2 3) [11 1 2 3]))
   (assert (= (☘ 1 2 3) [13 1 2 3]))
   (with [(pytest.raises NameError)]

--- a/tests/native_tests/import.hy
+++ b/tests/native_tests/import.hy
@@ -135,24 +135,26 @@
   (assert (in "b.xyzzy" _hy_macros)))
 
 
+;; `remote-test-macro` is a macro used within
+;; `tests.resources.macro-with-require.test-module-macro`.
+;; Here, we introduce an equivalently named version that, when
+;; used, will expand to a different output string.
+(defmacro remote-test-macro [x]
+  "this is the home version of `remote-test-macro`!")
+
+(require tests.resources.macro-with-require *)
+(defmacro home-test-macro [x]
+  (.format "This is the home version of `remote-test-macro` returning {}!" (int x)))
+
 (defn test-macro-namespace-resolution []
-  "Confirm that local versions of macro-macro dependencies do not shadow the
+  "Confirm that new versions of macro-macro dependencies do not shadow the
 versions from the macro's own module, but do resolve unbound macro references
 in expansions."
 
-  ;; `nonlocal-test-macro` is a macro used within
-  ;; `tests.resources.macro-with-require.test-module-macro`.
-  ;; Here, we introduce an equivalently named version in local scope that, when
-  ;; used, will expand to a different output string.
-  (defmacro nonlocal-test-macro [x]
-    (print "this is the local version of `nonlocal-test-macro`!"))
-
   ;; Was the above macro created properly?
-  (assert (in "nonlocal_test_macro" _hy_macros))
+  (assert (in "remote_test_macro" _hy_macros))
 
-  (setv nonlocal-test-macro (get _hy_macros "nonlocal_test_macro"))
-
-  (require tests.resources.macro-with-require *)
+  (setv remote-test-macro (get _hy_macros "remote_test_macro"))
 
   (setv module-name-var "tests.native_tests.native_macros.test-macro-namespace-resolution")
   (assert (= (+ "This macro was created in tests.resources.macros, "
@@ -162,10 +164,7 @@ in expansions."
 
   ;; Now, let's use a `require`d macro that depends on another macro defined only
   ;; in this scope.
-  (defmacro local-test-macro [x]
-    (.format "This is the local version of `nonlocal-test-macro` returning {}!" (int x)))
-
-  (assert (= "This is the local version of `nonlocal-test-macro` returning 3!"
+  (assert (= "This is the home version of `remote-test-macro` returning 3!"
              (test-module-macro-2 3))))
 
 

--- a/tests/native_tests/import.hy
+++ b/tests/native_tests/import.hy
@@ -111,15 +111,15 @@
     (brother 1 2 3 4)))
 
 
-(defn test-relative-require []
-  (require ..resources.macros [test-macro])
-  (assert (in "test_macro" _hy_macros))
+(require
+  ..resources.macros [test-macro-2]
+  .beside [xyzzy]
+  . [beside :as BS])
 
-  (require .beside [xyzzy])
+(defn test-require-global-relative []
+  (assert (in "test_macro_2" _hy_macros))
   (assert (in "xyzzy" _hy_macros))
-
-  (require . [beside :as b])
-  (assert (in "b.xyzzy" _hy_macros)))
+  (assert (in "BS.xyzzy" _hy_macros)))
 
 
 ;; `remote-test-macro` is a macro used within

--- a/tests/native_tests/macros.hy
+++ b/tests/native_tests/macros.hy
@@ -167,10 +167,12 @@
                (wrap-error-test))))
   (assert (in "HyWrapperError" (str excinfo.value))))
 
+
+(defmacro delete-me [] "world")
+
 (defn test-delmacro
   []
   ;; test deletion of user defined macro
-  (defmacro delete-me [] "world")
   (delmacro delete-me)
   (with [exc (pytest.raises NameError)]
     (delete-me))

--- a/tests/native_tests/macros_local.hy
+++ b/tests/native_tests/macros_local.hy
@@ -1,0 +1,54 @@
+"Tests of local macro definitions."
+
+
+(defn test-nonleaking []
+  (defn fun []
+    (defmacro helper []
+      "helper macro in fun")
+    (helper))
+  (defclass C []
+    (defmacro helper []
+      "helper macro in class")
+    (setv attribute (helper)))
+  (defn helper []
+    "helper function")
+  (assert (= (helper) "helper function"))
+  (assert (= (fun) "helper macro in fun"))
+  (assert (= C.attribute "helper macro in class"))
+  (assert (=
+    (lfor
+      x [1 2 3]
+      :do (defmacro helper []
+        "helper macro in lfor")
+      y [1 2 3]
+      (if (= x y 2) (helper) (+ (* x 10) y)))
+    [11 12 13 21 "helper macro in lfor" 23 31 32 33]))
+  (assert (= (helper) "helper function")))
+
+
+(defmacro shadowable []
+  "global version")
+
+(defn test-shadowing-global []
+  (defn inner []
+    (defmacro shadowable []
+      "local version")
+    (shadowable))
+  (assert (= (shadowable) "global version"))
+  (assert (= (inner) "local version"))
+  (assert (= (shadowable) "global version")))
+
+
+(defn test-nested-local-shadowing []
+  (defn inner1 []
+    (defmacro shadowable []
+      "local version 1")
+    (defn inner2 []
+      (defmacro shadowable []
+        "local version 2")
+       (shadowable))
+    [(inner2) (shadowable)])
+  (assert (= (shadowable) "global version"))
+  (print (inner1))
+  (assert (= (inner1) ["local version 2" "local version 1"]))
+  (assert (= (shadowable) "global version")))

--- a/tests/native_tests/macros_local.hy
+++ b/tests/native_tests/macros_local.hy
@@ -1,4 +1,4 @@
-"Tests of local macro definitions."
+"Tests of local `defmacro` and `require`."
 
 
 (defn test-nonleaking []
@@ -52,3 +52,24 @@
   (print (inner1))
   (assert (= (inner1) ["local version 2" "local version 1"]))
   (assert (= (shadowable) "global version")))
+
+
+(defmacro local-require-test [arg] `(do
+  (defmacro wiz []
+    "local wiz")
+
+  (defn fun []
+    (require tests.resources.local-req-example ~arg)
+    [(get-wiz) (helper)])
+  (defn helper []
+    "local helper function")
+
+  (assert (= [(wiz) (helper)] ["local wiz" "local helper function"]))
+  (assert (= (fun) ["remote wiz" "remote helper macro"]))
+  (assert (= [(wiz) (helper)] ["local wiz" "local helper function"]))))
+
+(defn test-require []
+  (local-require-test [get-wiz helper]))
+
+(defn test-require-star []
+  (local-require-test *))

--- a/tests/native_tests/macros_local.hy
+++ b/tests/native_tests/macros_local.hy
@@ -54,6 +54,19 @@
   (assert (= (shadowable) "global version")))
 
 
+(defmacro one-plus-two []
+  '(+ 1 2))
+
+(defn test-local-macro-in-expansion-of-nonlocal []
+  (defn f []
+    (defmacro + [a b]
+      "Shadow the core macro `+`. #yolo"
+      `f"zomg! {~a} {~b}")
+    (one-plus-two))
+  (assert (= (f) "zomg! 1 2"))
+  (assert (= (one-plus-two) 3)))
+
+
 (defmacro local-require-test [arg] `(do
   (defmacro wiz []
     "local wiz")

--- a/tests/resources/local_req_example.hy
+++ b/tests/resources/local_req_example.hy
@@ -1,0 +1,6 @@
+(defmacro wiz []
+  "remote wiz")
+(defmacro get-wiz []
+  (wiz))
+(defmacro helper []
+  "remote helper macro")

--- a/tests/resources/macro_with_require.hy
+++ b/tests/resources/macro_with_require.hy
@@ -4,11 +4,11 @@
 
 (defmacro test-module-macro [a]
   "The variable `macro-level-var' here should not bind to the same-named symbol
-in the expansion of `nonlocal-test-macro'."
+in the expansion of `remote-test-macro'."
   (setv macro-level-var "tests.resources.macros.macro-with-require")
-  `(nonlocal-test-macro ~a))
+  `(remote-test-macro ~a))
 
 (defmacro test-module-macro-2 [a]
-  "The macro `local-test-macro` isn't in this module's namespace, so it better
+  "The macro `home-test-macro` isn't in this module's namespace, so it better
  be in the expansion's!"
-  `(local-test-macro ~a))
+  `(home-test-macro ~a))

--- a/tests/resources/macros.hy
+++ b/tests/resources/macros.hy
@@ -6,7 +6,7 @@
 (defmacro test-macro-2 []
   '(setv qup 2))
 
-(defmacro nonlocal-test-macro [x]
+(defmacro remote-test-macro [x]
   "When called from `macro-with-require`'s macro(s), the first instance of
 `module-name-var` should resolve to the value in the module where this is
 defined, then the expansion namespace/module"

--- a/tests/resources/more_test_macros.hy
+++ b/tests/resources/more_test_macros.hy
@@ -1,0 +1,8 @@
+(defmacro bairn [#* tree]
+  `[14 ~@tree])
+
+(defmacro cairn [ #* tree]
+  `[15 ~@tree])
+
+(defmacro _dairn []
+  `[16 ~@tree])


### PR DESCRIPTION
- Closes #900

I haven't added support for local macros to other parts of the language (like `hy.eval`) in lieu of a more comprehensive approach to macros as first-class objects (#1467), which I'd like to do soon. Similarly, I haven't polished the documentation because I'd like to do that as part of a larger overhaul of, and content addition for, macro-related documentation (#2484).