### PR TITLE
Automatically promote `nonlocal` as needed

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -36,6 +36,7 @@ New Features
 * `HyReader` now has an optional parameter to install existing
   reader macros from the calling module.
 * New pragma `warn-on-core-shadow`.
+* `nonlocal` now also works for globally defined names.
 
 Misc. Improvements
 ------------------------------
@@ -53,6 +54,7 @@ Bug Fixes
   install a new reader.
 * `require` now warns when you shadow a core macro, like `defmacro`
   already did.
+* `nonlocal` now works for top-level `let`-bound names.
 
 0.27.0 (released 2023-07-06)
 =============================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -797,7 +797,22 @@ base names, such that ``hy.core.macros.foo`` can be called as just ``foo``.
 
 .. hy:macro:: (nonlocal [#* syms])
 
-   As :hy:func:`global`, but the result is a :py:keyword:`nonlocal` statement.
+   Similar to :hy:func:`global`, but names can be declared in any enclosing
+   scope. ``nonlocal`` compiles to a :py:keyword:`global` statement for any
+   names originally defined in the global scope, and a :py:keyword:`nonlocal`
+   statement for all other names. ::
+
+       (setv  a 1  b 1)
+       (defn f []
+         (setv  c 10  d 10)
+         (defn g []
+           (nonlocal a c)
+           (setv  a 2  b 2
+                  c 20 d 20))
+         (print a b c d)  ; => 1 1 10 10
+         (g)
+         (print a b c d)) ; => 2 1 20 10
+       (f)
 
 .. hy:macro:: (py [string])
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -35,7 +35,7 @@ from hy.models import (
     is_unpack,
 )
 from hy.reader import mangle, HyReader
-from hy.scoping import ScopeGlobal
+from hy.scoping import ResolveOuterVars, ScopeGlobal
 
 hy_ast_compile_flags = 0
 
@@ -859,6 +859,8 @@ def hy_compile(
 
     if not get_expr:
         result += result.expr_as_stmt()
+
+    result.stmts = list(map(ResolveOuterVars().visit, result.stmts))
 
     body = []
 

--- a/tests/native_tests/let.hy
+++ b/tests/native_tests/let.hy
@@ -290,6 +290,20 @@
     (assert (= fox 42))))
 
 
+(defn test-top-level-let-nonlocal []
+  (hy.eval '(do
+              (let [my-fuel 50]
+                (defn propulse-me [distance]
+                  (nonlocal my-fuel)
+                  (-= my-fuel distance))
+                (defn check-fuel []
+                  my-fuel))
+              (assert (= (check-fuel) 50))
+              (propulse-me 3)
+              (assert (= (check-fuel) 47)))
+           :globals {}))
+
+
 (defn test-let-nested-nonlocal []
   (let [fox 42]
     (defn bar []

--- a/tests/native_tests/nonlocal.hy
+++ b/tests/native_tests/nonlocal.hy
@@ -1,0 +1,48 @@
+(import pytest)
+
+
+(defn test-nonlocal-promotion []
+  (setv G {})
+  (hy.eval '(do
+              (setv home "earth")
+              (defn blastoff []
+                (nonlocal home)
+                (setv home "saturn"))
+              (blastoff))
+           :globals G)
+  (assert (= (get G "home") "saturn"))
+
+  (setv health
+        (hy.eval '(do
+                    (defn make-ration-log [days intensity]
+                      (setv health 20
+                            ration-log
+                            (list (map (fn [_]
+                                         ;; only `rations` should be upgraded
+                                         (nonlocal rations health)
+                                         (-= rations intensity)
+                                         (+= health (* 0.5 intensity))
+                                         rations)
+                                       (range days))))
+                      health)
+                    ;; "late" global binding should still work
+                    (setv rations 100)
+                    (make-ration-log 43 1.5))
+                 :globals G))
+  (assert (= health (+ 20 (* 43 0.5 1.5))))
+  (assert (= (get G "rations") (- 100 (* 43 1.5)))))
+
+
+(defn test-nonlocal-must-have-def []
+  (with [err (pytest.raises SyntaxError)]
+    (hy.eval '(do
+                (defn make-ration-log [days intensity]
+                  (list (map (fn [_]
+                               (nonlocal rations)
+                               (-= rations intensity)
+                               rations)
+                             (range days))))
+                ;; oops! I forgot to pack my rations!
+                (make-ration-log 43 1.5))
+             :globals {}))
+  (assert (in "no binding for nonlocal 'rations'" err.value.msg)))


### PR DESCRIPTION
Promote `nonlocal` declarations to `global` ones if the "nearest" matching definition is in the global scope.

Also addresses #2507; can be considered a fix if we decide that the explicit-`nonlocal` formulation is the proper way to do things.