### PR TITLE
Make `hy -i <filename>` skip shebang line

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -55,6 +55,7 @@ Bug Fixes
 * `require` now warns when you shadow a core macro, like `defmacro`
   already did.
 * `nonlocal` now works for top-level `let`-bound names.
+* `hy -i` with a filename now skips shebang lines.
 
 0.27.0 (released 2023-07-06)
 =============================

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -261,12 +261,14 @@ def cmdline_handler(argv):
         runpy.run_module(hy.mangle(action_arg), run_name="__main__", alter_sys=True)
         return 0
     elif action == "run_script_stdin":
+        sys.argv = argv
         if repl:
             source = sys.stdin
             filename = 'stdin'
         else:
             return run_command(sys.stdin.read(), filename="<stdin>")
     elif action == "run_script_file":
+        sys.argv = argv
         filename = Path(action_arg)
         set_path(filename)
         # Ensure __file__ is set correctly in the code we're about
@@ -278,9 +280,9 @@ def cmdline_handler(argv):
                 filename = os.path.normpath(filename)
         if repl:
             source = Path(filename).read_text()
+            repl.compile.compiler.skip_next_shebang = True
         else:
             try:
-                sys.argv = argv
                 with filtered_hy_exceptions():
                     runhy.run_path(str(filename), run_name="__main__")
                 return 0

--- a/hy/repl.py
+++ b/hy/repl.py
@@ -118,6 +118,7 @@ class HyCompile(codeop.Compile):
         self.ast_callback = ast_callback
         self.hy_compiler = hy_compiler
         self.reader = HyReader()
+        self.skip_next_shebang = False
 
         super().__init__()
 
@@ -165,8 +166,10 @@ class HyCompile(codeop.Compile):
             self.hy_compiler.filename = name
             self.hy_compiler.source = source
             hy_ast = read_many(
-                source, filename=name, reader=self.reader
+                source, filename=name, reader=self.reader,
+                skip_shebang=self.skip_next_shebang,
             )
+            self.skip_next_shebang = False
             exec_ast, eval_ast = hy_compile(
                 hy_ast,
                 self.module,

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -202,6 +202,13 @@ def test_icmd_file():
     assert "CUTTLEFISH" in output
 
 
+def test_icmd_shebang(tmp_path):
+    (tmp_file := tmp_path / 'icmd_with_shebang.hy').write_text('#!/usr/bin/env hy\n(setv order "Sepiida")')
+    output, error = run_cmd(["hy", "-i", tmp_file], '(.upper order)')
+    assert "#!/usr/bin/env" not in error
+    assert "SEPIIDA" in output
+
+
 def test_icmd_and_spy():
     output, _ = run_cmd('hy --spy -i -c "(+ [] [])"', "(+ 1 1)")
     assert "[] + []" in output
@@ -221,6 +228,14 @@ def test_missing_file():
 
 def test_file_with_args():
     cmd = "hy tests/resources/argparse_ex.hy"
+    assert "usage" in run_cmd(f"{cmd} -h")[0]
+    assert "got c" in run_cmd(f"{cmd} -c bar")[0]
+    assert "foo" in run_cmd(f"{cmd} -i foo")[0]
+    assert "foo" in run_cmd(f"{cmd} -i foo -c bar")[0]
+
+
+def test_ifile_with_args():
+    cmd = "hy -i tests/resources/argparse_ex.hy"
     assert "usage" in run_cmd(f"{cmd} -h")[0]
     assert "got c" in run_cmd(f"{cmd} -c bar")[0]
     assert "foo" in run_cmd(f"{cmd} -i foo")[0]


### PR DESCRIPTION
Also sets `sys.argv` as `python3 -i <filename>` does.