### PR TITLE
Fix comments in the index and why Hy documents

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,8 +14,8 @@ Hy is a Lisp dialect that's embedded in Python. Since Hy transforms its Lisp
 code into Python abstract syntax tree (AST) objects, you have the whole
 beautiful world of Python at your fingertips, in Lisp form.
 
-..
-   Changes to this paragraph should be mirrored on Hy's homepage.
+.. Changes to this paragraph should be mirrored on Hy's homepage.
+
 To install the latest release of Hy, just use the command ``pip3 install
 --user hy``. Then you can start an interactive read-eval-print loop (REPL) with
 the command ``hy``, or run a Hy program with ``hy myprogram.hy``.

--- a/docs/whyhy.rst
+++ b/docs/whyhy.rst
@@ -2,8 +2,8 @@
 Why Hy?
 =======
 
-..
-   Changes to this paragraph should be mirrored on Hy's homepage.
+.. Changes to this paragraph should be mirrored on Hy's homepage.
+
 Hy (or "Hylang" for long; named after the insect order Hymenoptera,
 since Paul Tagliamonte was studying swarm behavior when he created the
 language) is a multi-paradigm general-purpose programming language in


### PR DESCRIPTION
This is to avoid the following warnings when building the documentation

    Explicit markup ends without a blank line; unexpected unindent.