### PR TITLE
importer: fix _could_be_hy_src failing on non-existent paths

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -112,3 +112,4 @@
 * Zhan Tang <tz59pk@gmail.com>
 * Ati Sharma <ati@agalmic.ltd>
 * Kevin M Granger <py@kmg.fyi>
+* Anton Hibl <antonhibl11@gmail.com>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -10,6 +10,9 @@ Supports Python 3.x – Python 3.y
 Bug Fixes
 ------------------------------
 
+* Fixed `_could_be_hy_src` in `importer.py` incorrectly returning
+  `False` for valid Hy source paths that do not exist on disk, such
+  as ``dfile`` override paths passed to `py_compile.compile`; Closes #2701.
 * Captured exception variables are now properly scoped.
 * Fixed bugs in `hy.model-patterns.whole` (and other combinators that
   use it, like `brackets`) in which tuples were not always produced.

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -89,7 +89,7 @@ def _get_code_from_file(run_name, fname=None, hy_src_check=lambda x: x.endswith(
         code = pkgutil.read_code(f)
 
     if code is None:
-        if hy_src_check(fname):
+        if os.path.isfile(fname) and hy_src_check(fname):
             code = _hy_code_from_file(fname, loader_type=HyLoader)
         else:
             # Try normal source
@@ -107,7 +107,7 @@ _py_source_to_code = importlib.machinery.SourceFileLoader.source_to_code
 
 
 def _could_be_hy_src(filename):
-    return os.path.isfile(filename) and (
+    return (
         os.path.splitext(filename)[1]
         not in set(importlib.machinery.SOURCE_SUFFIXES) - {".hy"}
     )


### PR DESCRIPTION
Fixes #2701.

`_could_be_hy_src` gates on `os.path.isfile` which caused it to return `False` for valid Hy source paths that don't exist on disk, such as `dfile` override paths passed to `py_compile.compile`. This meant the source fell through to CPython's parser which then failed on Hy syntax.

My proposed fix removes the `isfile` check from `_could_be_hy_src` so it checks extension only, and moves the `isfile` check explicitly into `_get_code_from_file` where it is needed before opening the file from disk. All existing behavior is preserved and tests pass.