### PR TITLE
fix installing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools==80.2.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,16 @@ requires = [
     "funcparserlib ~= 1.0",
 ]
 
-import os
+import os.path
+import sys
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(DIR)
+os.chdir(DIR)
 
 import fastentrypoints  # Monkey-patches setuptools.
 from setuptools import find_packages, setup
 from setuptools.command.install import install
-
-os.chdir(os.path.split(os.path.abspath(__file__))[0])
 
 PKG = "hy"
 


### PR DESCRIPTION
fix #2653 

With a pyproject.toml the importing of fastentrypoints needs to have the directory of the fastentrypoints.py in sys.path