### PR TITLE
Overhaul rendering of the manual

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,15 @@
+div.body, div.footer, code, div.code-block-caption,
+div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6,
+a.toc-backref
+   {color: black}
+
+div.body p, div.body dd, div.body li, div.body blockquote
+   {hyphens: manual}
+
+a
+   {color: navy}
+a:visited
+   {color: purple}
+
+code
+   {background-color: #dfd}

--- a/docs/_static/overrides.css
+++ b/docs/_static/overrides.css
@@ -1,5 +1,0 @@
-.rst-content table.docutils td {vertical-align: top; padding: 6px 16px; line-height: 20px}
-.wy-table-responsive table td {white-space: normal}
-.wy-table-responsive table td:first-child {white-space: nowrap}
-.rst-content code.xref {color: #2E7FB3; font-size: 90%;
-                        padding: 0px 2px; border: none; background: none; line-height: 20px}

--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,5 +1,0 @@
-{% extends "!breadcrumbs.html" %}
-{% block breadcrumbs_aside %}
-  <li style="margin-left: 1em">Hy version {{ hy_descriptive_version }}</li>
-  {{ super() }}
-{% endblock %}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,9 @@
 API
 ===
 
+.. contents:: Contents
+   :local:
+
 .. _core-macros:
 
 Core Macros

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,6 +4,9 @@ Command-Line Interface
 
 Hy provides a handful of command-line programs for working with Hy code.
 
+.. contents:: Contents
+   :local:
+
 .. _hy-cli:
 
 hy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_static_path = ["_static"]
 
 html_use_smartypants = False
+html_copy_source = False
 html_show_sphinx = False
 
 html_context = dict(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,9 +21,6 @@ for c in (SD.RemovedInSphinx60Warning, SD.RemovedInSphinx70Warning):
 
 from get_version import __version__ as hy_version
 
-# Read the Docs might dirty its checkout, so strip the dirty flag.
-hy_version = re.sub(r"[+.]dirty\Z", "", hy_version)
-
 source_suffix = ".rst"
 
 master_doc = "index"
@@ -41,9 +38,6 @@ copyright = "%s the authors" % time.strftime("%Y")
 version = ".".join(hy_version.split(".")[:-1])
 # The full version, including alpha/beta/rc tags.
 release = hy_version
-hy_descriptive_version = html.escape(hy_version)
-if "+" in hy_version:
-    hy_descriptive_version += " <strong style='color: red;'>(unstable)</strong>"
 
 exclude_patterns = ["_build", "coreteam.rst"]
 add_module_names = True
@@ -63,9 +57,6 @@ html_static_path = ["_static"]
 html_use_smartypants = False
 html_copy_source = False
 html_show_sphinx = False
-
-html_context = dict(
-    hy_descriptive_version=hy_descriptive_version)
 
 highlight_language = "hylang"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,13 +24,13 @@ from get_version import __version__ as hy_version
 # Read the Docs might dirty its checkout, so strip the dirty flag.
 hy_version = re.sub(r"[+.]dirty\Z", "", hy_version)
 
-templates_path = ["_templates"]
 source_suffix = ".rst"
 
 master_doc = "index"
+html_title = f'Hy {hy_version} manual'
 
 # General information about the project.
-project = "hy"
+project = "Hy"
 copyright = "%s the authors" % time.strftime("%Y")
 
 # The version info for the project you're documenting, acts as replacement for
@@ -48,12 +48,12 @@ if "+" in hy_version:
 exclude_patterns = ["_build", "coreteam.rst"]
 add_module_names = True
 
-pygments_style = "sphinx"
-
-import sphinx_rtd_theme
-
-html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "nature"
+html_theme_options = dict(
+    nosidebar = True,
+    body_min_width = 0,
+    body_max_width = 'none')
+html_css_files = ['custom.css']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -76,10 +76,3 @@ intersphinx_mapping = dict(
 
 import hy
 hy.I = type(hy.I)  # A trick to enable `hy:autoclass:: hy.I`
-
-
-# ** Sphinx App Setup
-
-
-def setup(app):
-    app.add_css_file("overrides.css")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autodoc",
-    "sphinx.ext.viewcode",
     "sphinxcontrib.hydomain",
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,19 +1,14 @@
-# This file is execfile()d with the current directory set to its containing dir.
+import os, re, sys, time, html
 
-import html
-import os
-import re
-import sys
-import time
+sys.path.insert(0, os.path.abspath('..'))
 
-sys.path.insert(0, os.path.abspath(".."))
+import hy; hy.I = type(hy.I)  # A trick to enable `hy:autoclass:: hy.I`
 
 extensions = [
-    "sphinx.ext.napoleon",
-    "sphinx.ext.intersphinx",
-    "sphinx.ext.autodoc",
-    "sphinxcontrib.hydomain",
-]
+    'sphinx.ext.napoleon',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.autodoc',
+    'sphinxcontrib.hydomain']
 
 import warnings; import sphinx.deprecation as SD
 for c in (SD.RemovedInSphinx60Warning, SD.RemovedInSphinx70Warning):
@@ -21,49 +16,33 @@ for c in (SD.RemovedInSphinx60Warning, SD.RemovedInSphinx70Warning):
 
 from get_version import __version__ as hy_version
 
-source_suffix = ".rst"
-
-master_doc = "index"
+project = 'Hy'
+copyright = '%s the authors' % time.strftime('%Y')
 html_title = f'Hy {hy_version} manual'
-
-# General information about the project.
-project = "Hy"
-copyright = "%s the authors" % time.strftime("%Y")
-
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-# The short X.Y version.
-version = ".".join(hy_version.split(".")[:-1])
-# The full version, including alpha/beta/rc tags.
+version = '.'.join(hy_version.split('.')[:-1])
+  # The short dotted version identifier
 release = hy_version
+  # The full version identifier, including alpha, beta, and RC tags
 
-exclude_patterns = ["_build", "coreteam.rst"]
-add_module_names = True
+source_suffix = '.rst'
+master_doc = 'index'
+exclude_patterns = ['_build', 'coreteam.rst']
 
-html_theme = "nature"
+html_theme = 'nature'
 html_theme_options = dict(
     nosidebar = True,
     body_min_width = 0,
     body_max_width = 'none')
 html_css_files = ['custom.css']
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
-
+html_static_path = ['_static']
 html_use_smartypants = False
 html_copy_source = False
 html_show_sphinx = False
 
-highlight_language = "hylang"
+add_module_names = True
+
+highlight_language = 'hylang'
 
 intersphinx_mapping = dict(
-    py=("https://docs.python.org/3/", None),
-    hyrule=("https://hyrule.readthedocs.io/en/master/", None),
-)
-
-import hy
-hy.I = type(hy.I)  # A trick to enable `hy:autoclass:: hy.I`
+    py = ('https://docs.python.org/3/', None),
+    hyrule = ('https://hyrule.readthedocs.io/en/master/', None))

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -4,6 +4,9 @@
  Developing Hy
 ===============
 
+.. contents:: Contents
+   :local:
+
 .. include:: ../CONTRIBUTING.rst
 
 Core Team

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-The Hy Manual
-=============
+Contents
+========
 
 .. image:: _static/hy-logo-small.png
    :alt: Hy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ To install the latest release of Hy, just use the command ``pip3 install
 the command ``hy``, or run a Hy program with ``hy myprogram.hy``.
 
 Hy is tested on all released and currently maintained versions of CPython (on
-Linux and Windows), and on recent versions of PyPy and Pyodide.
+Linux, Windows, and Mac OS), and on recent versions of PyPy and Pyodide.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/interop.rst
+++ b/docs/interop.rst
@@ -10,6 +10,9 @@ Hy and Python. For example, Python's ``str.format_map`` can be written
 ``hyx_valid_Xquestion_markX`` in Python. You can call :hy:func:`hy.mangle` and
 :hy:func:`hy.unmangle` from either language.
 
+.. contents:: Contents
+   :local:
+
 Using Python from Hy
 ====================
 

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -4,6 +4,9 @@ Macros
 
 Macros, and the metaprogramming they enable, are one of the characteristic features of Lisp, and one of the main advantages Hy offers over vanilla Python. Much of the material covered in this chapter will be familiar to veterans of other Lisps, but there are also a lot of Hyly specific details.
 
+.. contents:: Contents
+   :local:
+
 What are macros for?
 --------------------
 

--- a/docs/semantics.rst
+++ b/docs/semantics.rst
@@ -6,6 +6,9 @@ This chapter describes features of Hy semantics that differ from Python's and
 aren't better categorized elsewhere, such as in the chapter :doc:`macros`. Each
 is a potential trap for the unwary.
 
+.. contents:: Contents
+   :local:
+
 .. _implicit-names:
 
 Implicit names

--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -14,6 +14,9 @@ Following Python, Hy is in general case-sensitive. For example, ``foo`` and
 ``FOO`` are different symbols, and the Python-level variables they refer to are
 also different.
 
+.. contents:: Contents
+   :local:
+
 .. _models:
 
 An introduction to models

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -10,6 +10,9 @@ Tutorial
 This chapter provides a quick introduction to Hy. It assumes a basic background
 in programming, but no specific prior knowledge of Python or Lisp.
 
+.. contents:: Contents
+   :local:
+
 Lisp-stick on a Python
 ======================
 

--- a/docs/whyhy.rst
+++ b/docs/whyhy.rst
@@ -16,6 +16,8 @@ other Lisps, Hy provides direct access to Python's built-ins and
 third-party Python libraries, while allowing you to freely mix
 imperative, functional, and object-oriented styles of programming.
 
+.. contents:: Contents
+   :local:
 
 Hy versus Python
 ----------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,4 @@ pytest >= 7
 # documentation
 Pygments @ git+https://github.com/Kodiologist/pygments@hylex
 Sphinx == 5.0.2
-sphinx_rtd_theme == 1.2.2
 git+https://github.com/hylang/sphinxcontrib-hydomain.git


### PR DESCRIPTION
- Closes #2417

Here are various changes, in combination with a commit I just pushed to [hyhomepage](https://github.com/hylang/hyhomepage), to clean up the manual and put it on hylang.org. You can see the result at http://hylang.org/hy/doc/doc-testing.  URLs that now look like

https://docs.hylang.org/en/stable/syntax.html

will instead be

https://hylang.org/hy/doc/v0.26.0/syntax

- I use version numbers insted of `stable` and `master` because [cool URIs don't change](https://www.w3.org/Provider/Style/URI). We'll no longer provide official web versions of pre-release versions of the Hy manual, and that should no longer be terribly necessary now that Hy isn't breaking backwards compatibility so frequently. I'll redirect docs.hylang.org to the latest release.
- The file extension (`.html`) is gone because it's an implementation detail.
- `en` is gone because full translations, if they're ever written (which I doubt), will probably be hosted under different URLs, as with Python itself.

If there are no objections, I'll make similar arrangements for Hyrule's manual, too.