### PR TITLE
Allow chained assignment in `setv`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,14 @@
 .. default-role:: code
 
+Unreleased
+======================================================================
+
+Supports Python 3.x – Python 3.y
+
+New Features
+------------------------------
+* `setv` now supports chained assignment with `:chain`.
+
 1.1.0 ("Business Hugs", released 2025-05-08)
 ======================================================================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -270,6 +270,12 @@ Assignment, mutation, and annotation
        (print letter1 letter2 (hy.repr others))
          ; => a b ["c" "d" "e" "f" "g"]
 
+   Finally, as of Hy 1.2, you can precede an assignment pair with the keyword ``:chain`` to assign the same value multiple times to each of several targets. This construct compiles to a chained assignment in Python. ::
+
+       (setv :chain [x y z] 0)
+       (print x y z)
+         ; => 0 0 0
+
    See :hy:func:`let` to simulate more traditionally Lispy block-level scoping.
 
 .. hy:macro:: (setx [target value])

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -535,15 +535,13 @@ def compile_assign(
         if let_scope:
             target = let_scope.add(target)
 
-    ld_target = compiler.compile(target)
-
     if result.temp_variables and isinstance(target, Symbol):
         result.rename(compiler, compiler._nonconst(target))
         if not is_assignment_expr:
             # Throw away .expr to ensure that (setv ...) returns None.
             result.expr = None
     else:
-        st_target = compiler._storeize(target, ld_target)
+        st_target = compiler._storeize(target, compiler.compile(target))
 
         if ann is not None:
             ann_result = compiler.compile(ann)

--- a/tests/native_tests/setv.hy
+++ b/tests/native_tests/setv.hy
@@ -112,11 +112,15 @@
   (setv :chain [a b c] 3)
   (assert (= a b c 3))
 
-  (setv  v1 1  :chain [v2 v3] 2  v4 4)
+  (setv x [])
+  (setv :chain [a b c] x)
+  (assert (is a b c x))
+
+  (setv  v1 1  :chain [v2 v3] 2  v4 4  :chain [v5 v6 v7] 5)
   (assert (= v1 1))
-  (assert (= v2 2))
-  (assert (= v3 2))
+  (assert (= v2 v3 2))
   (assert (= v4 4))
+  (assert (= v5 v6 v7 5))
 
   (setv :chain [[y #* z w] x [a b c d]] "abcd")
   (assert (= [y z w] ["a" ["b" "c"] "d"]))

--- a/tests/native_tests/setv.hy
+++ b/tests/native_tests/setv.hy
@@ -105,3 +105,35 @@
   (an (setv x.eggs "ham"))
   (assert (not (hasattr x "eggs")))
   (assert (= l [["eggs" "ham"]])))
+
+
+(defn test-setv-chain []
+
+  (setv :chain [a b c] 3)
+  (assert (= a b c 3))
+
+  (setv  v1 1  :chain [v2 v3] 2  v4 4)
+  (assert (= v1 1))
+  (assert (= v2 2))
+  (assert (= v3 2))
+  (assert (= v4 4))
+
+  (setv :chain [[y #* z w] x [a b c d]] "abcd")
+  (assert (= [y z w] ["a" ["b" "c"] "d"]))
+  (assert (= x "abcd"))
+  (assert (= [a b c d] ["a" "b" "c" "d"]))
+
+  (setv l (* [0] 5))
+  (setv calls [])
+  (defn f [i]
+    (.append calls [i (list l)])
+    i)
+  (setv :chain
+    [(get l (f 1)) (get l (f 2)) (get l (f 3))]
+    (f 9))
+  (assert (= calls [
+    [9 [0 0 0 0 0]]
+    [1 [0 0 0 0 0]]
+    [2 [0 9 0 0 0]]
+    [3 [0 9 9 0 0]]]))
+  (assert (= l [0 9 9 9 0])))

--- a/tests/resources/pydemo.hy
+++ b/tests/resources/pydemo.hy
@@ -43,6 +43,9 @@ Call me Ishmael. Some years ago—never mind how long precisely—having little 
 (import itertools [cycle])
 (setv mygenexpr (gfor x (cycle [1 2 3]) :if (!= x 2) x))
 
+(setv [unpacked1 #* repacked unpacked2] "WXYZ")
+(setv :chain [chained1 chained2 chained3] 77)
+
 (setv attr-ref str.upper)
 (setv subscript (get "hello" 2))
 (setv myslice (cut "hello" 1 None 2))

--- a/tests/test_hy2py.py
+++ b/tests/test_hy2py.py
@@ -89,6 +89,9 @@ def assert_stuff(m):
     assert type(m.mygenexpr) is type(x for x in [1, 2, 3])
     assert list(itertools.islice(m.mygenexpr, 5)) == [1, 3, 1, 3, 1]
 
+    assert (m.unpacked1, m.repacked, m.unpacked2) == ("W", ["X", "Y"], "Z")
+    assert m.chained1 == m.chained2 == m.chained3 == 77
+
     assert m.attr_ref is str.upper
     assert m.subscript == "l"
     assert m.myslice == "el"


### PR DESCRIPTION
@scauligi I decided it was best not to add a core macro, which would add to our already large set of core macros, for this rarely used feature.