### PR TITLE
Release Hy 0.29.0

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,0 @@
-[settings]
-line_length = 88
-profile = black
-skip_gitignore = true
-src_paths = hy,tests

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,6 @@
 .. default-role:: code
 
-Unreleased
+0.29.0 (released 2024-05-20)
 =============================
 
 Removals

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ version = '.'.join(hy.__version__.split('.')[:-1])
 release = hy.__version__
   # The full version identifier, including alpha, beta, and RC tags
 
-hyrule_version = 'doc-testing'
+hyrule_version = 'v0.6.0'
 
 source_suffix = '.rst'
 master_doc = 'index'


### PR DESCRIPTION
This is effectively a release candidate for Hy 1.0.0, since I have no specific plans for anything to do on Hy before then. If a few months pass and no new issues have come up, I may rerelease it as 1.0.0 with only changes to documentation and version numbers.