### PR TITLE
Fix statement pull-out in multi-item `with`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,6 +11,8 @@ Bug Fixes
 ------------------------------
 * Fixed a crash on Python 3.12.6.
 * Keyword objects can now be compared to each other with `<` etc.
+* The order of evaluation in multi-item `with`\s now matches that of
+  nested one-item `with`\s.
 * Fixed a bug in which the REPL misinterpreted the symbol `pass`.
 
 0.29.0 (released 2024-05-20)

--- a/tests/native_tests/with.hy
+++ b/tests/native_tests/with.hy
@@ -1,7 +1,7 @@
 (import
   asyncio
   pytest
-  tests.resources [async-test AsyncWithTest])
+  tests.resources [async-test AsyncWithTest async-exits])
 
 (defn test-context []
   (with [fd (open "tests/resources/text.txt" "r")] (assert fd))
@@ -12,6 +12,7 @@
     (with [fd (open filename "r" :encoding "UTF-8")] (.read fd)))
   (assert (= (read-file "tests/resources/text.txt") "TAARGÜS TAARGÜS\n")))
 
+(setv exits [])
 (defclass WithTest [object]
   (defn __init__ [self val]
     (setv self.val val)
@@ -21,27 +22,34 @@
     self.val)
 
   (defn __exit__ [self type value traceback]
-    (setv self.val None)))
+    (.append exits self.val)))
 
 (defn test-single-with []
+  (setv (cut exits) [])
   (with [t (WithTest 1)]
     (setv out t))
-  (assert (= out 1)))
+  (assert (= out 1))
+  (assert (= exits [1])))
 
 (defn test-quince-with []
+  (setv (cut exits) [])
   (with [t1 (WithTest 1)  t2 (WithTest 2)  t3 (WithTest 3)  _ (WithTest 4)]
     (setv out [t1 t2 t3]))
-  (assert (= out [1 2 3])))
+  (assert (= out [1 2 3]))
+  (assert (= exits [4 3 2 1])))
 
 (defn [async-test] test-single-with-async []
+  (setv (cut async-exits) [])
   (setv out [])
   (asyncio.run
     ((fn :async []
       (with [:async t (AsyncWithTest 1)]
         (.append out t)))))
-  (assert (= out [1])))
+  (assert (= out [1]))
+  (assert (= async-exits [1])))
 
 (defn [async-test] test-quince-with-async []
+  (setv (cut async-exits) [])
   (setv out [])
   (asyncio.run
     ((fn :async []
@@ -51,9 +59,11 @@
           :async t3 (AsyncWithTest 3)
           :async _ (AsyncWithTest 4)]
         (.extend out [t1 t2 t3])))))
-  (assert (= out [1 2 3])))
+  (assert (= out [1 2 3]))
+  (assert (= async-exits [4 3 2 1])))
 
 (defn [async-test] test-with-mixed-async []
+  (setv (cut exits) [])
   (setv out [])
   (asyncio.run
     ((fn :async []

--- a/tests/native_tests/with.hy
+++ b/tests/native_tests/with.hy
@@ -15,8 +15,7 @@
 (setv exits [])
 (defclass WithTest [object]
   (defn __init__ [self val]
-    (setv self.val val)
-    None)
+    (setv self.val val))
 
   (defn __enter__ [self]
     self.val)

--- a/tests/native_tests/with.hy
+++ b/tests/native_tests/with.hy
@@ -1,5 +1,6 @@
 (import
   asyncio
+  unittest.mock [Mock]
   pytest
   tests.resources [async-test AsyncWithTest async-exits])
 
@@ -106,3 +107,17 @@
   (setv w (with [(SuppressZDE)] (.append l w) (/ 1 0) 5))
   (assert (is w None))
   (assert (= l [7])))
+
+(defn test-statements []
+
+  (setv m (Mock))
+  (with [t (do (m) (WithTest 2))]
+    (setv out t))
+  (assert (= m.call-count 1))
+  (assert (= out 2))
+
+  ; https://github.com/hylang/hy/issues/2605
+  (with [t1 (WithTest 1)  t2 (do (setv foo t1) (WithTest 2))]
+    (setv out [t1 t2]))
+  (assert (= out [1 2]))
+  (assert (= foo 1)))

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -19,6 +19,7 @@ async_test = pytest.mark.skipif(
 )
 
 
+async_exits = []
 class AsyncWithTest:
     def __init__(self, val):
         self.val = val
@@ -27,7 +28,7 @@ class AsyncWithTest:
         return self.val
 
     async def __aexit__(self, exc_type, exc, traceback):
-        self.val = None
+        async_exits.append(self.val)
 
 
 async def async_loop(items):


### PR DESCRIPTION
- Fixes #2605

The code for `with` is now even hairier. C'est la vie. At least it's still pretty short.