### PR TITLE
Fix non-interactive with param -i in subprocess

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -110,3 +110,4 @@
 * Andrey Vlasovskikh <andrey.vlasovskikh@gmail.com>
 * Joseph LaFreniere <joseph@lafreniere.xyz>
 * Daniel Tan <danieltanfh95@gmail.com>
+* Zhan Tang <tz59pk@gmail.com>

--- a/hy/cmdline.py
+++ b/hy/cmdline.py
@@ -262,10 +262,7 @@ def cmdline_handler(argv):
         return 0
     elif action == "run_script_stdin":
         sys.argv = argv
-        if repl:
-            source = sys.stdin
-            filename = 'stdin'
-        else:
+        if not repl:
             return run_command(sys.stdin.read(), filename="<stdin>")
     elif action == "run_script_file":
         sys.argv = argv

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -79,6 +79,10 @@ def test_stdin():
     assert "RS" in out
     assert "TU" in out
 
+    # With it, the REPL variable must exists, like ps1
+    out, _ = run_cmd("hy -i", '(import sys) (bool (getattr sys "ps1" sys.flags.interactive))')
+    assert "True" in out
+
 
 def test_error_parts_length():
     """Confirm that exception messages print arrows surrounding the affected


### PR DESCRIPTION
continue #2555 .
When I use the -i parameter to force the launch of the REPL and send code in subprocess (using nvim conjure), it directly enters the repl.runsource block for execution and never enters repl.run(). In this case, the current environment is not the REPL environment, lacking the PS1, PS2 prompts, and some other REPL-specific environment settings, which contradicts the meaning of the -i parameter. On the other hand, other branches execute code first, such as from a file, before entering repl.run().