### PR TITLE
Templated strings

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -10,6 +10,8 @@ Supports Python 3.x – Python 3.y
 New Features
 ------------------------------
 * ``hyc`` now supports ``-q``/``--quiet`` to suppress progress messages.
+* Added support for t-strings from Python 3.14.
+* Added new pragma `bracketed-templates` to allow parsing `#[t[...]t]` and `#[t-<ident>[...]t-<ident>]` as template strings (analogous to bracketed f-strings).
 
 Bug Fixes
 ------------------------------
@@ -24,6 +26,7 @@ Bug Fixes
   and Complex models.
 * Fixed an importlib exception when using `hy.eval` on code that
   required other modules.
+* Invalid conversion chars in f-strings now properly raise a syntax error.
 
 1.2.0 ("Crackers and Snacks", released 2026-01-14)
 ======================================================================

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,12 +7,18 @@ Unreleased
 
 Supports Python 3.x – Python 3.y
 
+New Features
+------------------------------
+* Added support for t-strings from Python 3.14.
+* Added new pragma `bracketed-templates` to allow parsing `#[t[...]t]` and `#[t-<ident>[...]t-<ident>]` as template strings (analogous to bracketed f-strings).
+
 Bug Fixes
 ------------------------------
 
 * Captured exception variables are now properly scoped.
 * Fixed bugs in `hy.model-patterns.whole` (and other combinators that
   use it, like `brackets`) in which tuples were not always produced.
+* Invalid conversion chars in f-strings now properly raise a syntax error.
 
 1.2.0 ("Crackers and Snacks", released 2026-01-14)
 ======================================================================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -187,6 +187,12 @@ Fundamentals
     dangerous, because other macros may call your new macro when they meant to
     refer to the core macro.
 
+    .. _bracketed-templates:
+
+  - ``:bracketed-templates``: If set, then :ref:`bracket strings
+    <bracket-strings>` using the delimiter "t" or any delimiter starting with
+    "t-" are parsed as :ref:`template strings <syntax-tstrings>`.
+
 Quoting
 ~~~~~~~~~~~~
 

--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -347,7 +347,7 @@ The result is the model type :class:`String <hy.models.String>`.
 You may prefix a string literal with ``b`` to treat it as a sequence of bytes,
 producing :class:`Bytes <hy.models.Bytes>` instead.
 
-Unlike Python, Hy only recognizes string prefixes (``r``, ``b``, and ``f``) in
+Unlike Python, Hy only recognizes string prefixes (``r``, ``b``, ``f``, ``t``) in
 lowercase, and doesn't allow the no-op prefix ``u``.
 
 :ref:`F-strings <syntax-fstrings>` are a string-like compound construct
@@ -503,6 +503,28 @@ language. Thus e.g. ``f"{"a"}"`` is legal, and equivalent to ``"a"``.
 
 .. autoclass:: hy.models.FString
 .. autoclass:: hy.models.FComponent
+
+.. _syntax-tstrings:
+
+Template strings
+~~~~~~~~~~~~~~~~
+
+:py:mod:`Template strings <string.templatelib>` (aka "t-strings" or "template
+string literals") are similar to format strings, and parse to :class:`FString <hy.models.FString>`
+with the parameter ``:is_tstring`` set to ``True``.
+Template strings at runtime evaluate to instances of :py:class:`Template
+<string.templatelib.Template>` containing the sequence of string and
+expression components, without any interpolation.
+Template strings use the prefix "t" in front of a string. Otherwise, the syntax
+of t-strings are exactly the same as f-strings. ::
+
+    (setv tstr t"The sum is {(+ 1 1)}.")
+    tstr.strings      ; => #("The sum is " ".")
+    tstr.values       ; => #(2)
+
+If the :ref:`bracketed-templates <bracketed-templates>` pragma is set, then
+:ref:`bracket strings <bracket-strings>` using the delimiter "t" or any
+delimiter starting with "t-" are also parsed as template strings.
 
 .. _more-sugar:
 

--- a/hy/compat.py
+++ b/hy/compat.py
@@ -7,6 +7,7 @@ PY3_11 = sys.version_info >= (3, 11)
 PY3_12 = sys.version_info >= (3, 12)
 PY3_12_6 = sys.version_info >= (3, 12, 6)
 PY3_13 = sys.version_info >= (3, 13)
+PY3_14 = sys.version_info >= (3, 14)
 PYPY = platform.python_implementation() == "PyPy"
 
 

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -658,6 +658,10 @@ class HyASTCompiler:
 
     @builds_model(FComponent)
     def compile_fcomponent(self, fcomponent):
+        if fcomponent.conversion not in (None, 's', 'r', 'a'):
+            raise self._syntax_error(
+                fcomponent, f"Invalid conversion character {fcomponent.conversion!r}"
+            )
         conversion = ord(fcomponent.conversion) if fcomponent.conversion else -1
         root, *rest = fcomponent
         value = self.compile(root)

--- a/hy/compiler.py
+++ b/hy/compiler.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from funcparserlib.parser import NoParseError, many
 
 import hy
+from hy.compat import PY3_14
 from hy.errors import HyCompileError, HyLanguageError, HySyntaxError
 from hy.macros import macroexpand
 from hy.model_patterns import FORM, KEYWORD, unpack
@@ -658,6 +659,8 @@ class HyASTCompiler:
 
     @builds_model(FComponent)
     def compile_fcomponent(self, fcomponent):
+        if not PY3_14 and fcomponent.is_tstring:
+            raise self._syntax_error(fcomponent, "Template string literals require Python 3.14 or later")
         if fcomponent.conversion not in (None, 's', 'r', 'a'):
             raise self._syntax_error(
                 fcomponent, f"Invalid conversion character {fcomponent.conversion!r}"
@@ -673,15 +676,18 @@ class HyASTCompiler:
         return (
             value
             + ret
-            + asty.FormattedValue(
-                fcomponent, value=value.expr, conversion=conversion, format_spec=spec
+            + (asty.Interpolation if fcomponent.is_tstring else asty.FormattedValue)(
+                fcomponent, value=value.expr, conversion=conversion, format_spec=spec,
+                **(dict(str=fcomponent.expression) if fcomponent.is_tstring else {}),
             )
         )
 
     @builds_model(FString)
     def compile_fstring(self, fstring):
+        if not PY3_14 and fstring.is_tstring:
+            raise self._syntax_error(fstring, "Template string literals require Python 3.14 or later")
         elts, ret, _ = self._compile_collect(fstring)
-        return ret + asty.JoinedStr(fstring, values=elts)
+        return ret + (asty.TemplateStr if fstring.is_tstring else asty.JoinedStr)(fstring, values=elts)
 
     @builds_model(List, Set)
     def compile_list(self, expression):

--- a/hy/core/hy_repr.hy
+++ b/hy/core/hy_repr.hy
@@ -197,7 +197,7 @@
                         "}" "}}")
                       (hy-repr component)))
          "]" fstring.brackets "]")
-      (+ "f\""
+      (+ (if fstring.is-tstring "t" "f") "\""
          #* (lfor component fstring
                   :setv s (hy-repr component)
                   (if (isinstance component hy.models.String)

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -252,10 +252,18 @@ def render_quoted_form(compiler, form, level):
             contents.append(f_contents)
         body = [List(contents)]
 
-        if isinstance(form, FString) and form.brackets is not None:
-            body.extend([Keyword("brackets"), String(form.brackets)])
-        elif isinstance(form, FComponent) and form.conversion is not None:
-            body.extend([Keyword("conversion"), String(form.conversion)])
+        if isinstance(form, FString):
+            if form.brackets is not None:
+                body.extend([Keyword("brackets"), String(form.brackets)])
+            if form.is_tstring:
+                body.extend([Keyword("is_tstring"), Symbol("True")])
+        elif isinstance(form, FComponent):
+            if form.conversion is not None:
+                body.extend([Keyword("conversion"), String(form.conversion)])
+            if form.expression is not None:
+                body.extend([Keyword("expression"), String(form.expression)])
+            if form.is_tstring:
+                body.extend([Keyword("is_tstring"), Symbol("True")])
 
     elif isinstance(form, Symbol):
         body = [String(form), Keyword("from_parser"), Symbol("True")]

--- a/hy/core/result_macros.py
+++ b/hy/core/result_macros.py
@@ -58,7 +58,7 @@ from hy.models import (
     as_model,
     is_unpack,
 )
-from hy.reader import mangle
+from hy.reader import mangle, HyReader
 from hy.scoping import OuterVar, ScopeFn, ScopeGen, ScopeLet, is_function_scope, is_inside_function_scope, nearest_python_scope
 
 # ------------------------------------------------
@@ -185,6 +185,11 @@ def compile_pragma(compiler, expr, root, kwargs):
         elif kw == Keyword("warn-on-core-shadow"):
             compiler.local_state_stack[-1]['warn_on_core_shadow'] = (
                 bool(compiler.eval(value)))
+
+        elif kw == Keyword("bracketed-templates"):
+            reader = HyReader.current_reader(create=False)
+            if reader:
+                reader.bracketed_templates = bool(compiler.eval(value))
 
         else:
             raise compiler._syntax_error(kw, f"Unknown pragma `{kw}`. Perhaps it's implemented by a newer version of Hy.")

--- a/hy/hy_inspect.py
+++ b/hy/hy_inspect.py
@@ -11,14 +11,13 @@ The class finder in `findsource` relies on python 3.13 or later.
 
 import inspect
 import linecache
-import sys
 from contextlib import suppress
 
 from hy.compat import PY3_13
 from hy.errors import HySyntaxError
-from hy.models import as_model, Expression, Lazy, Object
+from hy.models import Expression, Lazy
 from hy.reader import HyReader, read
-from hy.reader.exceptions import LexException, PrematureEndOfInput
+from hy.reader.exceptions import LexException
 
 
 class HySafeReader(HyReader):

--- a/hy/models.py
+++ b/hy/models.py
@@ -4,7 +4,6 @@ from functools import reduce, total_ordering
 from itertools import groupby
 from math import isinf, isnan
 
-from hy import _initialize_env_var
 from hy.errors import HyWrapperError
 
 PRETTY = True

--- a/hy/models.py
+++ b/hy/models.py
@@ -4,7 +4,11 @@ from functools import reduce, total_ordering
 from itertools import groupby
 from math import isinf, isnan
 
+from hy.compat import PY3_14
 from hy.errors import HyWrapperError
+
+if PY3_14:
+    from string.templatelib import Interpolation, Template
 
 PRETTY = True
 
@@ -463,22 +467,28 @@ class FComponent(Sequence):
     format spec (if any).
     """
 
-    _extra_kwargs = ("conversion",)
+    _extra_kwargs = ("conversion", "expression", "is_tstring")
 
-    def __new__(cls, s=None, conversion=None):
+    def __new__(cls, s=None, conversion=None, expression=None, is_tstring=False):
         value = super().__new__(cls, s)
         value.conversion = conversion
+        value.expression = expression
+        value.is_tstring = is_tstring
         return value
 
     def replace(self, other, recursive=True):
         super().replace(other, recursive)
-        if hasattr(other, "conversion"):
-            self.conversion = other.conversion
+        for attr in self._extra_kwargs:
+            if hasattr(other, attr):
+                setattr(self, attr, getattr(other, attr))
         return self
 
     def __repr__(self):
         return "hy.models.FComponent({})".format(
-            super(Object, self).__repr__() + ", conversion=" + repr(self.conversion)
+            (super(Object, self).__repr__()
+             + ", conversion=" + repr(self.conversion)
+             + ", expression=" + repr(self.expression)
+             + ", is_tstring=" + repr(self.is_tstring))
         )
 
 
@@ -497,11 +507,12 @@ class FString(Sequence):
     and :class:`hy.models.FComponent`. The design mimics :class:`ast.JoinedStr`.
 
     :ivar brackets: As in :class:`hy.models.String`.
+    :ivar is_tstring: Whether this represents a template string rather than a format string.
     """
 
-    _extra_kwargs = ("brackets",)
+    _extra_kwargs = ("brackets", "is_tstring")
 
-    def __new__(cls, s=None, brackets=None):
+    def __new__(cls, s=None, brackets=None, is_tstring=False):
         value = super().__new__(
             cls,
             # Join adjacent string nodes for the sake of equality
@@ -518,6 +529,7 @@ class FString(Sequence):
         if brackets is not None and _string_in_node(f"]{brackets}]", value):
             raise ValueError(f"Syntactically illegal bracket string: {s!r}")
         value.brackets = brackets
+        value.is_tstring = is_tstring
         return value
 
     def __repr__(self):
@@ -527,13 +539,19 @@ class FString(Sequence):
         return self._suffixize(super().__str__())
 
     def _suffixize(self, x):
-        if self.brackets is None:
+        if self.brackets is None and not self.is_tstring:
             return x
-        return "{}{}brackets={!r})".format(
-            x[:-1],  # Clip off the final close paren
-            "" if x[-2] == "(" else ", ",
-            self.brackets,
-        )
+        args = []
+        if self.brackets is not None:
+            args.append(f"brackets={self.brackets!r}")
+        if PY3_14 and self.is_tstring:
+            args.append(f"is_tstring={self.is_tstring!r}")
+        s = x[:-1]  # Clip off the final close paren
+        if s[-1] != "(":
+            s += ", "
+        s += ", ".join(args)
+        s += ")"
+        return s
 
 
 class List(Sequence):
@@ -561,9 +579,19 @@ def recwrap(f):
 
 
 _wrappers[FComponent] = recwrap(FComponent)
+if PY3_14:
+    _wrappers[Interpolation] = lambda interp: FComponent(
+            [as_model(interp.value), as_model(interp.format_spec)],
+            conversion=interp.conversion,
+            expression=interp.expression,
+            is_tstring=True)
 _wrappers[FString] = lambda fstr: FString(
-    (as_model(x) for x in fstr), brackets=fstr.brackets
+    (as_model(x) for x in fstr),
+    brackets=fstr.brackets,
+    is_tstring=fstr.is_tstring,
 )
+if PY3_14:
+    _wrappers[Template] = recwrap(lambda els: FString(els, is_tstring=True))
 _wrappers[List] = recwrap(List)
 _wrappers[list] = recwrap(List)
 

--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -25,7 +25,6 @@ from hy.models import (
 )
 
 from .exceptions import LexException, PrematureEndOfInput
-from .mangling import mangle
 from .reader import Reader, isnormalizedspace
 
 

--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -295,8 +295,8 @@ class HyReader(Reader):
         prefix_chars = set(prefix)
         if (
             len(prefix_chars) != len(prefix)
-            or prefix_chars - set("bfr")
-            or set("bf") <= prefix_chars
+            or not prefix_chars < set("bfrt")
+            or len(prefix_chars - set("r")) > 1
         ):
             raise LexException.from_reader(f"invalid string prefix {prefix!r}", self)
 
@@ -321,7 +321,12 @@ class HyReader(Reader):
             escaping = False
             return 0
 
-        return self.read_string_until(quote_closing, prefix, "f" in prefix.lower())
+        fstring_mode = (
+            "f" if "f" in prefix_chars
+            else "t" if "t" in prefix_chars
+            else ""
+        )
+        return self.read_string_until(quote_closing, prefix, fstring_mode)
 
     ###
     # Special annotations
@@ -419,7 +424,11 @@ class HyReader(Reader):
                 )
             delim.append(c)
         delim = "".join(delim)
-        is_fstring = delim == "f" or delim.startswith("f-")
+        fstring_mode = (
+            "f" if delim == "f" or delim.startswith("f-")
+            else "t" if PY3_14 and (delim == "t" or delim.startswith("t-"))
+            else ""
+        )
 
         # discard single initial newline, if any, accounting for all
         # three styles of newline
@@ -446,16 +455,16 @@ class HyReader(Reader):
                     index = -1
             return 0
 
-        return self.read_string_until(delim_closing, "r", is_fstring, brackets=delim)
+        return self.read_string_until(delim_closing, "r", fstring_mode, brackets=delim)
 
-    def read_string_until(self, closing, prefix, is_fstring, **kwargs):
-        if is_fstring:
-            components = self.read_fcomponents_until(closing, prefix)
-            return FString(components, **kwargs)
-        s = self.read_chars_until(closing, prefix, is_fstring=False)
+    def read_string_until(self, closing, prefix, fstring_mode, **kwargs):
+        if fstring_mode:
+            components = self.read_fcomponents_until(closing, prefix, fstring_mode)
+            return FString(components, is_tstring=fstring_mode == 't', **kwargs)
+        s = self.read_chars_until(closing, prefix, fstring_mode="")
         return (Bytes if isinstance(s, bytes) else String)(s, **kwargs)
 
-    def read_chars_until(self, closing, prefix, is_fstring):
+    def read_chars_until(self, closing, prefix, fstring_mode):
         s = []
         in_named_escape = False
         for c in self.chars():
@@ -466,7 +475,7 @@ class HyReader(Reader):
                 # string has ended
                 s = s[:-n_closing_chars]
                 break
-            if is_fstring:
+            if fstring_mode:
                 # handle braces in f-strings
                 if c == "{":
                     if "r" not in prefix and s[-3:] == ["\\", "N", "{"]:
@@ -480,7 +489,7 @@ class HyReader(Reader):
                     if in_named_escape:
                         in_named_escape = False
                     elif not self.peek_and_getc("}"):
-                        raise SyntaxError("f-string: single '}' is not allowed")
+                        raise SyntaxError(f"{fstring_mode}-string: single '}}' is not allowed")
         res = "".join(s).replace("\x0d\x0a", "\x0a").replace("\x0d", "\x0a")
 
         if "b" in prefix:
@@ -499,23 +508,23 @@ class HyReader(Reader):
                 # see https://github.com/python/cpython/issues/65530
                 res = res.encode('ISO-8859-1', errors='backslashreplace').decode('unicode_escape')
 
-        if is_fstring:
+        if fstring_mode:
             return res, n_closing_chars
         return res
 
-    def read_fcomponents_until(self, closing, prefix):
+    def read_fcomponents_until(self, closing, prefix, fstring_mode):
         components = []
         start = self.pos
         while True:
-            s, closed = self.read_chars_until(closing, prefix, is_fstring=True)
+            s, closed = self.read_chars_until(closing, prefix, fstring_mode=fstring_mode)
             if s:
                 components.append(self.fill_pos(String(s), start))
             if closed:
                 break
-            components.extend(self.read_fcomponent(prefix))
+            components.extend(self.read_fcomponent(prefix, fstring_mode))
         return components
 
-    def read_fcomponent(self, prefix):
+    def read_fcomponent(self, prefix, fstring_mode):
         """May return one or two components, since the `=` debugging syntax
         will create a String component."""
         start = self.pos
@@ -529,6 +538,7 @@ class HyReader(Reader):
         with self.saving_chars() as form_text:
             model = self.parse_one_form()
         space_between = self.slurp_space()
+        form_text = "".join(form_text)
 
         # check for and handle debug syntax:
         # we emt the verbatim text before we emit the value
@@ -536,7 +546,7 @@ class HyReader(Reader):
             has_debug = True
             space_after = self.slurp_space()
             dbg_prefix = (
-                space_before + "".join(form_text) + space_between + "=" + space_after
+                space_before + form_text + space_between + "=" + space_after
             )
             values.append(self.fill_pos(String(dbg_prefix), start))
 
@@ -553,12 +563,12 @@ class HyReader(Reader):
         # handle formatting options
         format_components = []
         if self.peek_and_getc(":"):
-            format_components = self.read_fcomponents_until(component_closing, prefix)
+            format_components = self.read_fcomponents_until(component_closing, prefix, "f")
         else:
             if has_debug and conversion is None:
                 conversion = "r"
             if not self.getc() == "}":
-                raise LexException.from_reader("f-string: trailing junk in field", self)
+                raise LexException.from_reader(f"{fstring_mode}-string: trailing junk in field", self)
         return values + [
-            self.fill_pos(FComponent((model, *format_components), conversion), start)
+            self.fill_pos(FComponent((model, *format_components), conversion=conversion, expression=form_text, is_tstring=fstring_mode == "t"), start)
         ]

--- a/hy/reader/hy_reader.py
+++ b/hy/reader/hy_reader.py
@@ -125,8 +125,10 @@ class HyReader(Reader):
     NON_IDENT = set("()[]{};\"'`~")
     _current_reader = None
 
-    def __init__(self, *, use_current_readers=False):
+    def __init__(self, *, use_current_readers=False, bracketed_templates=False):
         super().__init__()
+
+        self.bracketed_templates = bracketed_templates
 
         # move any reader macros declared using
         # `reader_for("#...")` to the macro table
@@ -426,7 +428,7 @@ class HyReader(Reader):
         delim = "".join(delim)
         fstring_mode = (
             "f" if delim == "f" or delim.startswith("f-")
-            else "t" if PY3_14 and (delim == "t" or delim.startswith("t-"))
+            else "t" if self.bracketed_templates and (delim == "t" or delim.startswith("t-"))
             else ""
         )
 

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -417,6 +417,13 @@ def test_format_string():
     assert can_compile(r'f"hello {"\\n"} world"')
 
 
+def test_fstring_conversions():
+    assert can_compile('f"hello {(+ 1 1) !r} world"')
+    assert can_compile('f"hello {(+ 1 1) !s} world"')
+    assert can_compile('f"hello {(+ 1 1) !a} world"')
+    assert cant_compile('f"hello {(+ 1 1) !q} world"')
+
+
 def test_ast_bracket_string():
     assert s(r"#[[empty delims]]") == "empty delims"
     assert s(r"#[my delim[fizzle]my delim]") == "fizzle"

--- a/tests/compilers/test_ast.py
+++ b/tests/compilers/test_ast.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import pytest
 
 import hy
-from hy.compat import PY3_11
+from hy.compat import PY3_11, PY3_14
 from hy.compiler import hy_compile
 from hy.errors import HyError, HyLanguageError
 from hy.reader import read_many
@@ -422,6 +422,12 @@ def test_fstring_conversions():
     assert can_compile('f"hello {(+ 1 1) !s} world"')
     assert can_compile('f"hello {(+ 1 1) !a} world"')
     assert cant_compile('f"hello {(+ 1 1) !q} world"')
+
+
+def test_template_string():
+    assert can_compile('t"hello world"', iff=PY3_14)
+    assert can_compile('t"hello {(+ 1 1)} world"', iff=PY3_14)
+    assert cant_compile('t"hello {(+ 1 1) world"')
 
 
 def test_ast_bracket_string():

--- a/tests/native_tests/tstrings.hy
+++ b/tests/native_tests/tstrings.hy
@@ -1,0 +1,66 @@
+(do-mac (when hy.compat.PY3_14 '(do
+
+(import pytest)
+(import string.templatelib [Template Interpolation])
+
+;; neither Template nor Interpolation implement value equality,
+;; so we need to implement it ourselves
+(defn =t [t1 t2]
+  (and (is (type t1) (type t2) Template)
+       (= t1.strings t2.strings)
+       (all (gfor [i1 i2] (zip t1.interpolations t2.interpolations)
+              (and (= i1.value i2.value)
+                   (= i1.expression i2.expression)
+                   (= i1.conversion i2.conversion)
+                   (= i1.format-spec i2.format-spec))))))
+(defn !=t [t1 t2] (not (=t t1 t2)))
+
+(defn test-template-strings []
+  (assert (=t t"hello world" (Template "hello world")))
+  (assert (=t t"hello{3}world" (Template "hello" (Interpolation 3 "3") "world")))
+  (assert (!=t t"hello{(+ 2 1)}world" (Template "hello" (Interpolation 3 "3") "world")))
+  (assert (=t t"hello{(+ 2 1)}world" (Template "hello" (Interpolation 3 "(+ 2 1)") "world")))
+  (assert (=t t"hello{3 !r}world" (Template "hello" (Interpolation 3 "3" "r") "world")))
+  (assert (=t t"hello{3 :#x}world" (Template "hello" (Interpolation 3 "3" None "#x") "world"))))
+
+(defn test-template-bracketed-nopragma []
+  (assert (= #[t[this is not {yet} a template]t] "this is not {yet} a template"))
+  (assert (= #[t-nada[neither is {this}]t-nada] "neither is {this}"))
+
+  (setv good (Template "this is " (Interpolation 1 "1") " template"))
+  (assert (=t (hy.eval (hy.read "#[t[this is {1} template]t]"
+                                :reader (hy.HyReader :bracketed-templates True)))
+              good))
+  (assert (=t (hy.eval (hy.read-many
+                         "(pragma :bracketed-templates True)
+                          #[t[this is {1} template]t]"))
+              good)))
+
+
+(defn test-quote-tstring []
+  (setv tstr 't"foo{3}bar")
+  (assert (= tstr
+             (hy.models.FString [(hy.models.String "foo")
+                                 (hy.models.FComponent [(hy.models.Integer 3)])
+                                 (hy.models.String "bar")])))
+  ;; as of this writing, models don't implicitly compare their _extra_kwargs fields
+  ;; so we need to explicitly check these values
+  (assert tstr.is-tstring)
+  (assert (. tstr [1] is-tstring))
+  (assert (. tstr [1] expression) "3"))
+
+(defn test-tstring-repr []
+  (setv tstrings (.strip #[[
+t"hello world"
+t"hello{3}world"
+t"hello{(+ 2 1)}world"
+t"hello{3 !r}world"
+t"hello{3 :#x}world"
+#[t[this is {1} template]t]
+#[t-algo[so {(+ 1 1)} is this {(- 5 4)}]t-algo]
+]]))
+  (setv forms (hy.read-many tstrings :reader (hy.HyReader :bracketed-templates True)))
+  (for [[literal form] (zip (.split tstrings "\n") forms)]
+    (assert (= (+ "'" literal) (hy.repr form)))))
+
+)))

--- a/tests/native_tests/tstrings.hy
+++ b/tests/native_tests/tstrings.hy
@@ -1,0 +1,56 @@
+(defreader __requires_py314 []
+  (when (not hy.compat.PY3_14)
+    (for [_ (.chars &reader True)])))
+
+#__requires_py314
+
+(import pytest)
+(import string.templatelib [Template Interpolation])
+
+;; neither Template nor Interpolation implement value equality,
+;; so we need to implement it ourselves
+(defn =t [t1 t2]
+  (and (= (type t1) (type t2) Template)
+       (= t1.strings t2.strings)
+       (all (gfor [i1 i2] (zip t1.interpolations t2.interpolations)
+              (and (= i1.value i2.value)
+                   (= i1.expression i2.expression)
+                   (= i1.conversion i2.conversion)
+                   (= i1.format-spec i2.format-spec))))))
+(defn !=t [t1 t2] (not (=t t1 t2)))
+
+(defn test-template-strings []
+  (assert (=t t"hello world" (Template "hello world")))
+  (assert (=t t"hello{3}world" (Template "hello" (Interpolation 3 "3") "world")))
+  (assert (!=t t"hello{(+ 2 1)}world" (Template "hello" (Interpolation 3 "3") "world")))
+  (assert (=t t"hello{(+ 2 1)}world" (Template "hello" (Interpolation 3 "(+ 2 1)") "world")))
+  (assert (=t t"hello{3 !r}world" (Template "hello" (Interpolation 3 "3" "r") "world")))
+  (assert (=t t"hello{3 :#x}world" (Template "hello" (Interpolation 3 "3" None "#x") "world"))))
+
+(defn test-template-bracketed-nopragma []
+  (assert (= #[t[this is not {yet} a template]t] "this is not {yet} a template"))
+  (assert (= #[t-nada[neither is {this}]t-nada] "neither is {this}"))
+
+  (setv good (Template "this is " (Interpolation 1 "1") " template"))
+  (assert (=t (hy.eval (hy.read "#[t[this is {1} template]t]"
+                                :reader (hy.HyReader :bracketed-templates True)))
+              good))
+  (assert (=t (hy.eval (hy.read-many
+                         "(pragma :bracketed-templates True)
+                          #[t[this is {1} template]t]"))
+              good)))
+
+
+(defn test-quote-tstring []
+  (setv tstr 't"foo{3}bar")
+  (assert (= tstr
+             (hy.models.FString [(hy.models.String "foo")
+                                 (hy.models.FComponent [(hy.models.Integer 3)])
+                                 (hy.models.String "bar")])))
+  ;; as of this writing, models don't implicitly compare their _extra_kwargs fields
+  ;; so we need to explicitly check these values
+  (assert tstr.is-tstring)
+  (assert (. tstr [1] is-tstring))
+  (assert (. tstr [1] expression) "3"))
+
+

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -5,6 +5,7 @@ from math import isnan
 import pytest
 
 from hy import PrematureEndOfInput
+from hy.compat import PY3_14
 from hy.errors import hy_exc_handler
 from hy.models import (
     Bytes,
@@ -503,6 +504,8 @@ def test_string_prefixes():
     assert s(r'b"hello"') == Bytes(b"hello")
     assert s(r'rb"hello"') == Bytes(b"hello")
     assert s(r'fr"hello"') == FString([String("hello")])
+    if PY3_14:
+        assert s(r'tr"hello"') == FString([String("hello")], is_tstring=True)
 
     for bad in list("zRBFu") + ["bf", "rr", "rbr"]:
         with lexe():


### PR DESCRIPTION
- Closes #2687

Python 3.14 introduced [t-strings](https://docs.python.org/3/library/stdtypes.html#stdtypes-tstrings) as a new literal type.

This PR allows parsing t-strings, as well as introduces a new pragma `bracketed-templates` to additionally allow bracketed t-strings (a la bracketed f-strings).