### PR TITLE
Fall back to builtins for target module in derive_target_module

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,6 +22,8 @@ Bug Fixes
   use it, like `brackets`) in which tuples were not always produced.
 * Added pattern matching support to String, Bytes, Symbol, Integer, Float,
   and Complex models.
+* Fixed an importlib exception when using `hy.eval` on code that
+  required other modules.
 
 1.2.0 ("Crackers and Snacks", released 2026-01-14)
 ======================================================================

--- a/hy/macros.py
+++ b/hy/macros.py
@@ -118,7 +118,9 @@ def _same_modules(source_module, target_module):
 def derive_target_module(target_module, parent_frame):
     if target_module is None:
         target_namespace = parent_frame.f_globals
-        target_module = target_namespace.get("__name__", None)
+        target_module = target_namespace.get("__name__", "builtins")
+          # Why "builtins"? Because that's what Python produces with
+          # `exec("print(__name__)", globals = {})`.
     elif isinstance(target_module, str):
         target_module = importlib.import_module(target_module)
         target_namespace = target_module.__dict__

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -288,3 +288,8 @@ def test_zipimport(tmp_path):
         sys.path = [p for p in sys.path if p != str(zpath)]
     assert example.x == "Hy from ZIP"
     assert example.__file__ == str(zpath / "example.hy")
+
+
+def test_eval_requiring_macro():
+    # https://github.com/hylang/hy/issues/2695
+    hy.eval(hy.read("(require tests.resources.macros)"), globals={})


### PR DESCRIPTION
Fixes #2695 with _100% artisanal, hand-crafted commits made by humans_.

Since you (Kodiologist) identified the fix, and I just commited it, shall I set your name/email as the commit's author?