### PR TITLE
Add `local-macros` and extend `hy.eval` and `hy.macroexpand`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -31,6 +31,7 @@ Breaking Changes
   the same `sys.path` rules as Python when parsing a module
   vs a standalone script.
 * New macro `deftype`.
+* New macro `get-macro`.
 
 New Features
 ------------------------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -32,6 +32,7 @@ Breaking Changes
   vs a standalone script.
 * New macro `deftype`.
 * New macro `get-macro`.
+* New macro `local-macros`.
 
 New Features
 ------------------------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -17,14 +17,13 @@ Breaking Changes
 
 * `defmacro` and `require` can now define macros locally instead of
   only module-wide.
-
-  * `hy.macroexpand` doesn't work with local macros (yet).
-
 * When a macro is `require`\d from another module, that module is no
   longer implicitly included when checking for further macros in
   the expansion.
 * `hy.eval` has been overhauled to be more like Python's `eval`. It
   also has a new parameter `macros`.
+* `hy.macroexpand` and `hy.macroexpand-1` have been overhauled and
+  generalized to include more of the features of `hy.eval`.
 * `hy` now only implicitly launches a REPL if standard input is a TTY.
 * `hy -i` has been overhauled to work as a flag like `python3 -i`.
 * `hy2py` now requires `-m` to specify modules, and uses
@@ -63,6 +62,8 @@ Bug Fixes
 * `nonlocal` now works for top-level `let`-bound names.
 * `hy -i` with a filename now skips shebang lines.
 * Implicit returns are now disabled in async generators.
+* The parameter `result-ok` that was mistakenly included in the
+  signature of `hy.macroexpand` is now gone.
 
 0.27.0 (released 2023-07-06)
 =============================

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,13 +18,13 @@ Breaking Changes
 * `defmacro` and `require` can now define macros locally instead of
   only module-wide.
 
-  * `hy.eval` and `hy.macroexpand` don't work with
-    local macros (yet).
+  * `hy.macroexpand` doesn't work with local macros (yet).
 
 * When a macro is `require`\d from another module, that module is no
   longer implicitly included when checking for further macros in
   the expansion.
-* `hy.eval` has been overhauled to be more like Python's `eval`.
+* `hy.eval` has been overhauled to be more like Python's `eval`. It
+  also has a new parameter `macros`.
 * `hy` now only implicitly launches a REPL if standard input is a TTY.
 * `hy -i` has been overhauled to work as a flag like `python3 -i`.
 * `hy2py` now requires `-m` to specify modules, and uses

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -5,7 +5,7 @@ Macros
 Operations on macros
 --------------------
 
-The currently defined global macros can be accessed as a dictionary ``_hy_macros`` in each module. (Use ``bulitins._hy_macros``, attached to Python's usual :py:mod:`builtins` module, to see core macros.) The keys are mangled macro names and the values are the function objects that implement the macros. You can operate on this dictionary to list, add, delete, or get help on macros, but be sure to use :hy:func:`eval-and-compile` or :hy:func:`eval-when-compile` when you need the effect to happen at compile-time. The core macro :hy:func:`get-macro <hy.core.macros.get-macro>` provides some syntactic sugar. ::
+The currently defined global macros can be accessed as a dictionary ``_hy_macros`` in each module. (Use ``bulitins._hy_macros``, attached to Python's usual :py:mod:`builtins` module, to see core macros.) The keys are mangled macro names and the values are the function objects that implement the macros. You can operate on this dictionary to list, add, delete, or get help on macros, but be sure to use :hy:func:`eval-and-compile` or :hy:func:`eval-when-compile` when you need the effect to happen at compile-time. You can call :hy:func:`local-macros <hy.core.macros.local-macros>` to list local macros, but adding or deleting elements in this case is ineffective. The core macro :hy:func:`get-macro <hy.core.macros.get-macro>` provides some syntactic sugar. ::
 
     (defmacro m []
       "This is a docstring."
@@ -17,7 +17,7 @@ The currently defined global macros can be accessed as a dictionary ``_hy_macros
       (del (get _hy_macros "m")))
     (m)                           ; => NameError
 
-``_hy_reader_macros`` is a similar dictionary for reader macros, but here, the keys aren't mangled.
+``_hy_reader_macros`` is a dictionary like ``_hy_macros`` for reader macros, but here, the keys aren't mangled.
 
 .. _using-gensym:
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -114,29 +114,32 @@
 
 
 (defmacro get-macro [arg1 [arg2 None]]
-  "Get the function object used to implement a macro. This works for core macros, global (i.e., module-level) macros, and reader macros, but not local macros (yet). For regular macros, ``get-macro`` is called with one argument, a symbol or string literal, which can be premangled or not according to taste. For reader macros, this argument must be preceded by the literal keyword ``:reader`` (and note that the hash mark, ``#``, is not included in the name of the reader macro). ::
+  "Get the function object used to implement a macro. This works for all sorts of macros: core macros, global (i.e., module-level) macros, local macros, and reader macros. For regular (non-reader) macros, ``get-macro`` is called with one argument, a symbol or string literal, which can be premangled or not according to taste. For reader macros, this argument must be preceded by the literal keyword ``:reader`` (and note that the hash mark, ``#``, is not included in the name of the reader macro). ::
 
     (get-macro my-macro)
     (get-macro :reader my-reader-macro)
 
-  ``get-macro`` expands to a :hy:func:`get <hy.pyops.get>` form on the appropriate object, such as ``_hy_macros``, selected at the time of expanding ``get-macro``. This means you can say ``(del (get-macro …))``, perhaps wrapped in :hy:func:`eval-and-compile` or :hy:func:`eval-when-compile`, to delete a macro, but it's easy to get confused by the order of evaluation and number of evaluations. For more predictable results in complex situations, use ``(del (get …))`` directly instead of ``(del (get-macro …))``."
+  Except when retrieving a local macro, ``get-macro`` expands to a :hy:func:`get <hy.pyops.get>` form on the appropriate object, such as ``_hy_macros``, selected at the time of expanding ``get-macro``. This means you can say ``(del (get-macro …))``, perhaps wrapped in :hy:func:`eval-and-compile` or :hy:func:`eval-when-compile`, to delete a macro, but it's easy to get confused by the order of evaluation and number of evaluations. For more predictable results in complex situations, use ``(del (get …))`` directly instead of ``(del (get-macro …))``."
 
   (import builtins)
-  (setv [name namespace] (cond
+  (setv [name reader?] (cond
     (= arg1 ':reader)
-      [(str arg2) "_hy_reader_macros"]
+      [(str arg2) True]
     (isinstance arg1 hy.models.Expression)
-      [(hy.mangle (.join "." (cut arg1 1 None))) "_hy_macros"]
+      [(hy.mangle (.join "." (cut arg1 1 None))) False]
     True
-      [(hy.mangle arg1) "_hy_macros"]))
+      [(hy.mangle arg1) False]))
+  (setv namespace (if reader? "_hy_reader_macros" "_hy_macros"))
   (cond
+    (and (not reader?) (setx local (.get (_local-macros &compiler) name)))
+      local
     (in name (getattr &compiler.module namespace {}))
       `(get ~(hy.models.Symbol namespace) ~name)
     (in name (getattr builtins namespace {}))
       `(get (. hy.M.builtins ~(hy.models.Symbol namespace)) ~name)
     True
       (raise (NameError (.format "no such {}macro: {!r}"
-        (if (= namespace "_hy_reader_macros") "reader " "")
+        (if reader? "reader " "")
         name)))))
 
 

--- a/hy/core/macros.hy
+++ b/hy/core/macros.hy
@@ -140,6 +140,31 @@
         name)))))
 
 
+(defmacro local-macros []
+  #[[Expands to a dictionary mapping the mangled names of local macros to the function objects used to implement those macros. Thus, ``local-macros`` provides a rough local equivalent of ``_hy_macros``. ::
+
+      (defn f []
+        (defmacro m []
+          "This is the docstring for the macro `m`."
+          1)
+        (help (get (local-macros) "m")))
+      (f)
+
+  The equivalency is rough in the sense that ``local-macros`` returns a literal dictionary, not a preexisting object that Hy uses for resolving macro names. So, modifying the dictionary will have no effect.
+
+  See also :hy:func:`get-macro <hy.core.macros.get-macro>`.]]
+  (_local-macros &compiler))
+
+(defn _local_macros [&compiler]
+  (setv seen #{})
+  (dfor
+    state &compiler.local_state_stack
+    m (get state "macros")
+    :if (not-in m seen)
+    :do (.add seen m)
+    m (hy.models.Symbol (hy.macros.local-macro-name m))))
+
+
 (defmacro export [#* args]
   "A convenience macro for defining ``__all__`` and ``_hy_export_macros``, which
   control which Python objects and macros (respectively) are collected by ``*``

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -385,9 +385,11 @@ def macroexpand(tree, module, compiler=None, once=False, result_ok=True):
 
         # Choose the first namespace with the macro.
         m = ((compiler and next(
-                (d['macros'][fn]
-                    for d in reversed(compiler.local_state_stack)
-                    if fn in d['macros']),
+                (d[fn]
+                    for d in [
+                        compiler.extra_macros,
+                        *(s['macros'] for s in reversed(compiler.local_state_stack))]
+                    if fn in d),
                 None)) or
             next(
                 (mod._hy_macros[fn]

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -415,12 +415,6 @@ def macroexpand(tree, module, compiler=None, once=False, result_ok=True):
     return tree
 
 
-def macroexpand_1(tree, module, compiler=None):
-    """Expand the toplevel macro from `tree` once, in the context of
-    `compiler`."""
-    return macroexpand(tree, module, compiler, once=True)
-
-
 def rename_function(f, new_name):
     """Create a copy of a function, but with a new name."""
     f = type(f)(

--- a/tests/macros/test_macro_processor.py
+++ b/tests/macros/test_macro_processor.py
@@ -2,7 +2,7 @@ import pytest
 
 from hy.compiler import HyASTCompiler
 from hy.errors import HyMacroExpansionError
-from hy.macros import macro, macroexpand, macroexpand_1
+from hy.macros import macro, macroexpand
 from hy.models import Expression, Float, List, String, Symbol
 from hy.reader import read
 
@@ -58,6 +58,6 @@ def test_macroexpand_source_data():
     ast = Expression([Symbol("when"), String("a")])
     ast.start_line = 3
     ast.start_column = 5
-    bad = macroexpand_1(ast, "hy.core.macros")
+    bad = macroexpand(ast, "hy.core.macros", once = True)
     assert bad.start_line == 3
     assert bad.start_column == 5

--- a/tests/native_tests/hy_misc.hy
+++ b/tests/native_tests/hy_misc.hy
@@ -22,10 +22,30 @@
 
 
 (defn test-macroexpand []
-  (assert (= (hy.macroexpand '(mac (a b) (x y)))
-             '(x y (a b))))
-  (assert (= (hy.macroexpand '(mac (a b) (mac 5)))
-             '(a b 5))))
+  (assert (=
+    (hy.macroexpand '(mac (a b) (x y)))
+    '(x y (a b))))
+  (assert (=
+    (hy.macroexpand '(mac (a b) (mac 5)))
+    '(a b 5)))
+  (assert (=
+    (hy.macroexpand '(qplah "phooey") :module hy.M.tests.resources.tlib)
+    '[8 "phooey"]))
+  (assert (=
+    (hy.macroexpand '(chippy 1) :macros
+      {"chippy" (fn [&compiler x] `[~x ~x])})
+    '[1 1]))
+  ; Non-Expressions just get returned as-is.
+  (defn f [])
+  (assert (is
+    (hy.macroexpand f)
+    f))
+  ; If the macro expands to a `Result`, the user gets the original
+  ; back instead of the `Result`.
+  (setv model '(+ 1 1))
+  (assert (is
+    (hy.macroexpand model)
+    model)))
 
 
 (defmacro m-with-named-import []

--- a/tests/native_tests/macros_first_class.hy
+++ b/tests/native_tests/macros_first_class.hy
@@ -81,3 +81,23 @@ deleting them, and retrieving their docstrings. We also test `get-macro`
 (defn test-global-shadowing-builtin []
   (assert (= div1 "1/2"))
   (assert (= div2 0.5)))
+
+;; * Local macros
+
+(defn test-local-get []
+  (defmacro local1 [] "local1 doc" 1)
+  (defmacro local2 [] "local2 outer" 2)
+  (require tests.resources.local-req-example :as LRE)
+
+  (assert (= (. (get-macro local1) __doc__) "local1 doc"))
+  (assert (= (. (get-macro local2) __doc__) "local2 outer"))
+  (assert (= (. (get-macro LRE.wiz) __doc__) "remote wiz doc"))
+
+  (defn inner []
+    (defmacro local2 [] "local2 inner" 2)
+    (defmacro local3 [] "local3 doc" 2)
+    (assert (= (. (get-macro local2) __doc__) "local2 inner"))
+    (assert (= (. (get-macro local3) __doc__) "local3 doc"))
+    (assert (= (. (get-macro LRE.wiz) __doc__) "remote wiz doc")))
+
+  (inner))

--- a/tests/resources/local_req_example.hy
+++ b/tests/resources/local_req_example.hy
@@ -1,6 +1,8 @@
 (defmacro wiz []
+  "remote wiz doc"
   "remote wiz")
 (defmacro get-wiz []
   (wiz))
 (defmacro helper []
+  "remote helper doc"
   "remote helper macro")


### PR DESCRIPTION
- Closes #1467

Now the user can list local macros and get local-macro objects. I've decided it's best not to try to implement adding or deleting local macros dynamically, since that seems messy and of dubious value. So the situation is similar to ordinary variables in Python: the global set is completely dynamic, while the local set is fixed at runtime.

[Edit: the following turned out to be easy enough, so I just added it to this PR.] Next up is allowing `hy.eval` to use local macros, perhaps as part of a general faculty to allow the user to pass in a dictionary of macros. Next, perhaps, some extensions to `hy.macroexpand` and `hy.macroexpand-1` to control what set of macros they use.