### PR TITLE
Fix a regression in import of Python from ZIPs

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -2,6 +2,16 @@
 
 Hy is `semantically versioned <https://semver.org/>`__ since 1.0.0.
 
+Unreleased
+======================================================================
+
+Supports Python 3.x – Python 3.y
+
+Bug Fixes
+------------------------------
+* Fixed a regression in Hy 1.3.0 that could prevent imports of Python
+  code in ZIP archives.
+
 1.3.0 ("Dogs Should Be Raw", released 2026-05-24)
 ======================================================================
 

--- a/hy/importer.py
+++ b/hy/importer.py
@@ -146,7 +146,10 @@ if (".hy", False, False) not in zipimport._zip_searchorder:
 
     def _hy_compile_source(pathname, source, module=None):
         if not pathname.endswith(".hy"):
-            return _py_compile_source(pathname, source, module)
+            return _py_compile_source(
+                pathname,
+                source,
+                *([module] if hy.compat.PY3_15 else []))
         mname = f"<zip:{pathname}>"
         sys.modules[mname] = types.ModuleType(mname)
         return compile(

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -279,12 +279,17 @@ def test_zipimport(tmp_path, monkeypatch):
 
     zpath = tmp_path / "archive.zip"
     with ZipFile(zpath, "w") as o:
-        o.writestr("example.hy", '(setv x "Hy from ZIP")')
+        # Test a Python module as well as a Hy module to ensure that
+        # Hy's edits to ZIP imports can still get Python files.
+        o.writestr("zip_py.py", 'x = "Py from ZIP"')
+        o.writestr("zip_hy.hy", '(setv x "Hy from ZIP")')
 
     monkeypatch.syspath_prepend(zpath)
-    import example
-    assert example.x == "Hy from ZIP"
-    assert example.__file__ == str(zpath / "example.hy")
+    import zip_py, zip_hy
+    assert zip_py.x == "Py from ZIP"
+    assert zip_py.__file__ == str(zpath / "zip_py.py")
+    assert zip_hy.x == "Hy from ZIP"
+    assert zip_hy.__file__ == str(zpath / "zip_hy.hy")
 
 
 def test_eval_requiring_macro():

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -274,18 +274,15 @@ def test_filtered_importlib_frames(capsys):
     assert "importlib._" not in captured_w_filtering
 
 
-def test_zipimport(tmp_path):
+def test_zipimport(tmp_path, monkeypatch):
     from zipfile import ZipFile
 
     zpath = tmp_path / "archive.zip"
     with ZipFile(zpath, "w") as o:
         o.writestr("example.hy", '(setv x "Hy from ZIP")')
 
-    try:
-        sys.path.insert(0, str(zpath))
-        import example
-    finally:
-        sys.path = [p for p in sys.path if p != str(zpath)]
+    monkeypatch.syspath_prepend(zpath)
+    import example
     assert example.x == "Hy from ZIP"
     assert example.__file__ == str(zpath / "example.hy")
 


### PR DESCRIPTION
I noticed this bug just after releasing Hy 1.3.0, ugh. It broke Try Hy, so Try Hy is currently using this fix although it claims to be running Hy 1.3.0.